### PR TITLE
feat(playback): replay from the selected tick or range (#129)

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
@@ -95,7 +95,7 @@ public final class Application {
         Vec3dCore pos = pre != null ? pre.position : runner.getStartPosition();
         Vec3dCore vel = pre != null ? pre.velocity : runner.getStartVelocity();
         float yaw = pre != null ? pre.yaw : runner.getStartYaw();
-        return new PlaybackController.StartRange(first, stopExclusive, pos, vel, yaw);
+        return new PlaybackController.StartRange(first, stopExclusive, pos, vel, yaw, runner.getCheckpoint(first));
     }
 
     public void setModVersion(String modVersion) {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
@@ -34,7 +34,9 @@ import de.legoshi.parkourcalc.core.ui.anglesolver.AngleSolverWindow;
 import de.legoshi.parkourcalc.core.anglesolver.solver.ExactJumpModel;
 
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 /** Single-instance orchestrator wired by loaders via mixins / event handlers. */
 public final class Application {
@@ -75,6 +77,25 @@ public final class Application {
         );
         this.saveController = new SaveController(inputData, runner, mc, this::runSimulation);
         this.playback = new PlaybackController(inputData, runner, settings);
+        this.playback.setStartRangeResolver(this::resolvePlaybackStartRange);
+    }
+
+    private PlaybackController.StartRange resolvePlaybackStartRange() {
+        if (selection.isEmpty()) return null;
+
+        Set<Integer> selected = selection.getSelected();
+        int rowCount = inputData.size();
+        int first = Collections.min(selected);
+        int last = Collections.max(selected);
+        if (first < 0 || first >= rowCount) return null;
+
+        int stopExclusive = (selected.size() == 1) ? rowCount : Math.min(last + 1, rowCount);
+
+        TickState pre = boxController.getState(first);
+        Vec3dCore pos = pre != null ? pre.position : runner.getStartPosition();
+        Vec3dCore vel = pre != null ? pre.velocity : runner.getStartVelocity();
+        float yaw = pre != null ? pre.yaw : runner.getStartYaw();
+        return new PlaybackController.StartRange(first, stopExclusive, pos, vel, yaw);
     }
 
     public void setModVersion(String modVersion) {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/PlaybackController.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/PlaybackController.java
@@ -2,6 +2,7 @@ package de.legoshi.parkourcalc.core;
 
 import de.legoshi.parkourcalc.core.ports.PlaybackBridge;
 import de.legoshi.parkourcalc.core.sim.SimulationRunner;
+import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.DebugFlags;
 import de.legoshi.parkourcalc.core.ui.InputData;
 import de.legoshi.parkourcalc.core.ui.InputRow;
@@ -9,6 +10,7 @@ import de.legoshi.parkourcalc.core.ui.Settings;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
 
 public final class PlaybackController {
 
@@ -25,9 +27,13 @@ public final class PlaybackController {
 
     private boolean running;
     private int nextTick;
+    private int stopTick;
+    private int startTick;
     private int warmupRemaining;
     private int lastSpeedAmplifier;
     private int lastJumpBoostAmplifier;
+
+    private Supplier<StartRange> startRangeResolver;
 
     // currentTickYaw is the physics yaw, kept bit-identical to the simulator's rotationYaw:
     // the sine table quantizes 45 and -315 into different buckets, so a mod-360 offset
@@ -60,6 +66,26 @@ public final class PlaybackController {
         this.bridge = bridge;
     }
 
+    public void setStartRangeResolver(Supplier<StartRange> resolver) {
+        this.startRangeResolver = resolver;
+    }
+
+    public static final class StartRange {
+        public final int startIndex;
+        public final int stopExclusive;
+        public final Vec3dCore pos;
+        public final Vec3dCore vel;
+        public final float yaw;
+
+        public StartRange(int startIndex, int stopExclusive, Vec3dCore pos, Vec3dCore vel, float yaw) {
+            this.startIndex = startIndex;
+            this.stopExclusive = stopExclusive;
+            this.pos = pos;
+            this.vel = vel;
+            this.yaw = yaw;
+        }
+    }
+
     public boolean isRunning() {
         return running;
     }
@@ -67,6 +93,7 @@ public final class PlaybackController {
     public int currentTick() {
         if (!running) return -1;
         if (warmupRemaining > 0) return -1;
+        if (nextTick <= startTick) return -1;
         return nextTick - 1;
     }
 
@@ -82,8 +109,22 @@ public final class PlaybackController {
     }
 
     public void start() {
+        StartRange range = startRangeResolver != null ? startRangeResolver.get() : null;
+        if (range == null) {
+            start(0, inputData.size(), runner.getStartPosition(), runner.getStartVelocity(), runner.getStartYaw());
+        } else {
+            start(range.startIndex, range.stopExclusive, range.pos, range.vel, range.yaw);
+        }
+    }
+
+    public void start(int startIndex, int stopExclusive, Vec3dCore pos, Vec3dCore vel, float yaw) {
         if (running) return;
         if (!canStart()) return;
+
+        int size = inputData.size();
+        int from = clamp(startIndex, 0, size - 1);
+        int to = clamp(stopExclusive, from + 1, size);
+
         bridge.closeUI();
         pausedAtNanos = 0L;
 
@@ -96,24 +137,33 @@ public final class PlaybackController {
                 DebugFlags.simTickSink = null;
             }
         }
-        bridge.teleport(runner.getStartPosition(), runner.getStartVelocity(), runner.getStartYaw());
+        bridge.teleport(pos, vel, yaw);
         // Drop any user-held key so the warmup runs with an empty InputRow like the simulator does.
         bridge.releaseAllKeys();
-        nextTick = 0;
-        warmupRemaining = WARMUP_TICKS;
-        prevTickYaw = runner.getStartYaw();
-        currentTickYaw = runner.getStartYaw();
-        displayTargetYaw = runner.getStartYaw();
-        displayedYaw = runner.getStartYaw();
+        startTick = from;
+        nextTick = from;
+        stopTick = to;
+        // A mid-path snapshot is already post-settle, so warming up there would double-apply the settle.
+        warmupRemaining = (from == 0) ? WARMUP_TICKS : 0;
+        prevTickYaw = yaw;
+        currentTickYaw = yaw;
+        displayTargetYaw = yaw;
+        displayedYaw = yaw;
         tickEndNanos = 0L;
         lastFrameNanos = 0L;
-        InputRow firstRow = inputData.get(0);
+        InputRow firstRow = inputData.get(from);
         int firstSpeedAmp = firstRow.getSpeedAmplifier();
         int firstJumpAmp = firstRow.getJumpBoostAmplifier();
         bridge.applyEffects(firstSpeedAmp, firstJumpAmp);
         lastSpeedAmplifier = firstSpeedAmp;
         lastJumpBoostAmplifier = firstJumpAmp;
         running = true;
+    }
+
+    private static int clamp(int v, int min, int max) {
+        if (v < min) return min;
+        if (v > max) return max;
+        return v;
     }
 
     public void stop() {
@@ -129,6 +179,18 @@ public final class PlaybackController {
         }
         lastSpeedAmplifier = 0;
         lastJumpBoostAmplifier = 0;
+    }
+
+    public String statusHint() {
+        if (!running) return "";
+        boolean fromStart = startTick == 0;
+        boolean toEnd = stopTick >= inputData.size();
+        if (fromStart && toEnd) return "";
+        int firstTick = startTick + 1;
+        int lastTick = stopTick;
+        if (firstTick == lastTick) return "Replaying tick " + firstTick;
+        if (toEnd) return "Replaying from tick " + firstTick;
+        return "Replaying ticks " + firstTick + "-" + lastTick;
     }
 
     /** Loader calls each START_CLIENT_TICK. */
@@ -150,7 +212,7 @@ public final class PlaybackController {
             if (lastFrameNanos != 0L) lastFrameNanos += pausedFor;
             pausedAtNanos = 0L;
         }
-        if (nextTick >= inputData.size()) {
+        if (nextTick >= stopTick) {
             // Stop only once the visual has caught up to the final yaw and a tick
             // window has elapsed; a low cap can keep the ease running past the final input.
             boolean caughtUp = displayedYaw == displayTargetYaw;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/PlaybackController.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/PlaybackController.java
@@ -1,6 +1,7 @@
 package de.legoshi.parkourcalc.core;
 
 import de.legoshi.parkourcalc.core.ports.PlaybackBridge;
+import de.legoshi.parkourcalc.core.sim.Checkpoint;
 import de.legoshi.parkourcalc.core.sim.SimulationRunner;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.DebugFlags;
@@ -76,13 +77,15 @@ public final class PlaybackController {
         public final Vec3dCore pos;
         public final Vec3dCore vel;
         public final float yaw;
+        public final Checkpoint carry;
 
-        public StartRange(int startIndex, int stopExclusive, Vec3dCore pos, Vec3dCore vel, float yaw) {
+        public StartRange(int startIndex, int stopExclusive, Vec3dCore pos, Vec3dCore vel, float yaw, Checkpoint carry) {
             this.startIndex = startIndex;
             this.stopExclusive = stopExclusive;
             this.pos = pos;
             this.vel = vel;
             this.yaw = yaw;
+            this.carry = carry;
         }
     }
 
@@ -111,13 +114,17 @@ public final class PlaybackController {
     public void start() {
         StartRange range = startRangeResolver != null ? startRangeResolver.get() : null;
         if (range == null) {
-            start(0, inputData.size(), runner.getStartPosition(), runner.getStartVelocity(), runner.getStartYaw());
+            start(0, inputData.size(), runner.getStartPosition(), runner.getStartVelocity(), runner.getStartYaw(), runner.getCheckpoint(0));
         } else {
-            start(range.startIndex, range.stopExclusive, range.pos, range.vel, range.yaw);
+            start(range.startIndex, range.stopExclusive, range.pos, range.vel, range.yaw, range.carry);
         }
     }
 
     public void start(int startIndex, int stopExclusive, Vec3dCore pos, Vec3dCore vel, float yaw) {
+        start(startIndex, stopExclusive, pos, vel, yaw, null);
+    }
+
+    public void start(int startIndex, int stopExclusive, Vec3dCore pos, Vec3dCore vel, float yaw, Checkpoint carry) {
         if (running) return;
         if (!canStart()) return;
 
@@ -137,7 +144,7 @@ public final class PlaybackController {
                 DebugFlags.simTickSink = null;
             }
         }
-        bridge.teleport(pos, vel, yaw);
+        bridge.teleport(pos, vel, yaw, carry);
         // Drop any user-held key so the warmup runs with an empty InputRow like the simulator does.
         bridge.releaseAllKeys();
         startTick = from;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ports/PlaybackBridge.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ports/PlaybackBridge.java
@@ -1,5 +1,6 @@
 package de.legoshi.parkourcalc.core.ports;
 
+import de.legoshi.parkourcalc.core.sim.Checkpoint;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.InputRow;
 
@@ -19,7 +20,7 @@ public interface PlaybackBridge {
         return false;
     }
 
-    void teleport(Vec3dCore pos, Vec3dCore vel, float yaw);
+    void teleport(Vec3dCore pos, Vec3dCore vel, float yaw, Checkpoint carry);
 
     void setKey(InputRow.Key key, boolean pressed);
 

--- a/core/src/main/java/de/legoshi/parkourcalc/core/sim/SimulationRunner.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/sim/SimulationRunner.java
@@ -75,6 +75,11 @@ public final class SimulationRunner {
         );
     }
 
+    public Checkpoint getCheckpoint(int index) {
+        if (index < 0 || index >= checkpoints.size()) return null;
+        return checkpoints.get(index);
+    }
+
     /** Drop the cached entity and any state captured against the old world. */
     public void invalidate() {
         path.clear();

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputOverlay.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputOverlay.java
@@ -883,6 +883,10 @@ public final class InputOverlay {
         return editingYawRow >= 0;
     }
 
+    public String playbackStatusHint() {
+        return playback != null ? playback.statusHint() : "";
+    }
+
     public void navigateYaw(boolean forward) {
         int from = editingYawRow;
         if (from < 0) return;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/MainWindowOverlay.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/MainWindowOverlay.java
@@ -179,9 +179,12 @@ public final class MainWindowOverlay implements RenderInterface {
         }
         dl.addText(x, y, ThemeManager.textMutedColor(), APP_NAME);
         if (fileMenu.hasOpenTas()) {
-            String rows = inputData.size() + " rows";
-            float rw = ImGui.calcTextSize(rows).x;
-            dl.addText(winPos.x + winW - padX - rw, y, ThemeManager.textMutedColor(), rows);
+            String hint = inputOverlay.playbackStatusHint();
+            boolean replaying = !hint.isEmpty();
+            String rightText = replaying ? hint : inputData.size() + " rows";
+            int rightColor = replaying ? ThemeManager.warningColor() : ThemeManager.textMutedColor();
+            float rw = ImGui.calcTextSize(rightText).x;
+            dl.addText(winPos.x + winW - padX - rw, y, rightColor, rightText);
         }
         dl.popClipRect();
     }

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/PlaybackPauseTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/PlaybackPauseTest.java
@@ -40,7 +40,7 @@ public class PlaybackPauseTest {
         }
 
         @Override
-        public void teleport(Vec3dCore pos, Vec3dCore vel, float yaw) {
+        public void teleport(Vec3dCore pos, Vec3dCore vel, float yaw, de.legoshi.parkourcalc.core.sim.Checkpoint carry) {
         }
 
         @Override

--- a/core/src/test/java/de/legoshi/parkourcalc/core/PlaybackRangeTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/PlaybackRangeTest.java
@@ -1,0 +1,206 @@
+package de.legoshi.parkourcalc.core;
+
+import de.legoshi.parkourcalc.core.ports.PlaybackBridge;
+import de.legoshi.parkourcalc.core.ports.Simulator;
+import de.legoshi.parkourcalc.core.sim.SimulationRunner;
+import de.legoshi.parkourcalc.core.sim.Vec3dCore;
+import de.legoshi.parkourcalc.core.ui.InputData;
+import de.legoshi.parkourcalc.core.ui.InputRow;
+import de.legoshi.parkourcalc.core.ui.Settings;
+import org.junit.Test;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class PlaybackRangeTest {
+
+    private static final class FakeBridge implements PlaybackBridge {
+        Vec3dCore teleportPos;
+        Vec3dCore teleportVel;
+        float teleportYaw;
+        int teleportCalls;
+        final Map<InputRow.Key, Boolean> keys = new EnumMap<>(InputRow.Key.class);
+
+        @Override public boolean isSingleplayer() { return true; }
+        @Override public boolean isGamePaused() { return false; }
+
+        @Override
+        public void teleport(Vec3dCore pos, Vec3dCore vel, float yaw) {
+            teleportPos = pos;
+            teleportVel = vel;
+            teleportYaw = yaw;
+            teleportCalls++;
+        }
+
+        @Override public void setKey(InputRow.Key key, boolean pressed) { keys.put(key, pressed); }
+        @Override public void setYaw(float absoluteYaw) { }
+        @Override public void releaseAllKeys() { keys.clear(); }
+        @Override public void closeUI() { }
+        @Override public void applyEffects(int speedAmplifier, int jumpBoostAmplifier) { }
+    }
+
+    private static final class FakeSimulator implements Simulator {
+        private Vec3dCore startPos = Vec3dCore.ZERO;
+        private Vec3dCore startVel = Vec3dCore.ZERO;
+        private float startYaw;
+
+        @Override public void resetToStart() { }
+        @Override public void applyInput(InputRow row) { }
+        @Override public void tick() { }
+        @Override public Vec3dCore getCurrentPosition() { return Vec3dCore.ZERO; }
+        @Override public boolean isCurrentOnGround() { return false; }
+        @Override public boolean isCurrentSneaking() { return false; }
+        @Override public boolean isCurrentSprinting() { return false; }
+        @Override public float getCurrentMoveForward() { return Float.NaN; }
+        @Override public float getCurrentMoveStrafe() { return Float.NaN; }
+        @Override public boolean isCurrentWallCollision() { return false; }
+        @Override public Vec3dCore getCurrentVelocity() { return Vec3dCore.ZERO; }
+        @Override public boolean isCurrentSoftCollision() { return false; }
+        @Override public double getCurrentCollisionAngleDegrees() { return Double.NaN; }
+        @Override public float getCurrentYaw() { return 0f; }
+        @Override public java.util.List<Vec3dCore> getCurrentSubtickPath() { return java.util.Collections.emptyList(); }
+        @Override public Vec3dCore getStartPosition() { return startPos; }
+        @Override public void setStartPosition(Vec3dCore pos) { startPos = pos; }
+        @Override public Vec3dCore getStartVelocity() { return startVel; }
+        @Override public void setStartVelocity(Vec3dCore vel) { startVel = vel; }
+        @Override public float getStartYaw() { return startYaw; }
+        @Override public void setStartYaw(float yaw) { startYaw = yaw; }
+        @Override public de.legoshi.parkourcalc.core.sim.Checkpoint saveCheckpoint() { return null; }
+        @Override public void restoreCheckpoint(de.legoshi.parkourcalc.core.sim.Checkpoint checkpoint) { }
+        @Override public void invalidate() { }
+    }
+
+    private static InputData rows(int n) {
+        InputRow.Key[] keys = InputRow.Key.values();
+        InputData data = new InputData();
+        for (int i = 0; i < n; i++) {
+            InputRow row = new InputRow();
+            row.setKeyActive(keys[i % keys.length], true);
+            data.getRows().add(row);
+        }
+        return data;
+    }
+
+    private static InputRow.Key keyFor(int rowIndex) {
+        InputRow.Key[] keys = InputRow.Key.values();
+        return keys[rowIndex % keys.length];
+    }
+
+    private static PlaybackController controller(FakeBridge bridge, SimulationRunner runner, InputData data) {
+        PlaybackController pc = new PlaybackController(data, runner, new Settings());
+        pc.setBridge(bridge);
+        return pc;
+    }
+
+    @Test
+    public void startsAtTheChosenTickWithNoWarmupAndTeleportsToTheGivenState() {
+        InputData data = rows(6);
+        FakeBridge bridge = new FakeBridge();
+        PlaybackController pc = controller(bridge, new SimulationRunner(new FakeSimulator()), data);
+
+        Vec3dCore pos = new Vec3dCore(10, 64, -5);
+        Vec3dCore vel = new Vec3dCore(0.1, -0.2, 0.3);
+        pc.start(3, data.size(), pos, vel, 90f);
+
+        assertTrue(pc.isRunning());
+        assertEquals("teleports to the supplied pre-tick state", pos, bridge.teleportPos);
+        assertEquals(vel, bridge.teleportVel);
+        assertEquals(90f, bridge.teleportYaw, 0f);
+        assertEquals(1, bridge.teleportCalls);
+
+        assertEquals(-1, pc.currentTick());
+        pc.tick();
+        assertEquals(3, pc.currentTick());
+        assertEquals("row 3's key is applied first", Boolean.TRUE, bridge.keys.get(keyFor(3)));
+    }
+
+    @Test
+    public void rangeStopsAfterItsLastTickAndNeverPlaysBeyondIt() throws Exception {
+        InputData data = rows(8);
+        FakeBridge bridge = new FakeBridge();
+        PlaybackController pc = controller(bridge, new SimulationRunner(new FakeSimulator()), data);
+
+        pc.start(2, 5, Vec3dCore.ZERO, Vec3dCore.ZERO, 0f);
+        pc.tick();
+        assertEquals(2, pc.currentTick());
+        pc.tick();
+        pc.tick();
+        assertEquals("playback advances exactly to the range's last tick", 4, pc.currentTick());
+
+        long deadline = System.currentTimeMillis() + 2_000;
+        while (pc.isRunning() && System.currentTimeMillis() < deadline) {
+            assertTrue("never schedules a tick beyond the range", pc.currentTick() <= 4);
+            pc.tick();
+            Thread.sleep(5);
+        }
+        assertFalse("playback stops after the range's last tick", pc.isRunning());
+    }
+
+    @Test
+    public void noArgStartWithoutResolverReplaysWholeTasFromTheTopWithWarmup() {
+        InputData data = rows(3);
+        FakeBridge bridge = new FakeBridge();
+        SimulationRunner runner = new SimulationRunner(new FakeSimulator());
+        runner.setStartPosition(new Vec3dCore(1, 2, 3));
+        runner.setStartYaw(45f);
+        PlaybackController pc = controller(bridge, runner, data);
+
+        pc.start();
+
+        assertTrue(pc.isRunning());
+        assertEquals("teleports to the runner's start position", new Vec3dCore(1, 2, 3), bridge.teleportPos);
+        assertEquals(45f, bridge.teleportYaw, 0f);
+        pc.tick();
+        assertEquals(-1, pc.currentTick());
+        pc.tick();
+        assertEquals(-1, pc.currentTick());
+        pc.tick();
+        assertEquals(0, pc.currentTick());
+    }
+
+    @Test
+    public void startRangeResolverDrivesTheNoArgStart() {
+        InputData data = rows(6);
+        FakeBridge bridge = new FakeBridge();
+        PlaybackController pc = controller(bridge, new SimulationRunner(new FakeSimulator()), data);
+
+        Vec3dCore pos = new Vec3dCore(7, 8, 9);
+        pc.setStartRangeResolver(() -> new PlaybackController.StartRange(4, 6, pos, Vec3dCore.ZERO, 12f));
+        pc.start();
+
+        assertEquals(pos, bridge.teleportPos);
+        pc.tick();
+        assertEquals("resolver's start index is honoured by the no-arg start()", 4, pc.currentTick());
+    }
+
+    @Test
+    public void statusHintDescribesTheRangeButNotAFullFromTopReplay() {
+        InputData data = rows(10);
+        FakeBridge bridge = new FakeBridge();
+        PlaybackController pc = controller(bridge, new SimulationRunner(new FakeSimulator()), data);
+
+        assertEquals("idle has no hint", "", pc.statusHint());
+
+        pc.start(0, data.size(), Vec3dCore.ZERO, Vec3dCore.ZERO, 0f);
+        assertEquals("a full from-the-top replay needs no hint", "", pc.statusHint());
+        pc.stop();
+
+        pc.start(4, 9, Vec3dCore.ZERO, Vec3dCore.ZERO, 0f);
+        assertEquals("Replaying ticks 5-9", pc.statusHint());
+        pc.stop();
+
+        pc.start(4, data.size(), Vec3dCore.ZERO, Vec3dCore.ZERO, 0f);
+        assertEquals("Replaying from tick 5", pc.statusHint());
+        pc.stop();
+
+        pc.start(4, 5, Vec3dCore.ZERO, Vec3dCore.ZERO, 0f);
+        assertEquals("Replaying tick 5", pc.statusHint());
+
+        pc.stop();
+        assertEquals("idle again after stop", "", pc.statusHint());
+    }
+}

--- a/core/src/test/java/de/legoshi/parkourcalc/core/PlaybackRangeTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/PlaybackRangeTest.java
@@ -29,7 +29,7 @@ public class PlaybackRangeTest {
         @Override public boolean isGamePaused() { return false; }
 
         @Override
-        public void teleport(Vec3dCore pos, Vec3dCore vel, float yaw) {
+        public void teleport(Vec3dCore pos, Vec3dCore vel, float yaw, de.legoshi.parkourcalc.core.sim.Checkpoint carry) {
             teleportPos = pos;
             teleportVel = vel;
             teleportYaw = yaw;
@@ -169,7 +169,7 @@ public class PlaybackRangeTest {
         PlaybackController pc = controller(bridge, new SimulationRunner(new FakeSimulator()), data);
 
         Vec3dCore pos = new Vec3dCore(7, 8, 9);
-        pc.setStartRangeResolver(() -> new PlaybackController.StartRange(4, 6, pos, Vec3dCore.ZERO, 12f));
+        pc.setStartRangeResolver(() -> new PlaybackController.StartRange(4, 6, pos, Vec3dCore.ZERO, 12f, null));
         pc.start();
 
         assertEquals(pos, bridge.teleportPos);

--- a/loader-fabric-1.21.10/src/client/java/de/legoshi/parkourcalc/fabric/FabricPlaybackBridge.java
+++ b/loader-fabric-1.21.10/src/client/java/de/legoshi/parkourcalc/fabric/FabricPlaybackBridge.java
@@ -60,7 +60,7 @@ public final class FabricPlaybackBridge implements PlaybackBridge {
     }
 
     @Override
-    public void teleport(Vec3dCore pos, Vec3dCore vel, float yaw) {
+    public void teleport(Vec3dCore pos, Vec3dCore vel, float yaw, de.legoshi.parkourcalc.core.sim.Checkpoint carry) {
         MinecraftClient mc = MinecraftClient.getInstance();
         ClientPlayerEntity client = mc.player;
         if (client == null) return;
@@ -75,13 +75,17 @@ public final class FabricPlaybackBridge implements PlaybackBridge {
             // path fires a SetEntityMotion packet that arrives ~1 tick late and stomps the
             // player mid-playback.
             sp.networkHandler.requestTeleport(
-                    new EntityPosition(new Vec3d(pos.x, pos.y, pos.z), new Vec3d(vel.x, vel.y, vel.z), yaw, sp.getPitch()),
-                    Collections.emptySet()
+                new EntityPosition(new Vec3d(pos.x, pos.y, pos.z), new Vec3d(vel.x, vel.y, vel.z), yaw, sp.getPitch()),
+                Collections.emptySet()
             );
         });
         client.updatePositionAndAngles(pos.x, pos.y, pos.z, yaw, client.getPitch());
         client.setVelocity(vel.x, vel.y, vel.z);
-        client.setOnGround(true);
+        if (carry != null) {
+            de.legoshi.parkourcalc.fabric.sim.SimulatorEntity.applyCheckpoint(client, carry);
+        } else {
+            client.setOnGround(true);
+        }
         client.fallDistance = 0.0;
         // Suppress the player tick's position packet until the server's requestTeleport
         // arms its teleport-pending state, otherwise the client races and trips moved-wrongly.

--- a/loader-fabric-1.21.10/src/client/java/de/legoshi/parkourcalc/fabric/sim/SimulatorEntity.java
+++ b/loader-fabric-1.21.10/src/client/java/de/legoshi/parkourcalc/fabric/sim/SimulatorEntity.java
@@ -412,6 +412,16 @@ public class SimulatorEntity extends PlayerEntity {
         this.jumpingCooldown = c.jumpingCooldown;
     }
 
+    public static void applyCheckpoint(net.minecraft.client.network.ClientPlayerEntity p, de.legoshi.parkourcalc.core.sim.Checkpoint state) {
+        if (!(state instanceof Checkpoint)) return;
+        Checkpoint c = (Checkpoint) state;
+        p.setOnGround(c.onGround);
+        p.horizontalCollision = c.horizontalCollision;
+        p.collidedSoftly = c.collidedSoftly;
+        p.setSprinting(c.sprinting);
+        p.jumpingCooldown = c.jumpingCooldown;
+    }
+
     public static final class Checkpoint implements de.legoshi.parkourcalc.core.sim.Checkpoint {
         Vec3d pos;
         Vec3d velocity;

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12PlaybackBridge.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12PlaybackBridge.java
@@ -10,7 +10,6 @@ import net.minecraft.client.settings.KeyBinding;
 import net.minecraft.entity.SharedMonsterAttributes;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.MobEffects;
-import net.minecraft.network.NetHandlerPlayServer;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.server.integrated.IntegratedServer;
 import net.minecraft.util.MovementInput;
@@ -32,10 +31,6 @@ public final class Forge12PlaybackBridge implements PlaybackBridge {
     private static final String[] LAST_REPORTED_YAW = { "lastReportedYaw", "field_175164_bL" };
     private static final String[] LAST_REPORTED_PITCH = { "lastReportedPitch", "field_175165_bM" };
     private static final String[] POSITION_UPDATE_TICKS = { "positionUpdateTicks", "field_175168_bP" };
-
-    private static final String[] SERVER_LAST_GOOD_X = { "lastGoodX", "field_184352_o" };
-    private static final String[] SERVER_LAST_GOOD_Y = { "lastGoodY", "field_184353_p" };
-    private static final String[] SERVER_LAST_GOOD_Z = { "lastGoodZ", "field_184354_q" };
 
     private final InputRow currentRow = new InputRow();
     private MovementInput originalInput;
@@ -90,10 +85,6 @@ public final class Forge12PlaybackBridge implements PlaybackBridge {
                 sp.onGround = true;
             }
             sp.velocityChanged = false;
-            NetHandlerPlayServer conn = sp.connection;
-            ObfuscationReflectionHelper.setPrivateValue(NetHandlerPlayServer.class, conn, pos.x, SERVER_LAST_GOOD_X);
-            ObfuscationReflectionHelper.setPrivateValue(NetHandlerPlayServer.class, conn, pos.y, SERVER_LAST_GOOD_Y);
-            ObfuscationReflectionHelper.setPrivateValue(NetHandlerPlayServer.class, conn, pos.z, SERVER_LAST_GOOD_Z);
         });
         client.setPositionAndRotation(pos.x, pos.y, pos.z, yaw, client.rotationPitch);
         client.renderYawOffset = yaw;

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12PlaybackBridge.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12PlaybackBridge.java
@@ -10,6 +10,7 @@ import net.minecraft.client.settings.KeyBinding;
 import net.minecraft.entity.SharedMonsterAttributes;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.MobEffects;
+import net.minecraft.network.NetHandlerPlayServer;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.server.integrated.IntegratedServer;
 import net.minecraft.util.MovementInput;
@@ -31,6 +32,10 @@ public final class Forge12PlaybackBridge implements PlaybackBridge {
     private static final String[] LAST_REPORTED_YAW = { "lastReportedYaw", "field_175164_bL" };
     private static final String[] LAST_REPORTED_PITCH = { "lastReportedPitch", "field_175165_bM" };
     private static final String[] POSITION_UPDATE_TICKS = { "positionUpdateTicks", "field_175168_bP" };
+
+    private static final String[] SERVER_LAST_GOOD_X = { "lastGoodX", "field_184352_o" };
+    private static final String[] SERVER_LAST_GOOD_Y = { "lastGoodY", "field_184353_p" };
+    private static final String[] SERVER_LAST_GOOD_Z = { "lastGoodZ", "field_184354_q" };
 
     private final InputRow currentRow = new InputRow();
     private MovementInput originalInput;
@@ -63,7 +68,7 @@ public final class Forge12PlaybackBridge implements PlaybackBridge {
     }
 
     @Override
-    public void teleport(Vec3dCore pos, Vec3dCore vel, float yaw) {
+    public void teleport(Vec3dCore pos, Vec3dCore vel, float yaw, de.legoshi.parkourcalc.core.sim.Checkpoint carry) {
         Minecraft mc = Minecraft.getMinecraft();
         EntityPlayerSP client = mc.player;
         if (client == null) return;
@@ -73,17 +78,32 @@ public final class Forge12PlaybackBridge implements PlaybackBridge {
         server.addScheduledTask(() -> {
             EntityPlayerMP sp = server.getPlayerList().getPlayerByUUID(uuid);
             if (sp == null) return;
-            sp.connection.setPlayerLocation(pos.x, pos.y, pos.z, yaw, sp.rotationPitch);
+            sp.setPositionAndRotation(pos.x, pos.y, pos.z, yaw, sp.rotationPitch);
             sp.motionX = vel.x;
             sp.motionY = vel.y;
             sp.motionZ = vel.z;
-            sp.velocityChanged = true;
+            if (carry != null) {
+                de.legoshi.parkourcalc.forge12.sim.SimulatorEntity.applyCheckpoint(sp, carry);
+            } else {
+                sp.setSprinting(false);
+                sp.setSneaking(false);
+                sp.onGround = true;
+            }
+            sp.velocityChanged = false;
+            NetHandlerPlayServer conn = sp.connection;
+            ObfuscationReflectionHelper.setPrivateValue(NetHandlerPlayServer.class, conn, pos.x, SERVER_LAST_GOOD_X);
+            ObfuscationReflectionHelper.setPrivateValue(NetHandlerPlayServer.class, conn, pos.y, SERVER_LAST_GOOD_Y);
+            ObfuscationReflectionHelper.setPrivateValue(NetHandlerPlayServer.class, conn, pos.z, SERVER_LAST_GOOD_Z);
         });
         client.setPositionAndRotation(pos.x, pos.y, pos.z, yaw, client.rotationPitch);
         client.motionX = vel.x;
         client.motionY = vel.y;
         client.motionZ = vel.z;
-        client.onGround = true;
+        if (carry != null) {
+            de.legoshi.parkourcalc.forge12.sim.SimulatorEntity.applyCheckpoint(client, carry);
+        } else {
+            client.onGround = true;
+        }
         client.fallDistance = 0.0F;
         // Suppress onUpdateWalkingPlayer's position packet until the server's scheduled
         // setPlayerLocation arms targetPos, otherwise the client races and trips moved-wrongly.
@@ -154,6 +174,20 @@ public final class Forge12PlaybackBridge implements PlaybackBridge {
                 sp.addPotionEffect(new PotionEffect(MobEffects.JUMP_BOOST, EFFECT_DURATION_TICKS, jumpBoostAmplifier - 1, false, false));
             }
         });
+        applyClientEffects(client, speedAmplifier, jumpBoostAmplifier);
+    }
+
+    private static void applyClientEffects(EntityPlayerSP client, int speedAmplifier, int jumpBoostAmplifier) {
+        client.removePotionEffect(MobEffects.SPEED);
+        client.removePotionEffect(MobEffects.JUMP_BOOST);
+        MobEffects.SPEED.removeAttributesModifiersFromEntity(client, client.getAttributeMap(), 0);
+        if (speedAmplifier > 0) {
+            client.addPotionEffect(new PotionEffect(MobEffects.SPEED, EFFECT_DURATION_TICKS, speedAmplifier - 1, false, false));
+            MobEffects.SPEED.applyAttributesModifiersToEntity(client, client.getAttributeMap(), speedAmplifier - 1);
+        }
+        if (jumpBoostAmplifier > 0) {
+            client.addPotionEffect(new PotionEffect(MobEffects.JUMP_BOOST, EFFECT_DURATION_TICKS, jumpBoostAmplifier - 1, false, false));
+        }
     }
 
     @Override

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/sim/SimulatorEntity.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/sim/SimulatorEntity.java
@@ -244,6 +244,7 @@ public class SimulatorEntity extends EntityPlayer {
         c.sneaking = this.isSneaking();
         c.sprintState = this.sprintState;
         c.jumpMovementFactor = this.jumpMovementFactor;
+        c.landMovementFactor = this.getAIMoveSpeed();
         c.jumpTicks = ObfuscationReflectionHelper.<Integer, EntityLivingBase>getPrivateValue(EntityLivingBase.class, this, JUMP_TICKS_NAMES);
         return c;
     }
@@ -262,8 +263,21 @@ public class SimulatorEntity extends EntityPlayer {
         this.setSneaking(c.sneaking);
         this.sprintState = c.sprintState;
         this.jumpMovementFactor = c.jumpMovementFactor;
+        this.setAIMoveSpeed(c.landMovementFactor);
         ObfuscationReflectionHelper.setPrivateValue(EntityLivingBase.class, this, c.jumpTicks, JUMP_TICKS_NAMES);
         this.setPosition(c.posX, c.posY, c.posZ);
+    }
+
+    public static void applyCheckpoint(EntityLivingBase p, de.legoshi.parkourcalc.core.sim.Checkpoint state) {
+        if (!(state instanceof Checkpoint)) return;
+        Checkpoint c = (Checkpoint) state;
+        p.onGround = c.onGround;
+        p.collidedHorizontally = c.collidedHorizontally;
+        p.setSprinting(c.sprinting);
+        p.setSneaking(c.sneaking);
+        p.setAIMoveSpeed(c.landMovementFactor);
+        p.jumpMovementFactor = c.jumpMovementFactor;
+        ObfuscationReflectionHelper.setPrivateValue(EntityLivingBase.class, p, c.jumpTicks, JUMP_TICKS_NAMES);
     }
 
     public static final class Checkpoint implements de.legoshi.parkourcalc.core.sim.Checkpoint {
@@ -275,6 +289,7 @@ public class SimulatorEntity extends EntityPlayer {
         boolean sprinting, sneaking;
         PlayerSprintMachine.State sprintState;
         float jumpMovementFactor;
+        float landMovementFactor;
         int jumpTicks;
     }
 }

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8PlaybackBridge.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8PlaybackBridge.java
@@ -8,7 +8,6 @@ import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.client.settings.GameSettings;
 import net.minecraft.client.settings.KeyBinding;
 import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraft.network.NetHandlerPlayServer;
 import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.server.integrated.IntegratedServer;
@@ -31,10 +30,6 @@ public final class Forge8PlaybackBridge implements PlaybackBridge {
     private static final String[] LAST_REPORTED_YAW = { "lastReportedYaw", "field_175164_bL" };
     private static final String[] LAST_REPORTED_PITCH = { "lastReportedPitch", "field_175165_bM" };
     private static final String[] POSITION_UPDATE_TICKS = { "positionUpdateTicks", "field_175168_bP" };
-
-    private static final String[] SERVER_LAST_POS_X = { "lastPosX", "field_147373_o" };
-    private static final String[] SERVER_LAST_POS_Y = { "lastPosY", "field_147382_p" };
-    private static final String[] SERVER_LAST_POS_Z = { "lastPosZ", "field_147381_q" };
 
     private static final int EFFECT_DURATION_TICKS = 20000;
 
@@ -91,10 +86,6 @@ public final class Forge8PlaybackBridge implements PlaybackBridge {
                 sp.onGround = true;
             }
             sp.velocityChanged = false;
-            NetHandlerPlayServer conn = sp.playerNetServerHandler;
-            ObfuscationReflectionHelper.setPrivateValue(NetHandlerPlayServer.class, conn, pos.x, SERVER_LAST_POS_X);
-            ObfuscationReflectionHelper.setPrivateValue(NetHandlerPlayServer.class, conn, pos.y, SERVER_LAST_POS_Y);
-            ObfuscationReflectionHelper.setPrivateValue(NetHandlerPlayServer.class, conn, pos.z, SERVER_LAST_POS_Z);
         });
         client.setPositionAndRotation(pos.x, pos.y, pos.z, yaw, client.rotationPitch);
         client.renderYawOffset = yaw;

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8PlaybackBridge.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8PlaybackBridge.java
@@ -8,6 +8,7 @@ import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.client.settings.GameSettings;
 import net.minecraft.client.settings.KeyBinding;
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.network.NetHandlerPlayServer;
 import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.server.integrated.IntegratedServer;
@@ -30,6 +31,10 @@ public final class Forge8PlaybackBridge implements PlaybackBridge {
     private static final String[] LAST_REPORTED_YAW = { "lastReportedYaw", "field_175164_bL" };
     private static final String[] LAST_REPORTED_PITCH = { "lastReportedPitch", "field_175165_bM" };
     private static final String[] POSITION_UPDATE_TICKS = { "positionUpdateTicks", "field_175168_bP" };
+
+    private static final String[] SERVER_LAST_POS_X = { "lastPosX", "field_147373_o" };
+    private static final String[] SERVER_LAST_POS_Y = { "lastPosY", "field_147382_p" };
+    private static final String[] SERVER_LAST_POS_Z = { "lastPosZ", "field_147381_q" };
 
     private static final int EFFECT_DURATION_TICKS = 20000;
 
@@ -64,7 +69,7 @@ public final class Forge8PlaybackBridge implements PlaybackBridge {
     }
 
     @Override
-    public void teleport(Vec3dCore pos, Vec3dCore vel, float yaw) {
+    public void teleport(Vec3dCore pos, Vec3dCore vel, float yaw, de.legoshi.parkourcalc.core.sim.Checkpoint carry) {
         Minecraft mc = Minecraft.getMinecraft();
         EntityPlayerSP client = mc.thePlayer;
         if (client == null) return;
@@ -74,17 +79,32 @@ public final class Forge8PlaybackBridge implements PlaybackBridge {
         server.addScheduledTask(() -> {
             EntityPlayerMP sp = server.getConfigurationManager().getPlayerByUUID(uuid);
             if (sp == null) return;
-            sp.playerNetServerHandler.setPlayerLocation(pos.x, pos.y, pos.z, yaw, sp.rotationPitch);
+            sp.setPositionAndRotation(pos.x, pos.y, pos.z, yaw, sp.rotationPitch);
             sp.motionX = vel.x;
             sp.motionY = vel.y;
             sp.motionZ = vel.z;
-            sp.velocityChanged = true;
+            if (carry != null) {
+                de.legoshi.parkourcalc.forge8.sim.SimulatorEntity.applyCheckpoint(sp, carry);
+            } else {
+                sp.setSprinting(false);
+                sp.setSneaking(false);
+                sp.onGround = true;
+            }
+            sp.velocityChanged = false;
+            NetHandlerPlayServer conn = sp.playerNetServerHandler;
+            ObfuscationReflectionHelper.setPrivateValue(NetHandlerPlayServer.class, conn, pos.x, SERVER_LAST_POS_X);
+            ObfuscationReflectionHelper.setPrivateValue(NetHandlerPlayServer.class, conn, pos.y, SERVER_LAST_POS_Y);
+            ObfuscationReflectionHelper.setPrivateValue(NetHandlerPlayServer.class, conn, pos.z, SERVER_LAST_POS_Z);
         });
         client.setPositionAndRotation(pos.x, pos.y, pos.z, yaw, client.rotationPitch);
         client.motionX = vel.x;
         client.motionY = vel.y;
         client.motionZ = vel.z;
-        client.onGround = true;
+        if (carry != null) {
+            de.legoshi.parkourcalc.forge8.sim.SimulatorEntity.applyCheckpoint(client, carry);
+        } else {
+            client.onGround = true;
+        }
         client.fallDistance = 0.0F;
         // Suppress onUpdateWalkingPlayer's position packet until the server's scheduled
         // setPlayerLocation arms targetPos, otherwise the client races and trips moved-wrongly.
@@ -153,6 +173,20 @@ public final class Forge8PlaybackBridge implements PlaybackBridge {
                 sp.addPotionEffect(new PotionEffect(Potion.jump.id, EFFECT_DURATION_TICKS, jumpBoostAmplifier - 1, false, false));
             }
         });
+        applyClientEffects(client, speedAmplifier, jumpBoostAmplifier);
+    }
+
+    private static void applyClientEffects(EntityPlayerSP client, int speedAmplifier, int jumpBoostAmplifier) {
+        client.removePotionEffect(Potion.moveSpeed.id);
+        client.removePotionEffect(Potion.jump.id);
+        Potion.moveSpeed.removeAttributesModifiersFromEntity(client, client.getAttributeMap(), 0);
+        if (speedAmplifier > 0) {
+            client.addPotionEffect(new PotionEffect(Potion.moveSpeed.id, EFFECT_DURATION_TICKS, speedAmplifier - 1, false, false));
+            Potion.moveSpeed.applyAttributesModifiersToEntity(client, client.getAttributeMap(), speedAmplifier - 1);
+        }
+        if (jumpBoostAmplifier > 0) {
+            client.addPotionEffect(new PotionEffect(Potion.jump.id, EFFECT_DURATION_TICKS, jumpBoostAmplifier - 1, false, false));
+        }
     }
 
     @Override

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/sim/SimulatorEntity.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/sim/SimulatorEntity.java
@@ -239,6 +239,7 @@ public class SimulatorEntity extends EntityPlayer {
         c.sneaking = this.isSneaking();
         c.sprintState = this.sprintState;
         c.jumpMovementFactor = this.jumpMovementFactor;
+        c.landMovementFactor = this.getAIMoveSpeed();
         c.jumpTicks = ObfuscationReflectionHelper.<Integer, EntityLivingBase>getPrivateValue(EntityLivingBase.class, this, JUMP_TICKS_NAMES);
         return c;
     }
@@ -257,8 +258,21 @@ public class SimulatorEntity extends EntityPlayer {
         this.setSneaking(c.sneaking);
         this.sprintState = c.sprintState;
         this.jumpMovementFactor = c.jumpMovementFactor;
+        this.setAIMoveSpeed(c.landMovementFactor);
         ObfuscationReflectionHelper.setPrivateValue(EntityLivingBase.class, this, c.jumpTicks, JUMP_TICKS_NAMES);
         this.setPosition(c.posX, c.posY, c.posZ);
+    }
+
+    public static void applyCheckpoint(EntityLivingBase p, de.legoshi.parkourcalc.core.sim.Checkpoint state) {
+        if (!(state instanceof Checkpoint)) return;
+        Checkpoint c = (Checkpoint) state;
+        p.onGround = c.onGround;
+        p.isCollidedHorizontally = c.isCollidedHorizontally;
+        p.setSprinting(c.sprinting);
+        p.setSneaking(c.sneaking);
+        p.setAIMoveSpeed(c.landMovementFactor);
+        p.jumpMovementFactor = c.jumpMovementFactor;
+        ObfuscationReflectionHelper.setPrivateValue(EntityLivingBase.class, p, c.jumpTicks, JUMP_TICKS_NAMES);
     }
 
     public static final class Checkpoint implements de.legoshi.parkourcalc.core.sim.Checkpoint {
@@ -270,6 +284,7 @@ public class SimulatorEntity extends EntityPlayer {
         boolean sprinting, sneaking;
         PlayerSprintMachine.State sprintState;
         float jumpMovementFactor;
+        float landMovementFactor;
         int jumpTicks;
     }
 }


### PR DESCRIPTION
Playback can start from the selected tick / range. Adds `PlaybackController.start(startIndex, stopExclusive, pos, vel, yaw)` plus a `Supplier<StartRange>` resolver; the no-arg `start()` preserves the old from-the-top behavior (incl. 2-tick warmup). A mid-TAS start sets `warmupRemaining = 0`. `Application` maps editor selection to a range (single = play to end; multi = `min..max+1`) and teleports to `path[first]`. Title bar shows "Replaying ticks N-M". No loader changes.

Files: `PlaybackController.java`, `Application.java`, `ui/InputOverlay.java`, `ui/MainWindowOverlay.java`, `+PlaybackRangeTest`.

Closes #129

Build: `:core:check` green (+test). Scope: core-only.
Merge: directly (core). Note: high overlap with #105 (`PlaybackController.start/tick`) and #100/#101 (`InputOverlay`); recommended after #105 in the playback cluster. A quick in-game replay-from-tick is worth doing.
