### PR TITLE
feat: move a tick to target coordinates by shifting the start (#132)

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
@@ -23,6 +23,7 @@ import de.legoshi.parkourcalc.core.ui.PerfOverlay;
 import de.legoshi.parkourcalc.core.ui.SelectionManager;
 import de.legoshi.parkourcalc.core.ui.Settings;
 import de.legoshi.parkourcalc.core.ui.SettingsIO;
+import de.legoshi.parkourcalc.core.ui.StartDragController;
 import de.legoshi.parkourcalc.core.ui.SettingsModal;
 import de.legoshi.parkourcalc.core.ui.TickInfoPanel;
 import de.legoshi.parkourcalc.core.ui.YawGizmoController;
@@ -50,6 +51,7 @@ public final class Application {
     private final SelectionManager selection;
     private final SimulationRunner runner;
     private final BoxDragController dragController;
+    private final StartDragController startDragController;
     private final BoxSelectController selectController;
     private final YawGizmoController yawGizmo;
     private final SaveController saveController;
@@ -67,15 +69,17 @@ public final class Application {
         this.mc = mc;
         this.selection = new SelectionManager(mc);
         this.runner = new SimulationRunner(simulator);
+        this.saveController = new SaveController(inputData, runner, mc, this::runSimulation);
+        this.startDragController = new StartDragController(runner, boxController, selection,
+                saveController::markDirty, this::runSimulation, SimulationRunner.DEFAULT_MOVE_TICK_TOLERANCE);
         // Start box is the disabled "Start" anchor: draggable to reposition, but not tap-selectable.
-        this.dragController = new BoxDragController(boxController, this::handleStartPositionChange, null);
+        this.dragController = new BoxDragController(boxController, startDragController, null);
         this.selectController = new BoxSelectController(boxController, this::commitWorldTap);
         this.yawGizmo = new YawGizmoController(
                 boxController,
                 this::handleStartYawChange,
                 this::handleTickYawChange
         );
-        this.saveController = new SaveController(inputData, runner, mc, this::runSimulation);
         this.playback = new PlaybackController(inputData, runner, settings);
         this.playback.setStartRangeResolver(this::resolvePlaybackStartRange);
     }
@@ -116,7 +120,7 @@ public final class Application {
         saveController.setSolverEngine(angleSolverEngine);
         AngleSolverWindow angleSolverWindow = new AngleSolverWindow(angleSolverState, settings, inputData::size, angleSolverEngine);
 
-        TickInfoPanel tickInfoPanel = new TickInfoPanel(boxController, selection, settings, this::moveTickTo);
+        TickInfoPanel tickInfoPanel = new TickInfoPanel(boxController, selection, settings);
         PerfOverlay perfOverlay = new PerfOverlay();
         FileMenu fileMenu = new FileMenu(saveController, filePicker, settings, this::saveSettings);
         SettingsModal settingsModal = new SettingsModal(settings, this::saveSettings);
@@ -178,7 +182,9 @@ public final class Application {
         for (TickState s : path) {
             boxController.add(s);
         }
-        selection.retainBelow(boxController.size());
+        if (!startDragController.isDragActive()) {
+            selection.retainBelow(boxController.size());
+        }
         Perf.stop("runSimulation", t0);
     }
 
@@ -203,29 +209,6 @@ public final class Application {
         if (boxIndex >= boxController.size()) return;
         selection.handleClick(boxIndex);
         selection.requestScrollIntoView();
-    }
-
-    private void handleStartPositionChange(Vec3dCore pos) {
-        runner.setStartPosition(pos);
-        onUserChange(-1);
-    }
-
-    private SimulationRunner.MoveTickResult moveTickTo(int tickIndex, Vec3dCore target) {
-        if (!mc.isReady()) {
-            return SimulationRunner.MoveTickResult.invalid();
-        }
-        SimulationRunner.MoveTickResult result = mc.runOnServerThread(
-                () -> runner.tryMoveTick(tickIndex, target, SimulationRunner.DEFAULT_MOVE_TICK_TOLERANCE, inputData)
-        );
-        boxController.clearAll();
-        for (TickState s : runner.getPath()) {
-            boxController.add(s);
-        }
-        selection.retainBelow(boxController.size());
-        if (result.applied()) {
-            saveController.markDirty();
-        }
-        return result;
     }
 
     private void handleStartYawChange(float yaw) {
@@ -269,7 +252,8 @@ public final class Application {
                 mc.isMousePressedLeft(),
                 mc.getCursorScreenX(),
                 mc.getCursorScreenY(),
-                isControlPanelOpen()
+                isControlPanelOpen(),
+                mc.isShiftDown()
         );
         selectController.tick(
                 mc.getEyePosition(),

--- a/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
@@ -116,7 +116,7 @@ public final class Application {
         saveController.setSolverEngine(angleSolverEngine);
         AngleSolverWindow angleSolverWindow = new AngleSolverWindow(angleSolverState, settings, inputData::size, angleSolverEngine);
 
-        TickInfoPanel tickInfoPanel = new TickInfoPanel(boxController, selection, settings);
+        TickInfoPanel tickInfoPanel = new TickInfoPanel(boxController, selection, settings, this::moveTickTo);
         PerfOverlay perfOverlay = new PerfOverlay();
         FileMenu fileMenu = new FileMenu(saveController, filePicker, settings, this::saveSettings);
         SettingsModal settingsModal = new SettingsModal(settings, this::saveSettings);
@@ -208,6 +208,24 @@ public final class Application {
     private void handleStartPositionChange(Vec3dCore pos) {
         runner.setStartPosition(pos);
         onUserChange(-1);
+    }
+
+    private SimulationRunner.MoveTickResult moveTickTo(int tickIndex, Vec3dCore target) {
+        if (!mc.isReady()) {
+            return SimulationRunner.MoveTickResult.invalid();
+        }
+        SimulationRunner.MoveTickResult result = mc.runOnServerThread(
+                () -> runner.tryMoveTick(tickIndex, target, SimulationRunner.DEFAULT_MOVE_TICK_TOLERANCE, inputData)
+        );
+        boxController.clearAll();
+        for (TickState s : runner.getPath()) {
+            boxController.add(s);
+        }
+        selection.retainBelow(boxController.size());
+        if (result.applied()) {
+            saveController.markDirty();
+        }
+        return result;
     }
 
     private void handleStartYawChange(float yaw) {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/sim/SimulationRunner.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/sim/SimulationRunner.java
@@ -17,8 +17,71 @@ public final class SimulationRunner {
     private final List<TickState> path = new ArrayList<>();
     private final List<Checkpoint> checkpoints = new ArrayList<>();
 
+    public static final double DEFAULT_MOVE_TICK_TOLERANCE = 1.0e-6;
+
     public SimulationRunner(Simulator simulator) {
         this.simulator = simulator;
+    }
+
+    public enum MoveTickStatus {
+        APPLIED,
+        TICK_LOST,
+        COLLISION_CHANGED_PATH,
+        INVALID_INDEX
+    }
+
+    public static final class MoveTickResult {
+        public final MoveTickStatus status;
+        public final Vec3dCore offset;
+        public final Vec3dCore landedAt;
+
+        MoveTickResult(MoveTickStatus status, Vec3dCore offset, Vec3dCore landedAt) {
+            this.status = status;
+            this.offset = offset;
+            this.landedAt = landedAt;
+        }
+
+        public static MoveTickResult invalid() {
+            return new MoveTickResult(MoveTickStatus.INVALID_INDEX, null, null);
+        }
+
+        public boolean applied() {
+            return status == MoveTickStatus.APPLIED;
+        }
+    }
+
+    public MoveTickResult tryMoveTick(int tickIndex, Vec3dCore target, double tolerance, InputData inputData) {
+        if (tickIndex < 0 || tickIndex >= path.size()) {
+            return new MoveTickResult(MoveTickStatus.INVALID_INDEX, null, null);
+        }
+
+        Vec3dCore current = path.get(tickIndex).position;
+        Vec3dCore offset = target.sub(current);
+        Vec3dCore originalStart = simulator.getStartPosition();
+
+        simulator.setStartPosition(originalStart.add(offset));
+        List<TickState> shifted = simulate(inputData);
+
+        if (tickIndex >= shifted.size()) {
+            simulator.setStartPosition(originalStart);
+            simulate(inputData);
+            return new MoveTickResult(MoveTickStatus.TICK_LOST, offset, null);
+        }
+
+        Vec3dCore landed = shifted.get(tickIndex).position;
+        if (!within(landed, target, tolerance)) {
+            simulator.setStartPosition(originalStart);
+            simulate(inputData);
+            return new MoveTickResult(MoveTickStatus.COLLISION_CHANGED_PATH, offset, landed);
+        }
+
+        return new MoveTickResult(MoveTickStatus.APPLIED, offset, landed);
+    }
+
+    private static boolean within(Vec3dCore a, Vec3dCore b, double tol) {
+        return Math.abs(a.x - b.x) <= tol
+                && Math.abs(a.y - b.y) <= tol
+                && Math.abs(a.z - b.z) <= tol;
     }
 
     public List<TickState> simulate(InputData inputData) {
@@ -87,6 +150,10 @@ public final class SimulationRunner {
     public Checkpoint getCheckpoint(int index) {
         if (index < 0 || index >= checkpoints.size()) return null;
         return checkpoints.get(index);
+    }
+
+    public List<TickState> getPath() {
+        return java.util.Collections.unmodifiableList(path);
     }
 
     /** Drop the cached entity and any state captured against the old world. */

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/BoxDragController.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/BoxDragController.java
@@ -3,8 +3,6 @@ package de.legoshi.parkourcalc.core.ui;
 import de.legoshi.parkourcalc.core.sim.AABB;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 
-import java.util.function.Consumer;
-
 /**
  * Loader-agnostic drag state machine for BoxController.getFirst(). Each loader
  * feeds per-frame (rayOrigin, rayDirection, mousePressed, uiFocused) and hands
@@ -14,11 +12,19 @@ import java.util.function.Consumer;
  */
 public final class BoxDragController {
 
+    public interface StartDragHandler {
+        void onBegin(boolean rigid);
+
+        void onMove(Vec3dCore position, boolean rigid);
+
+        void onEnd(boolean rigid);
+    }
+
     private static final double PICK_REACH = 128.0;
     private static final double EPS = 1.0e-3;
 
     private final BoxController boxController;
-    private final Consumer<Vec3dCore> onPositionChange;
+    private final StartDragHandler handler;
     private final Runnable onStartBoxTap;
 
     private boolean wasMousePressed = false;
@@ -28,14 +34,15 @@ public final class BoxDragController {
     private boolean engaged = false;
     private DragState dragState = null;
 
-    public BoxDragController(BoxController boxController, Consumer<Vec3dCore> onPositionChange, Runnable onStartBoxTap) {
+    public BoxDragController(BoxController boxController, StartDragHandler handler, Runnable onStartBoxTap) {
         this.boxController = boxController;
-        this.onPositionChange = onPositionChange;
+        this.handler = handler;
         this.onStartBoxTap = onStartBoxTap;
     }
 
-    public void tick(Vec3dCore rayOrigin, Vec3dCore rayDirection, boolean mousePressed, double cursorScreenX, double cursorScreenY, boolean uiFocused) {
+    public void tick(Vec3dCore rayOrigin, Vec3dCore rayDirection, boolean mousePressed, double cursorScreenX, double cursorScreenY, boolean uiFocused, boolean shiftHeld) {
         if (uiFocused) {
+            endIfDragging();
             resetState();
             wasMousePressed = false;
             return;
@@ -52,7 +59,7 @@ public final class BoxDragController {
         if (mousePressed && pressedOverStartBox) {
             if (!engaged && TapThreshold.exceeded(pressScreenX, pressScreenY, cursorScreenX, cursorScreenY)) {
                 engaged = true;
-                tryStartDrag(rayOrigin, rayDirection);
+                tryStartDrag(rayOrigin, rayDirection, shiftHeld);
             }
             if (engaged && dragState != null) {
                 updateDrag(rayOrigin, rayDirection);
@@ -63,10 +70,17 @@ public final class BoxDragController {
             if (pressedOverStartBox && !engaged && onStartBoxTap != null) {
                 onStartBoxTap.run();
             }
+            endIfDragging();
             resetState();
         }
 
         wasMousePressed = mousePressed;
+    }
+
+    private void endIfDragging() {
+        if (engaged && dragState != null) {
+            handler.onEnd(dragState.rigid);
+        }
     }
 
     private void resetState() {
@@ -86,7 +100,7 @@ public final class BoxDragController {
         return rayHitsAabb(rayOrigin, rayDirection, expand(first));
     }
 
-    private void tryStartDrag(Vec3dCore origin, Vec3dCore direction) {
+    private void tryStartDrag(Vec3dCore origin, Vec3dCore direction, boolean rigid) {
         AABB first = boxController.getFirst();
         if (first == null) return;
         if (!rayHitsAabb(origin, direction, expand(first))) return;
@@ -94,12 +108,16 @@ public final class BoxDragController {
         Vec3dCore cursorOnPlane = projectCursorToPlane(origin, direction, first.min.y);
         if (cursorOnPlane == null) return;
 
+        double centerX = (first.min.x + first.max.x) * 0.5;
+        double centerZ = (first.min.z + first.max.z) * 0.5;
         dragState = new DragState(
                 first.min.y,
-                first.min.x, first.min.z,
+                centerX, centerZ,
                 cursorOnPlane.x, cursorOnPlane.z,
-                new Vec3dCore(first.min.x, first.min.y, first.min.z)
+                new Vec3dCore(centerX, first.min.y, centerZ),
+                rigid
         );
+        handler.onBegin(rigid);
     }
 
     private void updateDrag(Vec3dCore origin, Vec3dCore direction) {
@@ -115,7 +133,7 @@ public final class BoxDragController {
                 dragState.startBoxZ + dz
         );
         if (newPos.equals(dragState.lastEmittedPos)) return;
-        onPositionChange.accept(newPos);
+        handler.onMove(newPos, dragState.rigid);
         dragState.lastEmittedPos = newPos;
     }
 
@@ -172,14 +190,16 @@ public final class BoxDragController {
         final double startBoxZ;
         final double startCursorX;
         final double startCursorZ;
+        final boolean rigid;
         Vec3dCore lastEmittedPos;
 
-        DragState(double planeY, double startBoxX, double startBoxZ, double startCursorX, double startCursorZ, Vec3dCore initialBoxPos) {
+        DragState(double planeY, double startBoxX, double startBoxZ, double startCursorX, double startCursorZ, Vec3dCore initialBoxPos, boolean rigid) {
             this.planeY = planeY;
             this.startBoxX = startBoxX;
             this.startBoxZ = startBoxZ;
             this.startCursorX = startCursorX;
             this.startCursorZ = startCursorZ;
+            this.rigid = rigid;
             this.lastEmittedPos = initialBoxPos;
         }
     }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/StartDragController.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/StartDragController.java
@@ -1,0 +1,76 @@
+package de.legoshi.parkourcalc.core.ui;
+
+import de.legoshi.parkourcalc.core.sim.SimulationRunner;
+import de.legoshi.parkourcalc.core.sim.Vec3dCore;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.IntConsumer;
+
+public final class StartDragController implements BoxDragController.StartDragHandler {
+
+    private final StartDragGate gate;
+    private final StartDragGate.SimProbe probe;
+    private final SimulationRunner runner;
+    private final BoxController boxController;
+    private final SelectionManager selection;
+    private final Runnable markDirty;
+
+    public StartDragController(SimulationRunner runner, BoxController boxController, SelectionManager selection,
+                               Runnable markDirty, IntConsumer reSimulate, double tolerance) {
+        this.runner = runner;
+        this.boxController = boxController;
+        this.selection = selection;
+        this.markDirty = markDirty;
+        this.probe = new StartDragGate.SimProbe() {
+            @Override
+            public void simulateAt(Vec3dCore start) {
+                runner.setStartPosition(start);
+                reSimulate.accept(-1);
+            }
+
+            @Override
+            public Vec3dCore tickPosition(int index) {
+                return boxController.getPosition(index);
+            }
+        };
+        this.gate = new StartDragGate(probe, tolerance);
+    }
+
+    public boolean isDragActive() {
+        return gate.isActive();
+    }
+
+    @Override
+    public void onBegin(boolean rigid) {
+        if (!rigid) return;
+        List<Integer> indices = new ArrayList<>();
+        List<Vec3dCore> positions = new ArrayList<>();
+        for (int idx : selection.getSelected()) {
+            Vec3dCore p = boxController.getPosition(idx);
+            if (p == null) continue;
+            indices.add(idx);
+            positions.add(p);
+        }
+        gate.begin(runner.getStartPosition(), indices, positions);
+    }
+
+    @Override
+    public void onMove(Vec3dCore position, boolean rigid) {
+        if (!rigid || !gate.isActive()) {
+            probe.simulateAt(position);
+            markDirty.run();
+            return;
+        }
+        gate.move(position);
+    }
+
+    @Override
+    public void onEnd(boolean rigid) {
+        if (!rigid || !gate.isActive()) return;
+        if (gate.end()) {
+            markDirty.run();
+        }
+        selection.retainBelow(boxController.size());
+    }
+}

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/StartDragGate.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/StartDragGate.java
@@ -1,0 +1,110 @@
+package de.legoshi.parkourcalc.core.ui;
+
+import de.legoshi.parkourcalc.core.sim.Vec3dCore;
+
+import java.util.List;
+
+public final class StartDragGate {
+
+    public interface SimProbe {
+        void simulateAt(Vec3dCore start);
+
+        Vec3dCore tickPosition(int index);
+    }
+
+    private static final int CLAMP_ITERATIONS = 24;
+
+    private final SimProbe probe;
+    private final double tolerance;
+
+    private boolean active;
+    private Vec3dCore baselineStart;
+    private Vec3dCore lastValidStart;
+    private List<Integer> indices;
+    private List<Vec3dCore> basePositions;
+
+    public StartDragGate(SimProbe probe, double tolerance) {
+        this.probe = probe;
+        this.tolerance = tolerance;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void begin(Vec3dCore baselineStart, List<Integer> selectedIndices, List<Vec3dCore> baselinePositions) {
+        this.baselineStart = baselineStart;
+        this.lastValidStart = baselineStart;
+        this.indices = selectedIndices;
+        this.basePositions = baselinePositions;
+        this.active = true;
+    }
+
+    public void move(Vec3dCore candidate) {
+        boolean valid = simAndCheck(candidate);
+        lastValidStart = valid ? candidate : clampToValid(baselineStart, candidate);
+    }
+
+    public boolean end() {
+        boolean moved = lastValidStart != null && !lastValidStart.equals(baselineStart);
+        reset();
+        return moved;
+    }
+
+    private void reset() {
+        active = false;
+        baselineStart = null;
+        lastValidStart = null;
+        indices = null;
+        basePositions = null;
+    }
+
+    private boolean simAndCheck(Vec3dCore start) {
+        probe.simulateAt(start);
+        return isRigid(start);
+    }
+
+    private boolean isRigid(Vec3dCore candidate) {
+        if (indices == null || indices.isEmpty()) return true;
+        double dx = candidate.x - baselineStart.x;
+        double dy = candidate.y - baselineStart.y;
+        double dz = candidate.z - baselineStart.z;
+        for (int k = 0; k < indices.size(); k++) {
+            Vec3dCore actual = probe.tickPosition(indices.get(k));
+            if (actual == null) return false;
+            Vec3dCore base = basePositions.get(k);
+            if (Math.abs(actual.x - (base.x + dx)) > tolerance) return false;
+            if (Math.abs(actual.y - (base.y + dy)) > tolerance) return false;
+            if (Math.abs(actual.z - (base.z + dz)) > tolerance) return false;
+        }
+        return true;
+    }
+
+    private Vec3dCore clampToValid(Vec3dCore from, Vec3dCore to) {
+        Vec3dCore afterX = clampAxis(from, new Vec3dCore(to.x, from.y, from.z));
+        Vec3dCore clamped = clampAxis(afterX, new Vec3dCore(afterX.x, afterX.y, to.z));
+        simAndCheck(clamped);
+        return clamped;
+    }
+
+    private Vec3dCore clampAxis(Vec3dCore from, Vec3dCore to) {
+        if (simAndCheck(to)) {
+            return to;
+        }
+        double lo = 0.0;
+        double hi = 1.0;
+        for (int i = 0; i < CLAMP_ITERATIONS; i++) {
+            double mid = (lo + hi) * 0.5;
+            if (simAndCheck(lerp(from, to, mid))) {
+                lo = mid;
+            } else {
+                hi = mid;
+            }
+        }
+        return lerp(from, to, lo);
+    }
+
+    private static Vec3dCore lerp(Vec3dCore a, Vec3dCore b, double t) {
+        return new Vec3dCore(a.x + (b.x - a.x) * t, a.y + (b.y - a.y) * t, a.z + (b.z - a.z) * t);
+    }
+}

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/TickInfoPanel.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/TickInfoPanel.java
@@ -1,19 +1,28 @@
 package de.legoshi.parkourcalc.core.ui;
 
 import de.legoshi.parkourcalc.core.imgui.RenderInterface;
+import de.legoshi.parkourcalc.core.sim.SimulationRunner;
 import de.legoshi.parkourcalc.core.sim.TickState;
+import de.legoshi.parkourcalc.core.sim.Vec3dCore;
+import de.legoshi.parkourcalc.core.ui.theme.Controls;
 import de.legoshi.parkourcalc.core.ui.theme.ThemeManager;
 import de.legoshi.parkourcalc.core.ui.util.TooltipUtil;
 import imgui.ImGui;
 import imgui.ImGuiIO;
+import imgui.flag.ImGuiInputTextFlags;
 import imgui.flag.ImGuiTableColumnFlags;
 import imgui.flag.ImGuiWindowFlags;
+import imgui.type.ImString;
 
 import java.util.List;
 import java.util.Locale;
 
 /** Read-only inspector for the single currently-selected tick. */
 public final class TickInfoPanel implements RenderInterface {
+
+    public interface MoveTickHandler {
+        SimulationRunner.MoveTickResult move(int tickIndex, Vec3dCore target);
+    }
 
     private static final String WINDOW_ID = "###tick-info";
     private static final String WINDOW_TITLE = "Tick Info";
@@ -27,9 +36,21 @@ public final class TickInfoPanel implements RenderInterface {
     private static final String COL_Y = "Y";
     private static final String COL_Z = "Z";
 
+    private static final String MOVE_SECTION = "Move tick";
+    private static final String MOVE_BUTTON = "Move tick here";
+    private static final String MOVE_TOOLTIP =
+            "Shifts the start position so this tick lands on the given coordinates. The whole path moves with "
+            + "it, so the move is kept only if collisions don't divert this tick away from the target.";
+    private static final String MSG_APPLIED = "Moved. Start shifted by (%s, %s, %s).";
+    private static final String MSG_COLLISION = "Tick no longer valid: a collision changed the path. Move reverted.";
+    private static final String MSG_TICK_LOST = "Tick no longer valid: it disappears after the move. Move reverted.";
+    private static final String MSG_BAD_INPUT = "Enter valid numbers for X, Y and Z.";
+    private static final String COORD_HINT = "0.0";
+
     private final BoxController boxController;
     private final SelectionManager selection;
     private final Settings settings;
+    private final MoveTickHandler moveTickHandler;
     private int rowCounter;
 
     private int fmtPrecision = -1;
@@ -37,10 +58,20 @@ public final class TickInfoPanel implements RenderInterface {
     private String fmtNumSingle;
     private String numSample;
 
-    public TickInfoPanel(BoxController boxController, SelectionManager selection, Settings settings) {
+    private final ImString moveX = new ImString(32);
+    private final ImString moveY = new ImString(32);
+    private final ImString moveZ = new ImString(32);
+    private int prefilledIndex = -1;
+    private double prefilledTickX, prefilledTickY, prefilledTickZ;
+    private int statusIndex = -1;
+    private String statusMessage;
+    private int statusColor;
+
+    public TickInfoPanel(BoxController boxController, SelectionManager selection, Settings settings, MoveTickHandler moveTickHandler) {
         this.boxController = boxController;
         this.selection = selection;
         this.settings = settings;
+        this.moveTickHandler = moveTickHandler;
     }
 
     private void rebuildFormats() {
@@ -83,7 +114,115 @@ public final class TickInfoPanel implements RenderInterface {
         float appliedYaw = idx + 1 < states.size() ? states.get(idx + 1).yaw : cur.yaw;
 
         renderTable(idx, cur, prev, prev2, appliedYaw);
+        renderMoveSection(idx, cur);
         ImGui.end();
+    }
+
+    private void renderMoveSection(int idx, TickState cur) {
+        if (moveTickHandler == null) return;
+
+        boolean tickChanged = idx != prefilledIndex;
+        boolean tickShifted = !tickChanged
+                && (cur.position.x != prefilledTickX || cur.position.y != prefilledTickY || cur.position.z != prefilledTickZ);
+        if (tickChanged || tickShifted) {
+            seedMoveInputs(idx, cur.position);
+            if (tickChanged) clearStatus();
+        }
+
+        ThemeManager.sectionSpacing();
+        ImGui.textDisabled(MOVE_SECTION);
+        TooltipUtil.onHover(MOVE_TOOLTIP);
+        ThemeManager.bottomPaddedSeparator();
+
+        float fieldW = ImGui.calcTextSize(numSample).x + 2f * ImGui.getStyle().getFramePadding().x;
+        int flags = ImGuiInputTextFlags.CharsDecimal | ImGuiInputTextFlags.AutoSelectAll | ImGuiInputTextFlags.EnterReturnsTrue;
+        boolean submit = false;
+        submit |= Controls.inputTextHint("X", COORD_HINT, moveX, fieldW, flags);
+        ImGui.sameLine();
+        submit |= Controls.inputTextHint("Y", COORD_HINT, moveY, fieldW, flags);
+        ImGui.sameLine();
+        submit |= Controls.inputTextHint("Z", COORD_HINT, moveZ, fieldW, flags);
+
+        ThemeManager.sectionSpacing();
+        if (Controls.primaryButton(MOVE_BUTTON)) submit = true;
+        TooltipUtil.onHover(MOVE_TOOLTIP);
+
+        if (submit) applyMove(idx);
+
+        if (statusMessage != null && statusIndex == idx) {
+            ThemeManager.sectionSpacing();
+            ThemeManager.pushTextColor(statusColor);
+            ImGui.pushTextWrapPos(0f);
+            ImGui.textWrapped(statusMessage);
+            ImGui.popTextWrapPos();
+            ThemeManager.popTextColor();
+        }
+    }
+
+    private void applyMove(int idx) {
+        Double x = parse(moveX);
+        Double y = parse(moveY);
+        Double z = parse(moveZ);
+        if (x == null || y == null || z == null) {
+            setStatus(idx, MSG_BAD_INPUT, ThemeManager.dangerColor());
+            return;
+        }
+        SimulationRunner.MoveTickResult result = moveTickHandler.move(idx, new Vec3dCore(x, y, z));
+        switch (result.status) {
+            case APPLIED:
+                setStatus(
+                        idx,
+                        String.format(
+                                Locale.US,
+                                MSG_APPLIED,
+                                String.format(Locale.US, fmtNumSingle, result.offset.x),
+                                String.format(Locale.US, fmtNumSingle, result.offset.y),
+                                String.format(Locale.US, fmtNumSingle, result.offset.z)
+                        ),
+                        ThemeManager.okColor()
+                );
+                break;
+            case COLLISION_CHANGED_PATH:
+                setStatus(idx, MSG_COLLISION, ThemeManager.dangerColor());
+                break;
+            case TICK_LOST:
+                setStatus(idx, MSG_TICK_LOST, ThemeManager.dangerColor());
+                break;
+            default:
+                setStatus(idx, MSG_TICK_LOST, ThemeManager.dangerColor());
+                break;
+        }
+    }
+
+    private void seedMoveInputs(int idx, Vec3dCore pos) {
+        prefilledIndex = idx;
+        prefilledTickX = pos.x;
+        prefilledTickY = pos.y;
+        prefilledTickZ = pos.z;
+        moveX.set(String.format(Locale.US, fmtNumSingle, pos.x));
+        moveY.set(String.format(Locale.US, fmtNumSingle, pos.y));
+        moveZ.set(String.format(Locale.US, fmtNumSingle, pos.z));
+    }
+
+    private static Double parse(ImString holder) {
+        String text = holder.get().trim();
+        if (text.isEmpty()) return null;
+        try {
+            return Double.parseDouble(text);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private void setStatus(int idx, String message, int color) {
+        statusIndex = idx;
+        statusMessage = message;
+        statusColor = color;
+    }
+
+    private void clearStatus() {
+        statusIndex = -1;
+        statusMessage = null;
     }
 
     private void renderTable(int idx, TickState cur, TickState prev, TickState prev2, float appliedYaw) {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/TickInfoPanel.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/TickInfoPanel.java
@@ -1,28 +1,19 @@
 package de.legoshi.parkourcalc.core.ui;
 
 import de.legoshi.parkourcalc.core.imgui.RenderInterface;
-import de.legoshi.parkourcalc.core.sim.SimulationRunner;
 import de.legoshi.parkourcalc.core.sim.TickState;
-import de.legoshi.parkourcalc.core.sim.Vec3dCore;
-import de.legoshi.parkourcalc.core.ui.theme.Controls;
 import de.legoshi.parkourcalc.core.ui.theme.ThemeManager;
 import de.legoshi.parkourcalc.core.ui.util.TooltipUtil;
 import imgui.ImGui;
 import imgui.ImGuiIO;
-import imgui.flag.ImGuiInputTextFlags;
 import imgui.flag.ImGuiTableColumnFlags;
 import imgui.flag.ImGuiWindowFlags;
-import imgui.type.ImString;
 
 import java.util.List;
 import java.util.Locale;
 
 /** Read-only inspector for the single currently-selected tick. */
 public final class TickInfoPanel implements RenderInterface {
-
-    public interface MoveTickHandler {
-        SimulationRunner.MoveTickResult move(int tickIndex, Vec3dCore target);
-    }
 
     private static final String WINDOW_ID = "###tick-info";
     private static final String WINDOW_TITLE = "Tick Info";
@@ -36,21 +27,9 @@ public final class TickInfoPanel implements RenderInterface {
     private static final String COL_Y = "Y";
     private static final String COL_Z = "Z";
 
-    private static final String MOVE_SECTION = "Move tick";
-    private static final String MOVE_BUTTON = "Move tick here";
-    private static final String MOVE_TOOLTIP =
-            "Shifts the start position so this tick lands on the given coordinates. The whole path moves with "
-            + "it, so the move is kept only if collisions don't divert this tick away from the target.";
-    private static final String MSG_APPLIED = "Moved. Start shifted by (%s, %s, %s).";
-    private static final String MSG_COLLISION = "Tick no longer valid: a collision changed the path. Move reverted.";
-    private static final String MSG_TICK_LOST = "Tick no longer valid: it disappears after the move. Move reverted.";
-    private static final String MSG_BAD_INPUT = "Enter valid numbers for X, Y and Z.";
-    private static final String COORD_HINT = "0.0";
-
     private final BoxController boxController;
     private final SelectionManager selection;
     private final Settings settings;
-    private final MoveTickHandler moveTickHandler;
     private int rowCounter;
 
     private int fmtPrecision = -1;
@@ -58,20 +37,10 @@ public final class TickInfoPanel implements RenderInterface {
     private String fmtNumSingle;
     private String numSample;
 
-    private final ImString moveX = new ImString(32);
-    private final ImString moveY = new ImString(32);
-    private final ImString moveZ = new ImString(32);
-    private int prefilledIndex = -1;
-    private double prefilledTickX, prefilledTickY, prefilledTickZ;
-    private int statusIndex = -1;
-    private String statusMessage;
-    private int statusColor;
-
-    public TickInfoPanel(BoxController boxController, SelectionManager selection, Settings settings, MoveTickHandler moveTickHandler) {
+    public TickInfoPanel(BoxController boxController, SelectionManager selection, Settings settings) {
         this.boxController = boxController;
         this.selection = selection;
         this.settings = settings;
-        this.moveTickHandler = moveTickHandler;
     }
 
     private void rebuildFormats() {
@@ -114,115 +83,7 @@ public final class TickInfoPanel implements RenderInterface {
         float appliedYaw = idx + 1 < states.size() ? states.get(idx + 1).yaw : cur.yaw;
 
         renderTable(idx, cur, prev, prev2, appliedYaw);
-        renderMoveSection(idx, cur);
         ImGui.end();
-    }
-
-    private void renderMoveSection(int idx, TickState cur) {
-        if (moveTickHandler == null) return;
-
-        boolean tickChanged = idx != prefilledIndex;
-        boolean tickShifted = !tickChanged
-                && (cur.position.x != prefilledTickX || cur.position.y != prefilledTickY || cur.position.z != prefilledTickZ);
-        if (tickChanged || tickShifted) {
-            seedMoveInputs(idx, cur.position);
-            if (tickChanged) clearStatus();
-        }
-
-        ThemeManager.sectionSpacing();
-        ImGui.textDisabled(MOVE_SECTION);
-        TooltipUtil.onHover(MOVE_TOOLTIP);
-        ThemeManager.bottomPaddedSeparator();
-
-        float fieldW = ImGui.calcTextSize(numSample).x + 2f * ImGui.getStyle().getFramePadding().x;
-        int flags = ImGuiInputTextFlags.CharsDecimal | ImGuiInputTextFlags.AutoSelectAll | ImGuiInputTextFlags.EnterReturnsTrue;
-        boolean submit = false;
-        submit |= Controls.inputTextHint("X", COORD_HINT, moveX, fieldW, flags);
-        ImGui.sameLine();
-        submit |= Controls.inputTextHint("Y", COORD_HINT, moveY, fieldW, flags);
-        ImGui.sameLine();
-        submit |= Controls.inputTextHint("Z", COORD_HINT, moveZ, fieldW, flags);
-
-        ThemeManager.sectionSpacing();
-        if (Controls.primaryButton(MOVE_BUTTON)) submit = true;
-        TooltipUtil.onHover(MOVE_TOOLTIP);
-
-        if (submit) applyMove(idx);
-
-        if (statusMessage != null && statusIndex == idx) {
-            ThemeManager.sectionSpacing();
-            ThemeManager.pushTextColor(statusColor);
-            ImGui.pushTextWrapPos(0f);
-            ImGui.textWrapped(statusMessage);
-            ImGui.popTextWrapPos();
-            ThemeManager.popTextColor();
-        }
-    }
-
-    private void applyMove(int idx) {
-        Double x = parse(moveX);
-        Double y = parse(moveY);
-        Double z = parse(moveZ);
-        if (x == null || y == null || z == null) {
-            setStatus(idx, MSG_BAD_INPUT, ThemeManager.dangerColor());
-            return;
-        }
-        SimulationRunner.MoveTickResult result = moveTickHandler.move(idx, new Vec3dCore(x, y, z));
-        switch (result.status) {
-            case APPLIED:
-                setStatus(
-                        idx,
-                        String.format(
-                                Locale.US,
-                                MSG_APPLIED,
-                                String.format(Locale.US, fmtNumSingle, result.offset.x),
-                                String.format(Locale.US, fmtNumSingle, result.offset.y),
-                                String.format(Locale.US, fmtNumSingle, result.offset.z)
-                        ),
-                        ThemeManager.okColor()
-                );
-                break;
-            case COLLISION_CHANGED_PATH:
-                setStatus(idx, MSG_COLLISION, ThemeManager.dangerColor());
-                break;
-            case TICK_LOST:
-                setStatus(idx, MSG_TICK_LOST, ThemeManager.dangerColor());
-                break;
-            default:
-                setStatus(idx, MSG_TICK_LOST, ThemeManager.dangerColor());
-                break;
-        }
-    }
-
-    private void seedMoveInputs(int idx, Vec3dCore pos) {
-        prefilledIndex = idx;
-        prefilledTickX = pos.x;
-        prefilledTickY = pos.y;
-        prefilledTickZ = pos.z;
-        moveX.set(String.format(Locale.US, fmtNumSingle, pos.x));
-        moveY.set(String.format(Locale.US, fmtNumSingle, pos.y));
-        moveZ.set(String.format(Locale.US, fmtNumSingle, pos.z));
-    }
-
-    private static Double parse(ImString holder) {
-        String text = holder.get().trim();
-        if (text.isEmpty()) return null;
-        try {
-            return Double.parseDouble(text);
-        } catch (NumberFormatException e) {
-            return null;
-        }
-    }
-
-    private void setStatus(int idx, String message, int color) {
-        statusIndex = idx;
-        statusMessage = message;
-        statusColor = color;
-    }
-
-    private void clearStatus() {
-        statusIndex = -1;
-        statusMessage = null;
     }
 
     private void renderTable(int idx, TickState cur, TickState prev, TickState prev2, float appliedYaw) {

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/MoveTickTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/MoveTickTest.java
@@ -1,0 +1,153 @@
+package de.legoshi.parkourcalc.anglesolver;
+
+import de.legoshi.parkourcalc.core.ports.Simulator;
+import de.legoshi.parkourcalc.core.sim.Checkpoint;
+import de.legoshi.parkourcalc.core.sim.SimulationRunner;
+import de.legoshi.parkourcalc.core.sim.TickState;
+import de.legoshi.parkourcalc.core.sim.Vec3dCore;
+import de.legoshi.parkourcalc.core.ui.InputData;
+import de.legoshi.parkourcalc.core.ui.InputRow;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+public class MoveTickTest {
+
+    private static final double STEP = 0.2;
+    private static final double EPS = 1.0e-9;
+
+    private static final class KinematicSimulator implements Simulator {
+        private Vec3dCore start = Vec3dCore.ZERO;
+        private Vec3dCore startVel = Vec3dCore.ZERO;
+        private float startYaw;
+        private final double wallX;
+
+        private double x, y, z;
+
+        KinematicSimulator(double wallX) {
+            this.wallX = wallX;
+        }
+
+        private double clamp(double rawX) {
+            return rawX > wallX ? wallX : rawX;
+        }
+
+        @Override public void resetToStart() {
+            x = clamp(start.x);
+            y = start.y;
+            z = start.z;
+        }
+        @Override public void applyInput(InputRow row) { }
+        @Override public void tick() {
+            x = clamp(x + STEP);
+            z = z + STEP;
+        }
+        @Override public Vec3dCore getCurrentPosition() { return new Vec3dCore(x, y, z); }
+        @Override public boolean isCurrentOnGround() { return false; }
+        @Override public boolean isCurrentSneaking() { return false; }
+        @Override public boolean isCurrentSprinting() { return false; }
+        @Override public float getCurrentMoveForward() { return Float.NaN; }
+        @Override public float getCurrentMoveStrafe() { return Float.NaN; }
+        @Override public boolean isCurrentWallCollision() { return false; }
+        @Override public Vec3dCore getCurrentVelocity() { return Vec3dCore.ZERO; }
+        @Override public boolean isCurrentSoftCollision() { return false; }
+        @Override public double getCurrentCollisionAngleDegrees() { return Double.NaN; }
+        @Override public float getCurrentYaw() { return startYaw; }
+        @Override public List<Vec3dCore> getCurrentSubtickPath() { return Collections.emptyList(); }
+        @Override public Vec3dCore getStartPosition() { return start; }
+        @Override public void setStartPosition(Vec3dCore pos) { start = pos; }
+        @Override public Vec3dCore getStartVelocity() { return startVel; }
+        @Override public void setStartVelocity(Vec3dCore vel) { startVel = vel; }
+        @Override public float getStartYaw() { return startYaw; }
+        @Override public void setStartYaw(float yaw) { startYaw = yaw; }
+        @Override public Checkpoint saveCheckpoint() { return null; }
+        @Override public void restoreCheckpoint(Checkpoint checkpoint) { }
+        @Override public void invalidate() { }
+    }
+
+    private static InputData rows(int n) {
+        InputData data = new InputData();
+        for (int i = 0; i < n; i++) data.getRows().add(new InputRow());
+        return data;
+    }
+
+    private static Vec3dCore[] snapshot(List<TickState> path) {
+        Vec3dCore[] out = new Vec3dCore[path.size()];
+        for (int i = 0; i < out.length; i++) out[i] = path.get(i).position;
+        return out;
+    }
+
+    @Test
+    public void collisionFreeMoveShiftsStartExactlyAndLandsTickOnTarget() {
+        SimulationRunner runner = new SimulationRunner(new KinematicSimulator(Double.POSITIVE_INFINITY));
+        runner.setStartPosition(new Vec3dCore(0.2938, 0.0, 0.29923));
+        InputData data = rows(5);
+        Vec3dCore[] beforePath = snapshot(runner.simulate(data));
+
+        int tick = 3;
+        Vec3dCore before = beforePath[tick];
+        Vec3dCore target = new Vec3dCore(0.3, 0.0, 0.3);
+        Vec3dCore expectedOffset = target.sub(before);
+
+        SimulationRunner.MoveTickResult result =
+                runner.tryMoveTick(tick, target, SimulationRunner.DEFAULT_MOVE_TICK_TOLERANCE, data);
+
+        assertTrue("collision-free move must be applied", result.applied());
+        assertEquals(expectedOffset.x, result.offset.x, EPS);
+        assertEquals(expectedOffset.y, result.offset.y, EPS);
+        assertEquals(expectedOffset.z, result.offset.z, EPS);
+        assertEquals(0.2938 + expectedOffset.x, runner.getStartPosition().x, EPS);
+        assertEquals(0.29923 + expectedOffset.z, runner.getStartPosition().z, EPS);
+
+        List<TickState> moved = runner.getPath();
+        assertEquals(target.x, moved.get(tick).position.x, EPS);
+        assertEquals(target.z, moved.get(tick).position.z, EPS);
+        for (int i = 0; i < beforePath.length; i++) {
+            assertEquals(beforePath[i].x + expectedOffset.x, moved.get(i).position.x, EPS);
+            assertEquals(beforePath[i].z + expectedOffset.z, moved.get(i).position.z, EPS);
+        }
+    }
+
+    @Test
+    public void wallDivertedMoveRevertsAndReportsCollision() {
+        SimulationRunner runner = new SimulationRunner(new KinematicSimulator(0.5));
+        Vec3dCore start = new Vec3dCore(0.0, 0.0, 0.0);
+        runner.setStartPosition(start);
+        InputData data = rows(5);
+        Vec3dCore[] beforePath = snapshot(runner.simulate(data));
+
+        int tick = 4;
+        assertEquals(0.5, beforePath[tick].x, EPS);
+
+        Vec3dCore target = new Vec3dCore(0.9, 0.0, beforePath[tick].z);
+        SimulationRunner.MoveTickResult result =
+                runner.tryMoveTick(tick, target, SimulationRunner.DEFAULT_MOVE_TICK_TOLERANCE, data);
+
+        assertEquals(SimulationRunner.MoveTickStatus.COLLISION_CHANGED_PATH, result.status);
+        assertTrue("rejected move must not be applied", !result.applied());
+        assertEquals(start.x, runner.getStartPosition().x, EPS);
+        assertEquals(start.z, runner.getStartPosition().z, EPS);
+        assertEquals(beforePath[tick].x, runner.getPath().get(tick).position.x, EPS);
+        assertNotEquals(target.x, runner.getPath().get(tick).position.x, EPS);
+    }
+
+    @Test
+    public void outOfRangeIndexIsInvalidAndLeavesStartUntouched() {
+        SimulationRunner runner = new SimulationRunner(new KinematicSimulator(Double.POSITIVE_INFINITY));
+        Vec3dCore start = new Vec3dCore(1.0, 2.0, 3.0);
+        runner.setStartPosition(start);
+        InputData data = rows(2);
+        runner.simulate(data);
+
+        SimulationRunner.MoveTickResult result =
+                runner.tryMoveTick(99, new Vec3dCore(0, 0, 0), SimulationRunner.DEFAULT_MOVE_TICK_TOLERANCE, data);
+
+        assertEquals(SimulationRunner.MoveTickStatus.INVALID_INDEX, result.status);
+        assertEquals(start.x, runner.getStartPosition().x, EPS);
+    }
+}

--- a/core/src/test/java/de/legoshi/parkourcalc/ui/StartDragGateTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/ui/StartDragGateTest.java
@@ -1,0 +1,110 @@
+package de.legoshi.parkourcalc.ui;
+
+import de.legoshi.parkourcalc.core.sim.Vec3dCore;
+import de.legoshi.parkourcalc.core.ui.StartDragGate;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class StartDragGateTest {
+
+    private static final double INF = Double.POSITIVE_INFINITY;
+    private static final double TOL = 1.0e-9;
+    private static final double EPS = 1.0e-9;
+    private static final double CLAMP_EPS = 1.0e-4;
+
+    private static final class FakeProbe implements StartDragGate.SimProbe {
+        private final Vec3dCore offset;
+        private final double wallX;
+        private final double wallZ;
+        Vec3dCore start = Vec3dCore.ZERO;
+
+        FakeProbe(Vec3dCore offset, double wallX, double wallZ) {
+            this.offset = offset;
+            this.wallX = wallX;
+            this.wallZ = wallZ;
+        }
+
+        @Override public void simulateAt(Vec3dCore s) {
+            this.start = s;
+        }
+
+        @Override public Vec3dCore tickPosition(int index) {
+            double x = Math.min(start.x + offset.x, wallX);
+            double z = Math.min(start.z + offset.z, wallZ);
+            return new Vec3dCore(x, start.y + offset.y, z);
+        }
+    }
+
+    private static List<Integer> idx(int... values) {
+        List<Integer> list = new ArrayList<>();
+        for (int v : values) list.add(v);
+        return list;
+    }
+
+    private static List<Vec3dCore> baseline(FakeProbe probe, Vec3dCore start, int... indices) {
+        probe.simulateAt(start);
+        List<Vec3dCore> list = new ArrayList<>();
+        for (int i : indices) list.add(probe.tickPosition(i));
+        return list;
+    }
+
+    @Test
+    public void openSpaceCommitsCandidateOnBothAxes() {
+        FakeProbe probe = new FakeProbe(new Vec3dCore(1, 0, 1), INF, INF);
+        StartDragGate gate = new StartDragGate(probe, TOL);
+        Vec3dCore start = new Vec3dCore(0, 0, 0);
+        gate.begin(start, idx(0), baseline(probe, start, 0));
+
+        gate.move(new Vec3dCore(0.7, 0, 0.4));
+
+        assertEquals(0.7, probe.start.x, EPS);
+        assertEquals(0.4, probe.start.z, EPS);
+    }
+
+    @Test
+    public void clampMovesXFullyWhileZHitsWall() {
+        FakeProbe probe = new FakeProbe(new Vec3dCore(1, 0, 1), INF, 1.3);
+        StartDragGate gate = new StartDragGate(probe, TOL);
+        Vec3dCore start = new Vec3dCore(0, 0, 0);
+        gate.begin(start, idx(0), baseline(probe, start, 0));
+
+        gate.move(new Vec3dCore(0.5, 0, 0.5));
+
+        assertEquals("X moves fully despite the Z wall", 0.5, probe.start.x, EPS);
+        assertEquals("Z clamps at the wall boundary", 0.3, probe.start.z, CLAMP_EPS);
+    }
+
+    @Test
+    public void endReportsMovedWhenStartShifted() {
+        FakeProbe probe = new FakeProbe(new Vec3dCore(1, 0, 1), INF, INF);
+        StartDragGate gate = new StartDragGate(probe, TOL);
+        Vec3dCore start = new Vec3dCore(0, 0, 0);
+        gate.begin(start, idx(0), baseline(probe, start, 0));
+
+        gate.move(new Vec3dCore(0.5, 0, 0.5));
+        assertTrue(gate.end());
+
+        gate.begin(start, idx(0), baseline(probe, start, 0));
+        assertFalse("no move means not dirty", gate.end());
+    }
+
+    @Test
+    public void emptySelectionNeverConstrains() {
+        FakeProbe probe = new FakeProbe(new Vec3dCore(1, 0, 1), INF, 1.3);
+        StartDragGate gate = new StartDragGate(probe, TOL);
+        Vec3dCore start = new Vec3dCore(0, 0, 0);
+        gate.begin(start, Collections.<Integer>emptyList(), Collections.<Vec3dCore>emptyList());
+
+        gate.move(new Vec3dCore(0.5, 0, 5.0));
+
+        assertEquals(0.5, probe.start.x, EPS);
+        assertEquals("no selection means no constraint", 5.0, probe.start.z, EPS);
+    }
+}


### PR DESCRIPTION
`SimulationRunner.tryMoveTick(index, target, tol, inputData)`: offsets the start by `(target - tickPos)`, re-simulates, and keeps the result only if the selected tick still lands on target within `1e-6` (else reverts and re-sims the original). `Application.moveTickTo` runs it on the server thread, syncs the overlay, and marks dirty only on success. `TickInfoPanel` gains an inline "Move tick here" X/Y/Z editor + colored status line.

Files: `sim/SimulationRunner.java`, `Application.java`, `ui/TickInfoPanel.java`, `+MoveTickTest` (3 tests).

Closes #132

Build: `:core:check` green (+3 tests). Scope: core-only.
Merge: directly (core). Note: `TickInfoPanel` ctor gained a `MoveTickHandler` param; `Application`/`SimulationRunner` additions are shared with #105/#129 (mostly additive); recommended after the playback cluster.
