### PR TITLE
feat(ui): browse sub-folders in the Open dialog (#108)

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/SaveController.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/SaveController.java
@@ -3,6 +3,7 @@ package de.legoshi.parkourcalc.core;
 import de.legoshi.parkourcalc.core.ports.MinecraftAccess;
 import de.legoshi.parkourcalc.core.save.FileSystemSaveStore;
 import de.legoshi.parkourcalc.core.save.Result;
+import de.legoshi.parkourcalc.core.save.SaveBrowseResult;
 import de.legoshi.parkourcalc.core.save.SaveFile;
 import de.legoshi.parkourcalc.core.save.SaveIO;
 import de.legoshi.parkourcalc.core.save.SaveInfo;
@@ -132,6 +133,11 @@ public final class SaveController {
     public List<SaveInfo> list() {
         if (store == null) return Collections.emptyList();
         return store.list();
+    }
+
+    public SaveBrowseResult browse(String relDir) {
+        if (store == null) return SaveBrowseResult.empty();
+        return store.browse(relDir);
     }
 
     public String currentName() {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/save/FileSystemSaveStore.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/save/FileSystemSaveStore.java
@@ -102,19 +102,23 @@ public final class FileSystemSaveStore {
     }
 
     public boolean exists(String name) {
-        return Files.isRegularFile(saveDir.resolve(name + EXTENSION));
+        Path file = resolveSave(name);
+        return file != null && Files.isRegularFile(file);
     }
 
     public String read(String name) throws IOException {
-        Path file = saveDir.resolve(name + EXTENSION);
+        Path file = resolveSave(name);
+        if (file == null) throw new IOException("Invalid save path: " + name);
         byte[] bytes = Files.readAllBytes(file);
         return new String(bytes, CHARSET);
     }
 
     public void write(String name, String contents) throws IOException {
-        Files.createDirectories(saveDir);
-        Path target = saveDir.resolve(name + EXTENSION);
-        Path tmp = saveDir.resolve(name + EXTENSION + TMP_SUFFIX);
+        Path target = resolveSave(name);
+        if (target == null) throw new IOException("Invalid save path: " + name);
+        Path parent = target.getParent();
+        Files.createDirectories(parent);
+        Path tmp = parent.resolve(target.getFileName() + TMP_SUFFIX);
         Files.write(tmp, contents.getBytes(CHARSET));
         try {
             Files.move(tmp, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
@@ -124,12 +128,13 @@ public final class FileSystemSaveStore {
     }
 
     public boolean moveToRecycleBin(String name) {
-        Path file = saveDir.resolve(name + EXTENSION);
-        if (!Files.exists(file)) return false;
+        Path file = resolveSave(name);
+        if (file == null || !Files.exists(file)) return false;
+        String flat = name.replace('/', '_');
         Path trash = saveDir.resolve(TRASH_DIR);
         try {
             Files.createDirectories(trash);
-            Path target = trash.resolve(name + "_" + System.currentTimeMillis() + EXTENSION);
+            Path target = trash.resolve(flat + "_" + System.currentTimeMillis() + EXTENSION);
             try {
                 Files.move(file, target, StandardCopyOption.ATOMIC_MOVE);
             } catch (FileAlreadyExistsException e) {
@@ -139,6 +144,47 @@ public final class FileSystemSaveStore {
         } catch (IOException e) {
             return false;
         }
+    }
+
+    private Path resolveSave(String relPath) {
+        return resolveWithin(relPath + EXTENSION);
+    }
+
+    private Path resolveWithin(String relPath) {
+        if (relPath == null) return null;
+        Path base = saveDir.toAbsolutePath().normalize();
+        Path resolved = base.resolve(relPath).normalize();
+        if (!resolved.startsWith(base)) return null;
+        return resolved;
+    }
+
+    public SaveBrowseResult browse(String relDir) {
+        Path dir = (relDir == null || relDir.isEmpty()) ? saveDir.toAbsolutePath().normalize() : resolveWithin(relDir);
+        if (dir == null || !Files.isDirectory(dir)) return SaveBrowseResult.empty();
+
+        List<String> folders = new ArrayList<>();
+        List<SaveInfo> files = new ArrayList<>();
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(dir)) {
+            for (Path p : stream) {
+                String fileName = p.getFileName().toString();
+                if (Files.isDirectory(p)) {
+                    if (TRASH_DIR.equals(fileName)) continue;
+                    folders.add(fileName);
+                } else if (Files.isRegularFile(p) && fileName.endsWith(EXTENSION)) {
+                    String name = fileName.substring(0, fileName.length() - EXTENSION.length());
+                    long mtime;
+                    try {
+                        mtime = Files.getLastModifiedTime(p).toMillis();
+                    } catch (IOException e) {
+                        mtime = 0L;
+                    }
+                    files.add(parseInfo(p, name, mtime));
+                }
+            }
+        } catch (IOException e) {
+            return SaveBrowseResult.empty();
+        }
+        return new SaveBrowseResult(folders, files);
     }
 
 }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveBrowseResult.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveBrowseResult.java
@@ -1,0 +1,19 @@
+package de.legoshi.parkourcalc.core.save;
+
+import java.util.Collections;
+import java.util.List;
+
+public final class SaveBrowseResult {
+
+    public final List<String> folders;
+    public final List<SaveInfo> files;
+
+    public SaveBrowseResult(List<String> folders, List<SaveInfo> files) {
+        this.folders = folders;
+        this.files = files;
+    }
+
+    public static SaveBrowseResult empty() {
+        return new SaveBrowseResult(Collections.<String>emptyList(), Collections.<SaveInfo>emptyList());
+    }
+}

--- a/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveIO.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveIO.java
@@ -30,7 +30,7 @@ import java.util.TimeZone;
 public final class SaveIO {
 
     public static Result<String> save(FileSystemSaveStore store, String rawName, InputData inputData, Vec3dCore startPos, Vec3dCore startVel, float startYaw, AngleSolverState angleSolver, List<TickState> states, boolean fullDebug) {
-        String name = sanitize(rawName);
+        String name = sanitizeRelative(rawName);
         if (name == null) {
             return Result.failure("Invalid save name. Use letters, numbers, dashes, or underscores.");
         }
@@ -47,7 +47,7 @@ public final class SaveIO {
     }
 
     public static Result<SaveFile> load(FileSystemSaveStore store, String rawName) {
-        String name = sanitize(rawName);
+        String name = sanitizeRelative(rawName);
         if (name == null) {
             return Result.failure("Invalid save name.");
         }
@@ -175,6 +175,22 @@ public final class SaveIO {
         String cleaned = out.toString();
         if (cleaned.isEmpty() || cleaned.equals(".") || cleaned.equals("..")) return null;
         return cleaned;
+    }
+
+    public static String sanitizeRelative(String raw) {
+        if (raw == null) return null;
+        String unified = raw.replace('\\', '/').trim();
+        if (unified.isEmpty()) return null;
+        String[] segments = unified.split("/");
+        StringBuilder out = new StringBuilder(unified.length());
+        for (String segment : segments) {
+            if (segment.isEmpty()) continue;
+            String clean = sanitize(segment);
+            if (clean == null) return null;
+            if (out.length() > 0) out.append('/');
+            out.append(clean);
+        }
+        return out.length() == 0 ? null : out.toString();
     }
 
     private static SaveFile buildFile(FileSystemSaveStore store, InputData inputData, Vec3dCore startPos, Vec3dCore startVel, float startYaw, AngleSolverState angleSolver, List<TickState> states, boolean fullDebug) {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/FileMenu.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/FileMenu.java
@@ -3,6 +3,7 @@ package de.legoshi.parkourcalc.core.ui;
 import de.legoshi.parkourcalc.core.SaveController;
 import de.legoshi.parkourcalc.core.ports.FilePickerPort;
 import de.legoshi.parkourcalc.core.save.Result;
+import de.legoshi.parkourcalc.core.save.SaveBrowseResult;
 import de.legoshi.parkourcalc.core.save.SaveFile;
 import de.legoshi.parkourcalc.core.save.SaveInfo;
 import de.legoshi.parkourcalc.core.ui.theme.Controls;
@@ -21,8 +22,6 @@ import imgui.type.ImString;
 import java.nio.file.Path;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -90,10 +89,16 @@ public final class FileMenu {
     private Runnable overwriteModalConfirm;
     private String overwriteCandidateName;
 
-    private List<SaveInfo> cached = Collections.emptyList();
+    private SaveBrowseResult cached = SaveBrowseResult.empty();
     private boolean cacheStale = true;
     private String openSelected;
+    private String openCurrentDir = "";
     private static final int OPEN_MODAL_VISIBLE_ROWS = 12;
+    private static final String PARENT_ENTRY = "..";
+
+    private static String folderLabel(String name) {
+        return name + "/";
+    }
 
     private String statusMessage;
     private boolean statusIsError;
@@ -312,6 +317,7 @@ public final class FileMenu {
     private void onOpen() {
         cacheStale = true;
         openSelected = null;
+        openCurrentDir = "";
         filterInput.set("");
         openOpenModal = true;
     }
@@ -524,20 +530,31 @@ public final class FileMenu {
         if (!Modal.begin(TITLE_OPEN, POPUP_OPEN, ImGuiWindowFlags.NoSavedSettings)) return;
 
         if (cacheStale) {
-            cached = controller.list();
+            cached = controller.browse(openCurrentDir);
             cacheStale = false;
         }
+
+        renderOpenBreadcrumb();
 
         Controls.inputTextHint("Search", "Filter by name...", filterInput, 320);
 
         ThemeManager.sectionSpacing();
 
-        java.util.List<SaveInfo> rows = sortedFiltered();
+        List<String> folders = sortedFilteredFolders();
+        List<SaveInfo> files = sortedFilteredFiles();
+        boolean atRoot = openCurrentDir.isEmpty();
         float tableH = OPEN_MODAL_VISIBLE_ROWS * ImGui.getFrameHeightWithSpacing();
+
+        String navigateInto = null;
+        boolean navigateUp = false;
         String doubleClickedToOpen = null;
 
         float maxFilenameW = 0f, maxDateW = 0f, maxMcW = 0f, maxWorldW = 0f;
-        for (SaveInfo info : rows) {
+        if (!atRoot) maxFilenameW = Math.max(maxFilenameW, ImGui.calcTextSize(PARENT_ENTRY).x);
+        for (String folder : folders) {
+            maxFilenameW = Math.max(maxFilenameW, ImGui.calcTextSize(folderLabel(folder)).x);
+        }
+        for (SaveInfo info : files) {
             maxFilenameW = Math.max(maxFilenameW, ImGui.calcTextSize(info.name).x);
             String d = info.lastModifiedMs > 0 ? dateFmt.format(new Date(info.lastModifiedMs)) : "";
             maxDateW = Math.max(maxDateW, ImGui.calcTextSize(d).x);
@@ -555,7 +572,17 @@ public final class FileMenu {
 
             float rowH = ThemeManager.tableRowHeight();
             int rowIndex = 0;
-            for (SaveInfo info : rows) {
+
+            if (!atRoot) {
+                if (renderFolderRow("##open_up", PARENT_ENTRY, rowIndex++, rowH)) navigateUp = true;
+            }
+            for (String folder : folders) {
+                if (renderFolderRow("##open_dir_" + folder, folderLabel(folder), rowIndex++, rowH)) {
+                    navigateInto = folder;
+                }
+            }
+
+            for (SaveInfo info : files) {
                 ImGui.tableNextRow(0, rowH);
                 ThemeManager.paintTableRowBg(rowIndex++);
                 boolean selected = info.name.equals(openSelected);
@@ -585,9 +612,19 @@ public final class FileMenu {
             ThemeManager.endStandardTable();
         }
 
+        if (navigateUp) {
+            goUpFolder();
+            Modal.end();
+            return;
+        }
+        if (navigateInto != null) {
+            enterFolder(navigateInto);
+            Modal.end();
+            return;
+        }
         if (doubleClickedToOpen != null) {
             ImGui.closeCurrentPopup();
-            onLoad(doubleClickedToOpen);
+            onLoad(joinPath(openCurrentDir, doubleClickedToOpen));
             Modal.end();
             return;
         }
@@ -603,9 +640,9 @@ public final class FileMenu {
             openClicked = false;
         }
         if (openClicked) {
-            String name = openSelected;
+            String key = joinPath(openCurrentDir, openSelected);
             ImGui.closeCurrentPopup();
-            onLoad(name);
+            onLoad(key);
             Modal.end();
             return;
         }
@@ -613,6 +650,75 @@ public final class FileMenu {
         if (Modal.footerButton(BTN_CANCEL)) ImGui.closeCurrentPopup();
 
         Modal.end();
+    }
+
+    private boolean renderFolderRow(String idSuffix, String label, int rowIndex, float rowH) {
+        ImGui.tableNextRow(0, rowH);
+        ThemeManager.paintTableRowBg(rowIndex);
+        ImGui.tableSetColumnIndex(0);
+        ThemeManager.tableLeftmostCellPad();
+        ImVec2 cellOrigin = ImGui.getCursorScreenPos();
+        ImGui.alignTextToFramePadding();
+        int selFlags = ImGuiSelectableFlags.SpanAllColumns | ImGuiSelectableFlags.AllowDoubleClick;
+        boolean activated = ImGui.selectable(idSuffix, false, selFlags);
+        float labelY = cellOrigin.y + ImGui.getStyle().getFramePadding().y;
+        ImGui.getWindowDrawList().addText(cellOrigin.x, labelY, ThemeManager.accentColor(), label);
+        ImGui.tableSetColumnIndex(3);
+        ThemeManager.tableRightmostCellTrailingPad();
+        return activated;
+    }
+
+    private void renderOpenBreadcrumb() {
+        ThemeManager.pushTextColor(ThemeManager.textMutedColor());
+        ImGui.text("saves");
+        ThemeManager.popTextColor();
+        if (openCurrentDir.isEmpty()) {
+            ThemeManager.sectionSpacing();
+            return;
+        }
+        String[] parts = openCurrentDir.split("/");
+        StringBuilder accum = new StringBuilder();
+        String jumpTo = null;
+        for (int i = 0; i < parts.length; i++) {
+            if (accum.length() > 0) accum.append('/');
+            accum.append(parts[i]);
+            ImGui.sameLine();
+            ThemeManager.pushTextColor(ThemeManager.textMutedColor());
+            ImGui.text("/");
+            ThemeManager.popTextColor();
+            ImGui.sameLine();
+            boolean last = i == parts.length - 1;
+            if (last) {
+                ImGui.text(parts[i]);
+            } else {
+                ThemeManager.pushTextColor(ThemeManager.accentColor());
+                if (ImGui.selectable(parts[i] + "##crumb_" + i, false, 0, ImGui.calcTextSize(parts[i]).x, 0f)) {
+                    jumpTo = accum.toString();
+                }
+                ThemeManager.popTextColor();
+            }
+        }
+        if (jumpTo != null) navigateToFolder(jumpTo);
+        ThemeManager.sectionSpacing();
+    }
+
+    private void enterFolder(String folderName) {
+        navigateToFolder(joinPath(openCurrentDir, folderName));
+    }
+
+    private void goUpFolder() {
+        int slash = openCurrentDir.lastIndexOf('/');
+        navigateToFolder(slash < 0 ? "" : openCurrentDir.substring(0, slash));
+    }
+
+    private void navigateToFolder(String relDir) {
+        openCurrentDir = relDir == null ? "" : relDir;
+        openSelected = null;
+        cacheStale = true;
+    }
+
+    private static String joinPath(String dir, String name) {
+        return (dir == null || dir.isEmpty()) ? name : dir + "/" + name;
     }
 
     private void renderDiscardModal() {
@@ -693,13 +799,23 @@ public final class FileMenu {
         ThemeManager.tableRightmostCellTrailingPad();
     }
 
-    private List<SaveInfo> sortedFiltered() {
+    private List<SaveInfo> sortedFilteredFiles() {
         String needle = filterInput.get().toLowerCase(Locale.US).trim();
-        List<SaveInfo> out = new ArrayList<>(cached.size());
-        for (SaveInfo info : cached) {
+        List<SaveInfo> out = new ArrayList<>(cached.files.size());
+        for (SaveInfo info : cached.files) {
             if (needle.isEmpty() || info.name.toLowerCase(Locale.US).contains(needle)) out.add(info);
         }
         out.sort((a, b) -> Long.compare(b.lastModifiedMs, a.lastModifiedMs));
+        return out;
+    }
+
+    private List<String> sortedFilteredFolders() {
+        String needle = filterInput.get().toLowerCase(Locale.US).trim();
+        List<String> out = new ArrayList<>(cached.folders.size());
+        for (String folder : cached.folders) {
+            if (needle.isEmpty() || folder.toLowerCase(Locale.US).contains(needle)) out.add(folder);
+        }
+        out.sort(String.CASE_INSENSITIVE_ORDER);
         return out;
     }
 

--- a/core/src/test/java/de/legoshi/parkourcalc/core/save/SaveSubfolderTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/save/SaveSubfolderTest.java
@@ -1,0 +1,94 @@
+package de.legoshi.parkourcalc.core.save;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class SaveSubfolderTest {
+
+    private static FileSystemSaveStore storeAt(Path dir) {
+        return new FileSystemSaveStore(dir, "test", "1.8.9", () -> null);
+    }
+
+    @Test
+    public void sanitizeRelativeKeepsBareNamesAndCleansSegments() {
+        assertEquals("run", SaveIO.sanitizeRelative("run"));
+        assertEquals("maps/spawn/run", SaveIO.sanitizeRelative("maps/spawn/run"));
+        assertEquals("maps/run", SaveIO.sanitizeRelative("maps\\run"));
+        assertEquals("maps/run", SaveIO.sanitizeRelative("/maps//run/"));
+        assertEquals("a_b/c", SaveIO.sanitizeRelative("a b/c"));
+    }
+
+    @Test
+    public void sanitizeRelativeRejectsTraversalAndEmpty() {
+        assertNull(SaveIO.sanitizeRelative(null));
+        assertNull(SaveIO.sanitizeRelative(""));
+        assertNull(SaveIO.sanitizeRelative("   "));
+        assertNull(SaveIO.sanitizeRelative("/"));
+        assertNull(SaveIO.sanitizeRelative(".."));
+        assertNull(SaveIO.sanitizeRelative("../secret"));
+        assertNull(SaveIO.sanitizeRelative("maps/../../etc"));
+        assertNull(SaveIO.sanitizeRelative("maps/."));
+    }
+
+    @Test
+    public void writeReadAndExistsTraverseSubfolders() throws IOException {
+        FileSystemSaveStore store = storeAt(Files.createTempDirectory("pkc-sub"));
+        store.write("maps/spawn/run", "{\"hello\":1}");
+
+        assertTrue(store.exists("maps/spawn/run"));
+        assertFalse(store.exists("maps/spawn/missing"));
+        assertEquals("{\"hello\":1}", store.read("maps/spawn/run"));
+        assertTrue(Files.isRegularFile(store.getSaveDir().resolve("maps/spawn/run.json")));
+    }
+
+    @Test
+    public void browseListsFoldersAndFilesAndHidesTrash() throws IOException {
+        Path dir = Files.createTempDirectory("pkc-browse");
+        FileSystemSaveStore store = storeAt(dir);
+        store.write("root", "{\"a\":1}");
+        store.write("maps/alpha", "{\"a\":1}");
+        store.write("maps/beta", "{\"a\":1}");
+        store.moveToRecycleBin("root");
+        store.write("root", "{\"a\":1}");
+
+        SaveBrowseResult top = store.browse("");
+        assertTrue("sub-folder is listed", top.folders.contains("maps"));
+        assertFalse(".trash must stay hidden", top.folders.contains(".trash"));
+        assertEquals("one .json file at root", 1, top.files.size());
+        assertEquals("root", top.files.get(0).name);
+
+        SaveBrowseResult inside = store.browse("maps");
+        assertTrue(inside.folders.isEmpty());
+        assertEquals(2, inside.files.size());
+        List<String> names = new java.util.ArrayList<>();
+        for (SaveInfo info : inside.files) names.add(info.name);
+        assertTrue(names.contains("alpha"));
+        assertTrue(names.contains("beta"));
+    }
+
+    @Test
+    public void browseRefusesToEscapeBaseDirectory() throws IOException {
+        Path base = Files.createTempDirectory("pkc-escape").resolve("saves");
+        Files.createDirectories(base);
+        Path sibling = base.resolveSibling("outside");
+        Files.createDirectories(sibling);
+        Files.write(sibling.resolve("secret.json"), "{\"x\":1}".getBytes(StandardCharsets.UTF_8));
+
+        FileSystemSaveStore store = storeAt(base);
+        SaveBrowseResult escaped = store.browse("../outside");
+        assertNotNull(escaped);
+        assertTrue("traversal out of the save dir yields nothing", escaped.folders.isEmpty());
+        assertTrue(escaped.files.isEmpty());
+    }
+}


### PR DESCRIPTION
Folder-aware Open dialog: clickable breadcrumb, `..` row, accent-colored folder rows above files; filter applies within the current folder; folders navigate, files open. The save-key pipeline is folder-aware (relative `/` paths) so Save / Ctrl+S / Open-Recent stay consistent. Bare root names are byte-for-byte unchanged. Base-dir escape is guarded at both the sanitizer and the store.

Files: `save/FileSystemSaveStore.java`, `save/SaveBrowseResult.java` (new), `save/SaveIO.java`, `SaveController.java`, `ui/FileMenu.java`, `+SaveSubfolderTest` (5 tests).

Closes #108

Build: `:core:check` green (+5 tests). Scope: core-only. Risk: low.
Merge: directly (independent; SaveIO overlap with #112/#100-101 is in unrelated sections).
