### PR TITLE
fix: invalidate entity on world change

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
@@ -106,6 +106,15 @@ public final class Application {
         }
     }
 
+    /** Loader calls this on disconnect / world unload so the next simulation builds against
+     *  the new world. Cached entity, recorded path, and per-tick checkpoints all reset;
+     *  InputData is kept so the user's tick list persists across world swaps. */
+    public void onWorldChange() {
+        runner.invalidate();
+        boxController.clearAll();
+        startInitialized = false;
+    }
+
     public void setStartToPlayer() {
         if (!mc.isReady()) return;
         runner.setStartPosition(mc.getPlayerPosition());

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ports/Simulator.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ports/Simulator.java
@@ -42,10 +42,9 @@ public interface Simulator {
 
     void setStartYaw(float yaw);
 
-    /** Snapshot all mutable simulator state needed to resume ticking from the current point.
-     *  Returned token is opaque to callers; only restoreCheckpoint understands it. */
     Checkpoint saveCheckpoint();
 
-    /** Restore a snapshot taken by saveCheckpoint. Token must come from this same simulator. */
     void restoreCheckpoint(Checkpoint checkpoint);
+
+    void invalidate();
 }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/sim/LazyEntitySimulator.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/sim/LazyEntitySimulator.java
@@ -133,6 +133,14 @@ public abstract class LazyEntitySimulator<E> implements Simulator {
         restoreCheckpoint(ensureEntity(), checkpoint);
     }
 
+    @Override
+    public final void invalidate() {
+        entity = null;
+        pendingStart = null;
+        pendingVelocity = null;
+        pendingYaw = null;
+    }
+
     private E ensureEntity() {
         if (entity == null) {
             entity = createEntity(pendingStart, pendingVelocity, pendingYaw);

--- a/core/src/main/java/de/legoshi/parkourcalc/core/sim/SimulationRunner.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/sim/SimulationRunner.java
@@ -71,6 +71,13 @@ public final class SimulationRunner {
         );
     }
 
+    /** Drop the cached entity and any state captured against the old world. */
+    public void invalidate() {
+        path.clear();
+        checkpoints.clear();
+        simulator.invalidate();
+    }
+
     public Vec3dCore getStartPosition() {
         return simulator.getStartPosition();
     }

--- a/loader-fabric-1.21.10/src/client/java/de/legoshi/parkourcalc/fabric/FabricParkourCalculator.java
+++ b/loader-fabric-1.21.10/src/client/java/de/legoshi/parkourcalc/fabric/FabricParkourCalculator.java
@@ -11,6 +11,7 @@ import imgui.ImGui;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.SharedConstants;
 import net.minecraft.client.MinecraftClient;
@@ -70,6 +71,7 @@ public class FabricParkourCalculator implements ClientModInitializer {
         ClientTickEvents.END_CLIENT_TICK.register(FabricParkourCalculator::handleInput);
         ClientTickEvents.START_CLIENT_TICK.register(FabricParkourCalculator::onStartTick);
         ClientTickEvents.END_CLIENT_TICK.register(FabricParkourCalculator::onEndTick);
+        ClientPlayConnectionEvents.DISCONNECT.register((handler, client) -> application.onWorldChange());
     }
 
     private static void onStartTick(MinecraftClient client) {

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12ParkourCalculator.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12ParkourCalculator.java
@@ -14,6 +14,7 @@ import net.minecraftforge.client.event.RenderWorldLastEvent;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.fml.client.registry.ClientRegistry;
+import net.minecraftforge.fml.common.network.FMLNetworkEvent;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.ModContainer;
@@ -146,6 +147,11 @@ public class Forge12ParkourCalculator {
         if (event.getButton() == 1 && application.shouldSuppressRightClick()) {
             event.setCanceled(true);
         }
+    }
+
+    @SubscribeEvent
+    public void onClientDisconnect(FMLNetworkEvent.ClientDisconnectionFromServerEvent event) {
+        application.onWorldChange();
     }
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8ParkourCalculator.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8ParkourCalculator.java
@@ -14,6 +14,7 @@ import net.minecraftforge.client.event.RenderWorldLastEvent;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.fml.client.registry.ClientRegistry;
+import net.minecraftforge.fml.common.network.FMLNetworkEvent;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.ModContainer;
@@ -146,6 +147,11 @@ public class Forge8ParkourCalculator {
         if (event.button == 1 && application.shouldSuppressRightClick()) {
             event.setCanceled(true);
         }
+    }
+
+    @SubscribeEvent
+    public void onClientDisconnect(FMLNetworkEvent.ClientDisconnectionFromServerEvent event) {
+        application.onWorldChange();
     }
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)


### PR DESCRIPTION
Closes #64

<!-- For a breaking change, add a footer like "BREAKING CHANGE: <what users do to upgrade>". release-please reads it to bump the major version (or minor, while 0.x). Delete this comment otherwise. -->
