### PR TITLE
fix: delay sneak slowdown by one tick to match vanilla

### DIFF
--- a/loader-fabric-1.21.10/src/client/java/de/legoshi/parkourcalc/fabric/sim/SimulatorEntity.java
+++ b/loader-fabric-1.21.10/src/client/java/de/legoshi/parkourcalc/fabric/sim/SimulatorEntity.java
@@ -350,7 +350,9 @@ public class SimulatorEntity extends PlayerEntity {
             return raw;
         }
         Vec2f result = raw.multiply(0.98F);
-        if (this.isSneaking()) {
+        // Vanilla gates on shouldSlowDown() (pose from the previous tick's sneak), so the
+        // slowdown lands one tick after the sneak input; isSneaking() would apply it a tick early.
+        if (this.shouldSlowDown()) {
             float sneakSpeed = (float) this.getAttributeValue(EntityAttributes.SNEAKING_SPEED);
             result = result.multiply(sneakSpeed);
         }


### PR DESCRIPTION
## Summary
- Gate the sneak speed factor in `SimulatorEntity.applyMovementSpeedFactors` on `shouldSlowDown()` instead of `isSneaking()`, matching vanilla `ClientPlayerEntity` (yarn 1.21.10+build.2).
- Vanilla computes `inSneakingPose` from the previous tick's input (before `input.tick()`), so the slowdown lands one tick after the sneak input; the simulator applied it a tick early.
- No checkpoint change needed (`inSneakingPose` is recomputed each `tickMovement` from the checkpointed `playerInput` before use). Solver inherits the fix via sampled TickStates. Forge loaders already match their versions' same-tick behavior.

Closes #121

## Verification
- `:loader-fabric-1.21.10:build` green.
- Worth an in-game agreement check against a real shift before release, since paths shift by one tick wherever sneak toggles.