### PR TITLE
fix: align macro launch onGround with the sim for airborne starts (#105)

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/PlaybackController.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/PlaybackController.java
@@ -29,6 +29,8 @@ public final class PlaybackController {
     private int lastSpeedAmplifier;
     private int lastJumpBoostAmplifier;
 
+    private boolean firstTickOnGround;
+
     // currentTickYaw is the physics yaw, kept bit-identical to the simulator's rotationYaw:
     // the sine table quantizes 45 and -315 into different buckets, so a mod-360 offset
     // drifts the replayed path off the simulated one. The short-way turn on locked rows
@@ -70,6 +72,10 @@ public final class PlaybackController {
         return nextTick - 1;
     }
 
+    public boolean firstTickOnGround() {
+        return firstTickOnGround;
+    }
+
     public boolean canStart() {
         return bridge != null && bridge.isSingleplayer() && inputData.size() > 0;
     }
@@ -96,7 +102,8 @@ public final class PlaybackController {
                 DebugFlags.simTickSink = null;
             }
         }
-        bridge.teleport(runner.getStartPosition(), runner.getStartVelocity(), runner.getStartYaw());
+        firstTickOnGround = runner.firstTickOnGround();
+        bridge.teleport(runner.getStartPosition(), runner.getStartVelocity(), runner.getStartYaw(), firstTickOnGround);
         // Drop any user-held key so the warmup runs with an empty InputRow like the simulator does.
         bridge.releaseAllKeys();
         nextTick = 0;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ports/PlaybackBridge.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ports/PlaybackBridge.java
@@ -19,7 +19,7 @@ public interface PlaybackBridge {
         return false;
     }
 
-    void teleport(Vec3dCore pos, Vec3dCore vel, float yaw);
+    void teleport(Vec3dCore pos, Vec3dCore vel, float yaw, boolean onGround);
 
     void setKey(InputRow.Key key, boolean pressed);
 

--- a/core/src/main/java/de/legoshi/parkourcalc/core/sim/SimulationRunner.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/sim/SimulationRunner.java
@@ -58,6 +58,15 @@ public final class SimulationRunner {
         }
     }
 
+    public boolean firstTickOnGround() {
+        if (path.isEmpty()) {
+            simulator.resetToStart();
+            path.add(snapshot());
+            checkpoints.add(simulator.saveCheckpoint());
+        }
+        return path.get(0).onGround;
+    }
+
     private TickState snapshot() {
         return new TickState(
                 simulator.getCurrentPosition(),

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/AirborneStartJumpTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/AirborneStartJumpTest.java
@@ -1,0 +1,162 @@
+package de.legoshi.parkourcalc.anglesolver;
+
+import de.legoshi.parkourcalc.core.PlaybackController;
+import de.legoshi.parkourcalc.core.ports.PlaybackBridge;
+import de.legoshi.parkourcalc.core.ports.Simulator;
+import de.legoshi.parkourcalc.core.sim.Checkpoint;
+import de.legoshi.parkourcalc.core.sim.SimulationRunner;
+import de.legoshi.parkourcalc.core.sim.TickState;
+import de.legoshi.parkourcalc.core.sim.Vec3dCore;
+import de.legoshi.parkourcalc.core.ui.InputData;
+import de.legoshi.parkourcalc.core.ui.InputRow;
+import de.legoshi.parkourcalc.core.ui.Settings;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class AirborneStartJumpTest {
+
+    private static final double JUMP_IMPULSE = 0.42;
+
+    private static final class JumpGatedSimulator implements Simulator {
+        private final boolean launchOnGround;
+
+        private Vec3dCore pos = Vec3dCore.ZERO;
+        private Vec3dCore vel = Vec3dCore.ZERO;
+        private boolean onGround;
+        private boolean jumpHeld;
+
+        JumpGatedSimulator(boolean launchOnGround) {
+            this.launchOnGround = launchOnGround;
+        }
+
+        @Override public void resetToStart() {
+            pos = Vec3dCore.ZERO;
+            vel = Vec3dCore.ZERO;
+            onGround = launchOnGround;
+            jumpHeld = false;
+        }
+
+        @Override public void applyInput(InputRow row) {
+            jumpHeld = row.isKeyActive(InputRow.Key.JUMP);
+        }
+
+        @Override public void tick() {
+            if (jumpHeld && onGround) {
+                vel = new Vec3dCore(vel.x, JUMP_IMPULSE, vel.z);
+                onGround = false;
+            } else {
+                vel = new Vec3dCore(vel.x, (vel.y - 0.08) * 0.98, vel.z);
+                onGround = false;
+            }
+            pos = pos.add(vel);
+        }
+
+        @Override public Vec3dCore getCurrentPosition() { return pos; }
+        @Override public boolean isCurrentOnGround() { return onGround; }
+        @Override public boolean isCurrentSneaking() { return false; }
+        @Override public boolean isCurrentSprinting() { return false; }
+        @Override public float getCurrentMoveForward() { return Float.NaN; }
+        @Override public float getCurrentMoveStrafe() { return Float.NaN; }
+        @Override public boolean isCurrentWallCollision() { return false; }
+        @Override public Vec3dCore getCurrentVelocity() { return vel; }
+        @Override public boolean isCurrentSoftCollision() { return false; }
+        @Override public double getCurrentCollisionAngleDegrees() { return Double.NaN; }
+        @Override public float getCurrentYaw() { return 0f; }
+        @Override public List<Vec3dCore> getCurrentSubtickPath() { return Collections.emptyList(); }
+        @Override public Vec3dCore getStartPosition() { return Vec3dCore.ZERO; }
+        @Override public void setStartPosition(Vec3dCore p) { }
+        @Override public Vec3dCore getStartVelocity() { return Vec3dCore.ZERO; }
+        @Override public void setStartVelocity(Vec3dCore v) { }
+        @Override public float getStartYaw() { return 0f; }
+        @Override public void setStartYaw(float yaw) { }
+        @Override public Checkpoint saveCheckpoint() { return null; }
+        @Override public void restoreCheckpoint(Checkpoint checkpoint) { }
+        @Override public void invalidate() { }
+    }
+
+    private static final class RecordingBridge implements PlaybackBridge {
+        Boolean teleportedOnGround;
+
+        @Override public boolean isSingleplayer() { return true; }
+        @Override public void teleport(Vec3dCore pos, Vec3dCore vel, float yaw, boolean onGround) {
+            teleportedOnGround = onGround;
+        }
+        @Override public void setKey(InputRow.Key key, boolean pressed) { }
+        @Override public void setYaw(float absoluteYaw) { }
+        @Override public void releaseAllKeys() { }
+        @Override public void closeUI() { }
+        @Override public void applyEffects(int speedAmplifier, int jumpBoostAmplifier) { }
+    }
+
+    private static InputData jumpOnFirstRow() {
+        InputData data = new InputData();
+        InputRow row = new InputRow();
+        row.setKeyActive(InputRow.Key.JUMP, true);
+        data.getRows().add(row);
+        return data;
+    }
+
+    @Test
+    public void airborneStartJumpFallsInTheSimulation() {
+        SimulationRunner runner = new SimulationRunner(new JumpGatedSimulator(false));
+        List<TickState> path = runner.simulate(jumpOnFirstRow());
+
+        assertFalse("the launch tick is airborne", runner.firstTickOnGround());
+        assertFalse("path[0] reflects the airborne launch", path.get(0).onGround);
+        assertTrue(
+                "an airborne first-row JUMP must not jump; the player falls",
+                path.get(1).velocity.y < 0.0
+        );
+    }
+
+    @Test
+    public void groundedStartJumpJumpsInTheSimulation() {
+        SimulationRunner runner = new SimulationRunner(new JumpGatedSimulator(true));
+        List<TickState> path = runner.simulate(jumpOnFirstRow());
+
+        assertTrue("the launch tick is grounded", runner.firstTickOnGround());
+        assertEquals("a grounded first-row JUMP jumps", JUMP_IMPULSE, path.get(1).velocity.y, 1e-9);
+    }
+
+    @Test
+    public void playbackLaunchUsesTheSimsAirborneOnGround() {
+        InputData data = jumpOnFirstRow();
+        SimulationRunner runner = new SimulationRunner(new JumpGatedSimulator(false));
+        runner.simulate(data);
+
+        RecordingBridge bridge = new RecordingBridge();
+        PlaybackController pc = new PlaybackController(data, runner, new Settings());
+        pc.setBridge(bridge);
+        pc.start();
+
+        assertEquals(
+                "playback seats the player with the sim's airborne launch onGround, not a forced true",
+                Boolean.FALSE, bridge.teleportedOnGround
+        );
+        assertFalse("the loader's tick-0 hook reads the same airborne value", pc.firstTickOnGround());
+    }
+
+    @Test
+    public void playbackLaunchUsesTheSimsGroundedOnGround() {
+        InputData data = jumpOnFirstRow();
+        SimulationRunner runner = new SimulationRunner(new JumpGatedSimulator(true));
+        runner.simulate(data);
+
+        RecordingBridge bridge = new RecordingBridge();
+        PlaybackController pc = new PlaybackController(data, runner, new Settings());
+        pc.setBridge(bridge);
+        pc.start();
+
+        assertEquals(
+                "a grounded start still launches on the ground so the jump fires",
+                Boolean.TRUE, bridge.teleportedOnGround
+        );
+        assertTrue(pc.firstTickOnGround());
+    }
+}

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/PlaybackPauseTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/PlaybackPauseTest.java
@@ -40,7 +40,7 @@ public class PlaybackPauseTest {
         }
 
         @Override
-        public void teleport(Vec3dCore pos, Vec3dCore vel, float yaw) {
+        public void teleport(Vec3dCore pos, Vec3dCore vel, float yaw, boolean onGround) {
         }
 
         @Override

--- a/loader-fabric-1.21.10/src/client/java/de/legoshi/parkourcalc/fabric/FabricParkourCalculator.java
+++ b/loader-fabric-1.21.10/src/client/java/de/legoshi/parkourcalc/fabric/FabricParkourCalculator.java
@@ -113,6 +113,10 @@ public class FabricParkourCalculator implements ClientModInitializer {
                 && application.getPlayback().currentTick() == 0;
     }
 
+    public static boolean firstTickOnGround() {
+        return application.getPlayback().firstTickOnGround();
+    }
+
     public static boolean shouldSuppressFallDamage(net.minecraft.entity.Entity self) {
         return application.isPlaybackRunning() && self instanceof net.minecraft.entity.player.PlayerEntity;
     }

--- a/loader-fabric-1.21.10/src/client/java/de/legoshi/parkourcalc/fabric/FabricPlaybackBridge.java
+++ b/loader-fabric-1.21.10/src/client/java/de/legoshi/parkourcalc/fabric/FabricPlaybackBridge.java
@@ -60,7 +60,7 @@ public final class FabricPlaybackBridge implements PlaybackBridge {
     }
 
     @Override
-    public void teleport(Vec3dCore pos, Vec3dCore vel, float yaw) {
+    public void teleport(Vec3dCore pos, Vec3dCore vel, float yaw, boolean onGround) {
         MinecraftClient mc = MinecraftClient.getInstance();
         ClientPlayerEntity client = mc.player;
         if (client == null) return;
@@ -81,7 +81,7 @@ public final class FabricPlaybackBridge implements PlaybackBridge {
         });
         client.updatePositionAndAngles(pos.x, pos.y, pos.z, yaw, client.getPitch());
         client.setVelocity(vel.x, vel.y, vel.z);
-        client.setOnGround(true);
+        client.setOnGround(onGround);
         client.fallDistance = 0.0;
         // Suppress the player tick's position packet until the server's requestTeleport
         // arms its teleport-pending state, otherwise the client races and trips moved-wrongly.

--- a/loader-fabric-1.21.10/src/client/java/de/legoshi/parkourcalc/fabric/mixin/ClientPlayerEntityTickMixin.java
+++ b/loader-fabric-1.21.10/src/client/java/de/legoshi/parkourcalc/fabric/mixin/ClientPlayerEntityTickMixin.java
@@ -14,7 +14,7 @@ public abstract class ClientPlayerEntityTickMixin {
     private void pkc$forceGroundOnTick0(CallbackInfo ci) {
         ClientPlayerEntity self = (ClientPlayerEntity) (Object) this;
         if (FabricParkourCalculator.shouldForceGroundOnTick0(self)) {
-            self.setOnGround(true);
+            self.setOnGround(FabricParkourCalculator.firstTickOnGround());
             self.fallDistance = 0.0;
         }
     }

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12ParkourCalculator.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12ParkourCalculator.java
@@ -126,10 +126,8 @@ public class Forge12ParkourCalculator {
         if (!application.isPlaybackRunning()) return;
         net.minecraft.entity.player.EntityPlayer p = event.player;
         if (p != Minecraft.getMinecraft().player) return;
-        // Sim runs noClip so its tick 0 sees onGround=true; the real player's warmup
-        // moveEntity can flip it false when startPosition isn't directly on a block top.
         if (application.getPlayback().currentTick() == 0) {
-            p.onGround = true;
+            p.onGround = application.getPlayback().firstTickOnGround();
             p.fallDistance = 0.0F;
         }
     }

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12PlaybackBridge.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12PlaybackBridge.java
@@ -63,7 +63,7 @@ public final class Forge12PlaybackBridge implements PlaybackBridge {
     }
 
     @Override
-    public void teleport(Vec3dCore pos, Vec3dCore vel, float yaw) {
+    public void teleport(Vec3dCore pos, Vec3dCore vel, float yaw, boolean onGround) {
         Minecraft mc = Minecraft.getMinecraft();
         EntityPlayerSP client = mc.player;
         if (client == null) return;
@@ -83,7 +83,7 @@ public final class Forge12PlaybackBridge implements PlaybackBridge {
         client.motionX = vel.x;
         client.motionY = vel.y;
         client.motionZ = vel.z;
-        client.onGround = true;
+        client.onGround = onGround;
         client.fallDistance = 0.0F;
         // Suppress onUpdateWalkingPlayer's position packet until the server's scheduled
         // setPlayerLocation arms targetPos, otherwise the client races and trips moved-wrongly.

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8ParkourCalculator.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8ParkourCalculator.java
@@ -128,10 +128,8 @@ public class Forge8ParkourCalculator {
         if (!application.isPlaybackRunning()) return;
         net.minecraft.entity.player.EntityPlayer p = event.player;
         if (p != Minecraft.getMinecraft().thePlayer) return;
-        // Sim runs noClip so its tick 0 sees onGround=true; the real player's warmup
-        // moveEntity can flip it false when startPosition isn't directly on a block top.
         if (application.getPlayback().currentTick() == 0) {
-            p.onGround = true;
+            p.onGround = application.getPlayback().firstTickOnGround();
             p.fallDistance = 0.0F;
         }
     }

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8PlaybackBridge.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8PlaybackBridge.java
@@ -64,7 +64,7 @@ public final class Forge8PlaybackBridge implements PlaybackBridge {
     }
 
     @Override
-    public void teleport(Vec3dCore pos, Vec3dCore vel, float yaw) {
+    public void teleport(Vec3dCore pos, Vec3dCore vel, float yaw, boolean onGround) {
         Minecraft mc = Minecraft.getMinecraft();
         EntityPlayerSP client = mc.thePlayer;
         if (client == null) return;
@@ -84,7 +84,7 @@ public final class Forge8PlaybackBridge implements PlaybackBridge {
         client.motionX = vel.x;
         client.motionY = vel.y;
         client.motionZ = vel.z;
-        client.onGround = true;
+        client.onGround = onGround;
         client.fallDistance = 0.0F;
         // Suppress onUpdateWalkingPlayer's position packet until the server's scheduled
         // setPlayerLocation arms targetPos, otherwise the client races and trips moved-wrongly.


### PR DESCRIPTION
The macro launch hard-coded `onGround = true` (commit `d655981`); for an airborne start with a first-tick JUMP the player wrongly jumped, while the noClip-warmup sim correctly saw `onGround = false` and fell, hence the visualizer/macro divergence. The macro side was wrong. The fix threads the sim's real launch `onGround` through a new `PlaybackBridge.teleport(pos, vel, yaw, onGround)` and `PlaybackController.firstTickOnGround()`; all loaders use the sim value instead of `true`.

Files (core): `sim/SimulationRunner.java`, `PlaybackController.java`, `ports/PlaybackBridge.java`. (loaders, not compiled): `Forge8/12PlaybackBridge`, `FabricPlaybackBridge`, `Forge8/12ParkourCalculator`, `ClientPlayerEntityTickMixin`. `+AirborneStartJumpTest`.

Closes #105

GATE: behavior review + loader test. Confirm the intended semantics: first-tick JUMP from the air should do nothing (fall), matching vanilla and the visualizer. Loader test: airborne start + jump tick 1 falls; grounded start still jumps.
Build: `:core:check` green (+test); loader code NOT compiled here.
Merge: FIRST in the playback/bridge cluster. The `teleport` signature change ripples to every loader bridge and conflicts with #129 (`start()`) and #100/#101 (bridge + controller).
