### PR TITLE
fix(forge-1.8.9): reset glColor4f after world/HUD overlay so hotbar stays opaque in F5 (#97)

### DIFF
--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/render/Forge8HudOverlayRenderer.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/render/Forge8HudOverlayRenderer.java
@@ -4,6 +4,7 @@ import de.legoshi.parkourcalc.core.ui.theme.MacroBadgeStyle;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.ScaledResolution;
+import net.minecraft.client.renderer.GlStateManager;
 
 /** Top-right MACRO badge shown while playback drives the real player. */
 @SuppressWarnings("DuplicatedCode")
@@ -17,5 +18,6 @@ public final class Forge8HudOverlayRenderer {
         String label = MacroBadgeStyle.LABEL;
         int x = sr.getScaledWidth() - fr.getStringWidth(label) - 4;
         fr.drawStringWithShadow(label, x, 4, MacroBadgeStyle.COLOR_ARGB);
+        GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
     }
 }

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/render/Forge8WorldOverlayRenderer.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/render/Forge8WorldOverlayRenderer.java
@@ -89,6 +89,8 @@ public final class Forge8WorldOverlayRenderer {
             }
         }
 
+        // Reset leaked per-vertex glColor4f to white so the F5 (third-person) hotbar stays opaque.
+        GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
         GlStateManager.disableBlend();
         GlStateManager.enableCull();
         GlStateManager.enableLighting();


### PR DESCRIPTION
Root cause: a leaked `glColor4f`. The world-overlay path/gizmo draws leave the current GL color at a sub-1.0-alpha vertex color and never reset it. In first person the vanilla held-item pass re-whitens the color; in F5 (third person) that pass is skipped, so the vanilla hotbar inherits the alpha and renders transparent. Fix: `GlStateManager.color(1,1,1,1)` at the end of `Forge8WorldOverlayRenderer.render()` and after the badge text in `Forge8HudOverlayRenderer`.

Files (loader, not compiled): `forge8/render/Forge8WorldOverlayRenderer.java`, `forge8/render/Forge8HudOverlayRenderer.java`.

Closes #97

GATE: loader test. Draw a path, toggle F5, hotbar opaque; repeat with the yaw gizmo visible and during/after playback.
Build: loader-only, NOT compiled here. Risk: low (additive).
Merge: anytime (Forge8 render files only), after its loader test.
Follow-up (out of scope): 1.12.2 has the identical latent bug.
