### PR TITLE
fix(anglesolver): full-height tick-row hitbox and aligned start/goal accent (#135, #136)

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverTable.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverTable.java
@@ -294,14 +294,16 @@ public final class AngleSolverTable {
 
         boolean sel = selection.isSelected(rowIndex);
         int flags = ImGuiSelectableFlags.SpanAllColumns | ImGuiSelectableFlags.AllowItemOverlap;
-        if (ThemeManager.rightAlignedSelectable("row" + rowIndex, "", sel, flags)) {
+        if (ThemeManager.rightAlignedSelectable("row" + rowIndex, "", sel, flags, 0f, rowH)) {
             selection.handleClick(rowIndex);
         }
         ImVec2 selMin = ImGui.getItemRectMin();
         ImVec2 selMax = ImGui.getItemRectMax();
-        // The selectable is only one line tall; carry the full grown-row rect so the start/landing
-        // inset and hover/selection bounds span the whole multi-line row.
-        gMinX = selMin.x; gMinY = selMin.y; gMaxX = selMax.x; gMaxY = selMin.y + rowH;
+        float cellPadY = ImGui.getStyle().getCellPadding().y;
+        gMinX = selMin.x;
+        gMinY = selMin.y - cellPadY;
+        gMaxX = selMax.x;
+        gMaxY = gMinY + rowH;
         // Row drag-drop must attach to the selectable (ImGui targets the last item), so the hook
         // runs here, before the chevron becomes the last item (gh-119).
         if (dragDropHook != null) dragDropHook.run();


### PR DESCRIPTION
Fixes two angle-solver gutter rendering bugs in `AngleSolverTable.renderGutter`:

- #135: the tick-level whole-row selectable was one line tall, so clicks below the first line on multi-line constraint rows missed. Now sized with `sizeY = rowH` to span the full multi-line row. Per-constraint chips untouched.
- #136: the Start/Goal accent line sat 1px low (used `selMin.y`). Fixed to `gMinY = selMin.y - cellPadY`, `gMaxY = gMinY + rowH`, scaling with UI scale.

Closes #135
Closes #136

Build: `:core:check` green. Scope: core-only. Risk: low.
Merge: directly (fully independent). Eyeball the geometry once in-app.
