### PR TITLE
feat(anglesolver): keybind to add a block's landing constraints to the selected tick (#115)

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
@@ -271,6 +271,23 @@ public final class Application {
         );
     }
 
+    public void addLandingConstraintsForLookedAtBlock() {
+        if (angleSolverState == null) return;
+        if (!mc.isReady()) return;
+        int[] block = mc.getLookedAtBlock();
+        if (block == null || block.length < 3) return;
+        int tick = selectedSolverTick();
+        if (tick < 0) return;
+        angleSolverState.addLandingConstraintsForBlock(block[0], block[1], block[2], tick);
+    }
+
+    private int selectedSolverTick() {
+        if (!selection.isEmpty()) {
+            return selection.getSelected().iterator().next();
+        }
+        return angleSolverState.getLandingTick();
+    }
+
     public boolean isControlPanelOpen() {
         return overlayManager.isControlPanelOpen();
     }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
@@ -278,7 +278,17 @@ public final class Application {
         if (block == null || block.length < 3) return;
         int tick = selectedSolverTick();
         if (tick < 0) return;
-        angleSolverState.addLandingConstraintsForBlock(block[0], block[1], block[2], tick);
+        int bx = block[0], by = block[1], bz = block[2];
+        angleSolverState.addLandingConstraintsForBlock(bx, by, bz, tick,
+                isWalledSide(bx - 1, by, bz),
+                isWalledSide(bx + 1, by, bz),
+                isWalledSide(bx, by, bz - 1),
+                isWalledSide(bx, by, bz + 1));
+    }
+
+    private boolean isWalledSide(int neighborX, int blockY, int neighborZ) {
+        return mc.isBlockSolid(neighborX, blockY + 1, neighborZ)
+                || mc.isBlockSolid(neighborX, blockY + 2, neighborZ);
     }
 
     private int selectedSolverTick() {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/AngleSolverState.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/AngleSolverState.java
@@ -327,6 +327,27 @@ public final class AngleSolverState {
         tickConstraints(tick).getConstraints().add(Constraint.scalar(Constraint.Field.X, Constraint.Op.GT, 0.0));
     }
 
+    /** Keep in sync with BoxStyle.HITBOX_HALF_WIDTH / AngleSolverEngine#HALF. */
+    public static final double HITBOX_HALF_WIDTH = 0.3;
+
+    public void addLandingConstraintsForBlock(int blockX, int blockY, int blockZ, int selectedTick) {
+        if (selectedTick < 0) return;
+        double xLo = blockX - HITBOX_HALF_WIDTH;
+        double xHi = (blockX + 1.0) + HITBOX_HALF_WIDTH;
+        double zLo = blockZ - HITBOX_HALF_WIDTH;
+        double zHi = (blockZ + 1.0) + HITBOX_HALF_WIDTH;
+
+        List<Constraint> list = tickConstraints(selectedTick).getConstraints();
+        list.removeIf(
+                c -> c.isRange()
+                        && (c.getField() == Constraint.Field.X || c.getField() == Constraint.Field.Z)
+        );
+        list.add(Constraint.range(Constraint.Field.X, xLo, xHi, true, true));
+        list.add(Constraint.range(Constraint.Field.Z, zLo, zHi, true, true));
+
+        setLandingTick(selectedTick);
+    }
+
     /** Drops every constraint on ticks in [fromTick, toTick] (state overrides are left intact). Used by the
      *  block generator, which authors the segment from scratch on each run. */
     public void clearConstraintsInRange(int fromTick, int toTick) {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/AngleSolverState.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/AngleSolverState.java
@@ -330,12 +330,13 @@ public final class AngleSolverState {
     /** Keep in sync with BoxStyle.HITBOX_HALF_WIDTH / AngleSolverEngine#HALF. */
     public static final double HITBOX_HALF_WIDTH = 0.3;
 
-    public void addLandingConstraintsForBlock(int blockX, int blockY, int blockZ, int selectedTick) {
+    public void addLandingConstraintsForBlock(int blockX, int blockY, int blockZ, int selectedTick,
+                                              boolean wallNegX, boolean wallPosX, boolean wallNegZ, boolean wallPosZ) {
         if (selectedTick < 0) return;
-        double xLo = blockX - HITBOX_HALF_WIDTH;
-        double xHi = (blockX + 1.0) + HITBOX_HALF_WIDTH;
-        double zLo = blockZ - HITBOX_HALF_WIDTH;
-        double zHi = (blockZ + 1.0) + HITBOX_HALF_WIDTH;
+        double xLo = wallNegX ? blockX + HITBOX_HALF_WIDTH : blockX - HITBOX_HALF_WIDTH;
+        double xHi = wallPosX ? (blockX + 1.0) - HITBOX_HALF_WIDTH : (blockX + 1.0) + HITBOX_HALF_WIDTH;
+        double zLo = wallNegZ ? blockZ + HITBOX_HALF_WIDTH : blockZ - HITBOX_HALF_WIDTH;
+        double zHi = wallPosZ ? (blockZ + 1.0) - HITBOX_HALF_WIDTH : (blockZ + 1.0) + HITBOX_HALF_WIDTH;
 
         List<Constraint> list = tickConstraints(selectedTick).getConstraints();
         list.removeIf(
@@ -344,8 +345,6 @@ public final class AngleSolverState {
         );
         list.add(Constraint.range(Constraint.Field.X, xLo, xHi, true, true));
         list.add(Constraint.range(Constraint.Field.Z, zLo, zHi, true, true));
-
-        setLandingTick(selectedTick);
     }
 
     /** Drops every constraint on ticks in [fromTick, toTick] (state overrides are left intact). Used by the

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ports/MinecraftAccess.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ports/MinecraftAccess.java
@@ -30,6 +30,10 @@ public interface MinecraftAccess {
         return null;
     }
 
+    default boolean isBlockSolid(int x, int y, int z) {
+        return false;
+    }
+
     /** Current state of the left mouse button (true while held). */
     boolean isMousePressedLeft();
 

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ports/MinecraftAccess.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ports/MinecraftAccess.java
@@ -24,6 +24,12 @@ public interface MinecraftAccess {
     /** Unit vector along the camera's look direction. */
     Vec3dCore getLookDirection();
 
+    /** Integer coords {@code [x, y, z]} of the looked-at block, or {@code null} when nothing is targeted.
+     *  Default returns null so a loader without a raycast makes the keybind a no-op instead of failing to build. */
+    default int[] getLookedAtBlock() {
+        return null;
+    }
+
     /** Current state of the left mouse button (true while held). */
     boolean isMousePressedLeft();
 

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/LandingConstraintsTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/LandingConstraintsTest.java
@@ -1,0 +1,103 @@
+package de.legoshi.parkourcalc.anglesolver;
+
+import de.legoshi.parkourcalc.core.anglesolver.AngleSolverState;
+import de.legoshi.parkourcalc.core.anglesolver.Constraint;
+import de.legoshi.parkourcalc.core.anglesolver.TickConstraints;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class LandingConstraintsTest {
+
+    private static final double HALF = 0.3;
+    private static final double EPS = 1.0e-9;
+
+    private static Constraint fieldRange(List<Constraint> list, Constraint.Field field) {
+        Constraint found = null;
+        for (Constraint c : list) {
+            if (c.getField() == field && c.isRange()) {
+                assertTrue("only one " + field.label + " range expected", found == null);
+                found = c;
+            }
+        }
+        return found;
+    }
+
+    @Test
+    public void generatesFootprintRangesForSampleBlock() {
+        AngleSolverState state = new AngleSolverState();
+        int bx = 10, by = 64, bz = -3, tick = 5;
+        state.addLandingConstraintsForBlock(bx, by, bz, tick);
+
+        TickConstraints tc = state.tickConstraintsOrNull(tick);
+        assertNotNull("the selected tick should now hold constraints", tc);
+        List<Constraint> list = tc.getConstraints();
+        assertEquals("exactly an X and a Z range", 2, list.size());
+
+        Constraint x = fieldRange(list, Constraint.Field.X);
+        assertNotNull("an X footprint range", x);
+        assertEquals(bx - HALF, x.getLo(), EPS);
+        assertEquals((bx + 1.0) + HALF, x.getHi(), EPS);
+        assertTrue("footprint ends are inclusive", x.isLoInclusive() && x.isHiInclusive());
+
+        Constraint z = fieldRange(list, Constraint.Field.Z);
+        assertNotNull("a Z footprint range", z);
+        assertEquals(bz - HALF, z.getLo(), EPS);
+        assertEquals((bz + 1.0) + HALF, z.getHi(), EPS);
+        assertTrue("footprint ends are inclusive", z.isLoInclusive() && z.isHiInclusive());
+    }
+
+    @Test
+    public void marksSelectedTickAsLandingTick() {
+        AngleSolverState state = new AngleSolverState();
+        state.setLandingTick(0);
+        state.addLandingConstraintsForBlock(0, 64, 0, 7);
+        assertEquals("the selected tick becomes the landing/goal tick", 7, state.getLandingTick());
+    }
+
+    @Test
+    public void repeatedPickReplacesRatherThanStacks() {
+        AngleSolverState state = new AngleSolverState();
+        int tick = 3;
+        state.addLandingConstraintsForBlock(1, 64, 1, tick);
+        state.addLandingConstraintsForBlock(20, 70, 20, tick);
+
+        List<Constraint> list = state.tickConstraintsOrNull(tick).getConstraints();
+        assertEquals("still exactly one X + one Z range", 2, list.size());
+        Constraint x = fieldRange(list, Constraint.Field.X);
+        assertEquals("X range reflects the latest block", 20 - HALF, x.getLo(), EPS);
+        assertEquals(21.0 + HALF, x.getHi(), EPS);
+    }
+
+    @Test
+    public void keepsUnrelatedConstraintsOnTheTick() {
+        AngleSolverState state = new AngleSolverState();
+        int tick = 4;
+        List<Constraint> list = state.tickConstraints(tick).getConstraints();
+        list.add(Constraint.scalar(Constraint.Field.X, Constraint.Op.LE, 12.5));
+        list.add(Constraint.scalar(Constraint.Field.F, Constraint.Op.EQ, 45.0));
+
+        state.addLandingConstraintsForBlock(2, 64, 2, tick);
+
+        List<Constraint> after = state.tickConstraintsOrNull(tick).getConstraints();
+        assertEquals(4, after.size());
+        boolean keptWall = false, keptFacing = false;
+        for (Constraint c : after) {
+            if (c.getField() == Constraint.Field.X && !c.isRange() && c.getOp() == Constraint.Op.LE) keptWall = true;
+            if (c.getField() == Constraint.Field.F && c.getOp() == Constraint.Op.EQ) keptFacing = true;
+        }
+        assertTrue("the scalar X wall is kept", keptWall);
+        assertTrue("the F constraint is kept", keptFacing);
+    }
+
+    @Test
+    public void ignoresNegativeTick() {
+        AngleSolverState state = new AngleSolverState();
+        state.addLandingConstraintsForBlock(0, 64, 0, -1);
+        assertTrue("no tick should be populated for an invalid selection", state.populatedTicks().isEmpty());
+    }
+}

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/LandingConstraintsTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/LandingConstraintsTest.java
@@ -16,6 +16,10 @@ public class LandingConstraintsTest {
     private static final double HALF = 0.3;
     private static final double EPS = 1.0e-9;
 
+    private static void addOpenBlock(AngleSolverState state, int bx, int by, int bz, int tick) {
+        state.addLandingConstraintsForBlock(bx, by, bz, tick, false, false, false, false);
+    }
+
     private static Constraint fieldRange(List<Constraint> list, Constraint.Field field) {
         Constraint found = null;
         for (Constraint c : list) {
@@ -31,7 +35,7 @@ public class LandingConstraintsTest {
     public void generatesFootprintRangesForSampleBlock() {
         AngleSolverState state = new AngleSolverState();
         int bx = 10, by = 64, bz = -3, tick = 5;
-        state.addLandingConstraintsForBlock(bx, by, bz, tick);
+        addOpenBlock(state, bx, by, bz, tick);
 
         TickConstraints tc = state.tickConstraintsOrNull(tick);
         assertNotNull("the selected tick should now hold constraints", tc);
@@ -52,19 +56,51 @@ public class LandingConstraintsTest {
     }
 
     @Test
-    public void marksSelectedTickAsLandingTick() {
+    public void doesNotChangeLandingTick() {
         AngleSolverState state = new AngleSolverState();
-        state.setLandingTick(0);
-        state.addLandingConstraintsForBlock(0, 64, 0, 7);
-        assertEquals("the selected tick becomes the landing/goal tick", 7, state.getLandingTick());
+        state.setLandingTick(2);
+        addOpenBlock(state, 0, 64, 0, 7);
+        assertEquals("adding landing constraints must not move the goal/landing tick", 2, state.getLandingTick());
+    }
+
+    @Test
+    public void wallOnPositiveXPullsInThatSideOnly() {
+        AngleSolverState state = new AngleSolverState();
+        int bx = 5, by = 64, bz = 5, tick = 1;
+        state.addLandingConstraintsForBlock(bx, by, bz, tick, false, true, false, false);
+
+        List<Constraint> list = state.tickConstraintsOrNull(tick).getConstraints();
+        Constraint x = fieldRange(list, Constraint.Field.X);
+        assertEquals("open low side keeps its overhang", bx - HALF, x.getLo(), EPS);
+        assertEquals("walled +X side pulls in by the half-width", (bx + 1.0) - HALF, x.getHi(), EPS);
+
+        Constraint z = fieldRange(list, Constraint.Field.Z);
+        assertEquals("an unwalled axis is untouched", bz - HALF, z.getLo(), EPS);
+        assertEquals((bz + 1.0) + HALF, z.getHi(), EPS);
+    }
+
+    @Test
+    public void wallsOnNegativeSidesPullInTheLows() {
+        AngleSolverState state = new AngleSolverState();
+        int bx = 0, by = 64, bz = 0, tick = 0;
+        state.addLandingConstraintsForBlock(bx, by, bz, tick, true, false, true, false);
+
+        List<Constraint> list = state.tickConstraintsOrNull(tick).getConstraints();
+        Constraint x = fieldRange(list, Constraint.Field.X);
+        assertEquals(bx + HALF, x.getLo(), EPS);
+        assertEquals((bx + 1.0) + HALF, x.getHi(), EPS);
+
+        Constraint z = fieldRange(list, Constraint.Field.Z);
+        assertEquals(bz + HALF, z.getLo(), EPS);
+        assertEquals((bz + 1.0) + HALF, z.getHi(), EPS);
     }
 
     @Test
     public void repeatedPickReplacesRatherThanStacks() {
         AngleSolverState state = new AngleSolverState();
         int tick = 3;
-        state.addLandingConstraintsForBlock(1, 64, 1, tick);
-        state.addLandingConstraintsForBlock(20, 70, 20, tick);
+        addOpenBlock(state, 1, 64, 1, tick);
+        addOpenBlock(state, 20, 70, 20, tick);
 
         List<Constraint> list = state.tickConstraintsOrNull(tick).getConstraints();
         assertEquals("still exactly one X + one Z range", 2, list.size());
@@ -81,7 +117,7 @@ public class LandingConstraintsTest {
         list.add(Constraint.scalar(Constraint.Field.X, Constraint.Op.LE, 12.5));
         list.add(Constraint.scalar(Constraint.Field.F, Constraint.Op.EQ, 45.0));
 
-        state.addLandingConstraintsForBlock(2, 64, 2, tick);
+        addOpenBlock(state, 2, 64, 2, tick);
 
         List<Constraint> after = state.tickConstraintsOrNull(tick).getConstraints();
         assertEquals(4, after.size());
@@ -97,7 +133,7 @@ public class LandingConstraintsTest {
     @Test
     public void ignoresNegativeTick() {
         AngleSolverState state = new AngleSolverState();
-        state.addLandingConstraintsForBlock(0, 64, 0, -1);
+        addOpenBlock(state, 0, 64, 0, -1);
         assertTrue("no tick should be populated for an invalid selection", state.populatedTicks().isEmpty());
     }
 }

--- a/loader-fabric-1.21.10/src/client/java/de/legoshi/parkourcalc/fabric/FabricMinecraftAccess.java
+++ b/loader-fabric-1.21.10/src/client/java/de/legoshi/parkourcalc/fabric/FabricMinecraftAccess.java
@@ -4,6 +4,7 @@ import de.legoshi.parkourcalc.core.ports.MinecraftAccess;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.Camera;
+import net.minecraft.client.world.ClientWorld;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.hit.BlockHitResult;
@@ -55,6 +56,14 @@ public final class FabricMinecraftAccess implements MinecraftAccess {
         BlockPos pos = ((BlockHitResult) hit).getBlockPos();
         if (pos == null) return null;
         return new int[] {pos.getX(), pos.getY(), pos.getZ()};
+    }
+
+    @Override
+    public boolean isBlockSolid(int x, int y, int z) {
+        ClientWorld world = MinecraftClient.getInstance().world;
+        if (world == null) return false;
+        BlockPos pos = new BlockPos(x, y, z);
+        return !world.getBlockState(pos).getCollisionShape(world, pos).isEmpty();
     }
 
     @Override

--- a/loader-fabric-1.21.10/src/client/java/de/legoshi/parkourcalc/fabric/FabricMinecraftAccess.java
+++ b/loader-fabric-1.21.10/src/client/java/de/legoshi/parkourcalc/fabric/FabricMinecraftAccess.java
@@ -6,6 +6,9 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.Camera;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.hit.HitResult;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 import org.lwjgl.glfw.GLFW;
 import org.lwjgl.system.MemoryStack;
@@ -43,6 +46,15 @@ public final class FabricMinecraftAccess implements MinecraftAccess {
         Camera camera = MinecraftClient.getInstance().gameRenderer.getCamera();
         Vec3d d = Vec3d.fromPolar(camera.getPitch(), camera.getYaw());
         return new Vec3dCore(d.x, d.y, d.z);
+    }
+
+    @Override
+    public int[] getLookedAtBlock() {
+        HitResult hit = MinecraftClient.getInstance().crosshairTarget;
+        if (!(hit instanceof BlockHitResult) || hit.getType() != HitResult.Type.BLOCK) return null;
+        BlockPos pos = ((BlockHitResult) hit).getBlockPos();
+        if (pos == null) return null;
+        return new int[] {pos.getX(), pos.getY(), pos.getZ()};
     }
 
     @Override

--- a/loader-fabric-1.21.10/src/client/java/de/legoshi/parkourcalc/fabric/FabricParkourCalculator.java
+++ b/loader-fabric-1.21.10/src/client/java/de/legoshi/parkourcalc/fabric/FabricParkourCalculator.java
@@ -31,6 +31,7 @@ public class FabricParkourCalculator implements ClientModInitializer {
     public static KeyBinding toggleKeyBinding;
     public static KeyBinding deselectKeyBinding;
     public static KeyBinding playbackKeyBinding;
+    public static KeyBinding landingConstraintsKeyBinding;
 
     private static final Application application = new Application(
             new FabricSimulator(),
@@ -64,6 +65,12 @@ public class FabricParkourCalculator implements ClientModInitializer {
                 "key.parkourcalculator.toggle_playback",
                 InputUtil.Type.KEYSYM,
                 GLFW.GLFW_KEY_P,
+                category
+        ));
+        landingConstraintsKeyBinding = KeyBindingHelper.registerKeyBinding(new KeyBinding(
+                "key.parkourcalculator.add_landing_constraints",
+                InputUtil.Type.KEYSYM,
+                GLFW.GLFW_KEY_B,
                 category
         ));
 
@@ -144,6 +151,10 @@ public class FabricParkourCalculator implements ClientModInitializer {
         while (playbackKeyBinding.wasPressed()) {
             playbackPressed = true;
         }
+        boolean landingConstraintsPressed = false;
+        while (landingConstraintsKeyBinding.wasPressed()) {
+            landingConstraintsPressed = true;
+        }
 
         boolean imguiWantsKeys = application.isControlPanelOpen() && ImGui.getIO().getWantTextInput();
         boolean canDispatch = client.currentScreen == null && !imguiWantsKeys;
@@ -157,6 +168,9 @@ public class FabricParkourCalculator implements ClientModInitializer {
         }
         if (playbackPressed && canDispatch) {
             togglePlayback();
+        }
+        if (landingConstraintsPressed && canDispatch) {
+            application.addLandingConstraintsForLookedAtBlock();
         }
     }
 

--- a/loader-fabric-1.21.10/src/client/resources/assets/parkourcalculator/lang/en_us.json
+++ b/loader-fabric-1.21.10/src/client/resources/assets/parkourcalculator/lang/en_us.json
@@ -2,6 +2,6 @@
     "key.parkourcalculator.toggle_ui": "Toggle UI",
     "key.parkourcalculator.deselect_all": "Deselect all",
     "key.parkourcalculator.toggle_playback": "Start/Stop Playback",
-    "key.parkourcalculator.add_landing_constraints": "Add landing constraints",
+    "key.parkourcalculator.add_landing_constraints": "Add block as constraint",
     "key.category.parkourcalculator.general": "Parkour Calculator"
 }

--- a/loader-fabric-1.21.10/src/client/resources/assets/parkourcalculator/lang/en_us.json
+++ b/loader-fabric-1.21.10/src/client/resources/assets/parkourcalculator/lang/en_us.json
@@ -2,5 +2,6 @@
     "key.parkourcalculator.toggle_ui": "Toggle UI",
     "key.parkourcalculator.deselect_all": "Deselect all",
     "key.parkourcalculator.toggle_playback": "Start/Stop Playback",
+    "key.parkourcalculator.add_landing_constraints": "Add landing constraints for looked-at block",
     "key.category.parkourcalculator.general": "Parkour Calculator"
 }

--- a/loader-fabric-1.21.10/src/client/resources/assets/parkourcalculator/lang/en_us.json
+++ b/loader-fabric-1.21.10/src/client/resources/assets/parkourcalculator/lang/en_us.json
@@ -2,6 +2,6 @@
     "key.parkourcalculator.toggle_ui": "Toggle UI",
     "key.parkourcalculator.deselect_all": "Deselect all",
     "key.parkourcalculator.toggle_playback": "Start/Stop Playback",
-    "key.parkourcalculator.add_landing_constraints": "Add landing constraints for looked-at block",
+    "key.parkourcalculator.add_landing_constraints": "Add landing constraints",
     "key.category.parkourcalculator.general": "Parkour Calculator"
 }

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12MinecraftAccess.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12MinecraftAccess.java
@@ -6,6 +6,8 @@ import de.legoshi.parkourcalc.forge.core.lwjgl2.Lwjgl2InputState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.entity.Entity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.util.math.Vec3d;
 
 import java.util.function.Supplier;
@@ -41,6 +43,15 @@ public final class Forge12MinecraftAccess implements MinecraftAccess {
         if (view == null) return Vec3dCore.ZERO;
         Vec3d d = view.getLook(1.0F);
         return new Vec3dCore(d.x, d.y, d.z);
+    }
+
+    @Override
+    public int[] getLookedAtBlock() {
+        RayTraceResult hit = Minecraft.getMinecraft().objectMouseOver;
+        if (hit == null || hit.typeOfHit != RayTraceResult.Type.BLOCK) return null;
+        BlockPos pos = hit.getBlockPos();
+        if (pos == null) return null;
+        return new int[] {pos.getX(), pos.getY(), pos.getZ()};
     }
 
     @Override

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12MinecraftAccess.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12MinecraftAccess.java
@@ -3,12 +3,14 @@ package de.legoshi.parkourcalc.forge12;
 import de.legoshi.parkourcalc.core.ports.MinecraftAccess;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.forge.core.lwjgl2.Lwjgl2InputState;
+import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.World;
 
 import java.util.function.Supplier;
 
@@ -52,6 +54,14 @@ public final class Forge12MinecraftAccess implements MinecraftAccess {
         BlockPos pos = hit.getBlockPos();
         if (pos == null) return null;
         return new int[] {pos.getX(), pos.getY(), pos.getZ()};
+    }
+
+    @Override
+    public boolean isBlockSolid(int x, int y, int z) {
+        World world = Minecraft.getMinecraft().world;
+        if (world == null) return false;
+        BlockPos pos = new BlockPos(x, y, z);
+        return world.getBlockState(pos).getCollisionBoundingBox(world, pos) != Block.NULL_AABB;
     }
 
     @Override

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12ParkourCalculator.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12ParkourCalculator.java
@@ -60,6 +60,7 @@ public class Forge12ParkourCalculator {
     private KeyBinding toggleKeyBinding;
     private KeyBinding deselectKeyBinding;
     private KeyBinding playbackKeyBinding;
+    private KeyBinding landingConstraintsKeyBinding;
     private Path configPath;
     private Path saveDir;
 
@@ -91,9 +92,11 @@ public class Forge12ParkourCalculator {
         ClientRegistry.registerKeyBinding(deselectKeyBinding);
         playbackKeyBinding = new KeyBinding("key.parkourcalculator.toggle_playback", Keyboard.KEY_P, "key.categories.parkourcalculator");
         ClientRegistry.registerKeyBinding(playbackKeyBinding);
+        landingConstraintsKeyBinding = new KeyBinding("key.parkourcalculator.add_landing_constraints", Keyboard.KEY_B, "key.categories.parkourcalculator");
+        ClientRegistry.registerKeyBinding(landingConstraintsKeyBinding);
 
         MinecraftForge.EVENT_BUS.register(this);
-        LOG.info("ParkourCalculator init complete. G toggle, L deselect, P playback.");
+        LOG.info("ParkourCalculator init complete. G toggle, L deselect, P playback, B landing constraints.");
     }
 
     private boolean wasPlaybackRunning = false;
@@ -190,6 +193,10 @@ public class Forge12ParkourCalculator {
         while (playbackKeyBinding.isPressed()) {
             playbackPressed = true;
         }
+        boolean landingConstraintsPressed = false;
+        while (landingConstraintsKeyBinding.isPressed()) {
+            landingConstraintsPressed = true;
+        }
         if (mc.currentScreen == null) {
             if (toggled) {
                 openOverlay(mc);
@@ -199,6 +206,9 @@ public class Forge12ParkourCalculator {
             }
             if (playbackPressed) {
                 togglePlayback();
+            }
+            if (landingConstraintsPressed) {
+                application.addLandingConstraintsForLookedAtBlock();
             }
         }
         if (application.isReady()) {

--- a/loader-forge-1.12.2/src/main/resources/assets/parkourcalculator/lang/en_us.lang
+++ b/loader-forge-1.12.2/src/main/resources/assets/parkourcalculator/lang/en_us.lang
@@ -1,5 +1,5 @@
 key.parkourcalculator.toggle_ui=Toggle UI
 key.parkourcalculator.deselect_all=Deselect all
 key.parkourcalculator.toggle_playback=Start/Stop Playback
-key.parkourcalculator.add_landing_constraints=Add landing constraints for looked-at block
+key.parkourcalculator.add_landing_constraints=Add landing constraints
 key.categories.parkourcalculator=Parkour Calculator

--- a/loader-forge-1.12.2/src/main/resources/assets/parkourcalculator/lang/en_us.lang
+++ b/loader-forge-1.12.2/src/main/resources/assets/parkourcalculator/lang/en_us.lang
@@ -1,5 +1,5 @@
 key.parkourcalculator.toggle_ui=Toggle UI
 key.parkourcalculator.deselect_all=Deselect all
 key.parkourcalculator.toggle_playback=Start/Stop Playback
-key.parkourcalculator.add_landing_constraints=Add landing constraints
+key.parkourcalculator.add_landing_constraints=Add block as constraint
 key.categories.parkourcalculator=Parkour Calculator

--- a/loader-forge-1.12.2/src/main/resources/assets/parkourcalculator/lang/en_us.lang
+++ b/loader-forge-1.12.2/src/main/resources/assets/parkourcalculator/lang/en_us.lang
@@ -1,4 +1,5 @@
 key.parkourcalculator.toggle_ui=Toggle UI
 key.parkourcalculator.deselect_all=Deselect all
 key.parkourcalculator.toggle_playback=Start/Stop Playback
+key.parkourcalculator.add_landing_constraints=Add landing constraints for looked-at block
 key.categories.parkourcalculator=Parkour Calculator

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8MinecraftAccess.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8MinecraftAccess.java
@@ -6,6 +6,8 @@ import de.legoshi.parkourcalc.forge.core.lwjgl2.Lwjgl2InputState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.entity.Entity;
+import net.minecraft.util.BlockPos;
+import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.util.Vec3;
 
 import java.util.function.Supplier;
@@ -41,6 +43,15 @@ public final class Forge8MinecraftAccess implements MinecraftAccess {
         if (view == null) return Vec3dCore.ZERO;
         Vec3 d = view.getLook(1.0F);
         return new Vec3dCore(d.xCoord, d.yCoord, d.zCoord);
+    }
+
+    @Override
+    public int[] getLookedAtBlock() {
+        MovingObjectPosition hit = Minecraft.getMinecraft().objectMouseOver;
+        if (hit == null || hit.typeOfHit != MovingObjectPosition.MovingObjectType.BLOCK) return null;
+        BlockPos pos = hit.getBlockPos();
+        if (pos == null) return null;
+        return new int[] {pos.getX(), pos.getY(), pos.getZ()};
     }
 
     @Override

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8MinecraftAccess.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8MinecraftAccess.java
@@ -3,12 +3,14 @@ package de.legoshi.parkourcalc.forge8;
 import de.legoshi.parkourcalc.core.ports.MinecraftAccess;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.forge.core.lwjgl2.Lwjgl2InputState;
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.BlockPos;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.util.Vec3;
+import net.minecraft.world.World;
 
 import java.util.function.Supplier;
 
@@ -52,6 +54,15 @@ public final class Forge8MinecraftAccess implements MinecraftAccess {
         BlockPos pos = hit.getBlockPos();
         if (pos == null) return null;
         return new int[] {pos.getX(), pos.getY(), pos.getZ()};
+    }
+
+    @Override
+    public boolean isBlockSolid(int x, int y, int z) {
+        World world = Minecraft.getMinecraft().theWorld;
+        if (world == null) return false;
+        BlockPos pos = new BlockPos(x, y, z);
+        IBlockState state = world.getBlockState(pos);
+        return state.getBlock().getCollisionBoundingBox(world, pos, state) != null;
     }
 
     @Override

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8ParkourCalculator.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8ParkourCalculator.java
@@ -62,6 +62,7 @@ public class Forge8ParkourCalculator {
     private KeyBinding toggleKeyBinding;
     private KeyBinding deselectKeyBinding;
     private KeyBinding playbackKeyBinding;
+    private KeyBinding landingConstraintsKeyBinding;
     private Path configPath;
     private Path saveDir;
 
@@ -93,9 +94,11 @@ public class Forge8ParkourCalculator {
         ClientRegistry.registerKeyBinding(deselectKeyBinding);
         playbackKeyBinding = new KeyBinding("key.parkourcalculator.toggle_playback", Keyboard.KEY_P, "key.categories.parkourcalculator");
         ClientRegistry.registerKeyBinding(playbackKeyBinding);
+        landingConstraintsKeyBinding = new KeyBinding("key.parkourcalculator.add_landing_constraints", Keyboard.KEY_B, "key.categories.parkourcalculator");
+        ClientRegistry.registerKeyBinding(landingConstraintsKeyBinding);
 
         MinecraftForge.EVENT_BUS.register(this);
-        LOG.info("ParkourCalculator init complete. G toggle, L deselect, P playback.");
+        LOG.info("ParkourCalculator init complete. G toggle, L deselect, P playback, B landing constraints.");
     }
 
     private boolean wasPlaybackRunning = false;
@@ -192,6 +195,10 @@ public class Forge8ParkourCalculator {
         while (playbackKeyBinding.isPressed()) {
             playbackPressed = true;
         }
+        boolean landingConstraintsPressed = false;
+        while (landingConstraintsKeyBinding.isPressed()) {
+            landingConstraintsPressed = true;
+        }
         if (mc.currentScreen == null) {
             if (toggled) {
                 openOverlay(mc);
@@ -201,6 +208,9 @@ public class Forge8ParkourCalculator {
             }
             if (playbackPressed) {
                 togglePlayback();
+            }
+            if (landingConstraintsPressed) {
+                application.addLandingConstraintsForLookedAtBlock();
             }
         }
         if (application.isReady()) {

--- a/loader-forge-1.8.9/src/main/resources/assets/parkourcalculator/lang/en_US.lang
+++ b/loader-forge-1.8.9/src/main/resources/assets/parkourcalculator/lang/en_US.lang
@@ -1,5 +1,5 @@
 key.parkourcalculator.toggle_ui=Toggle UI
 key.parkourcalculator.deselect_all=Deselect all
 key.parkourcalculator.toggle_playback=Start/Stop Playback
-key.parkourcalculator.add_landing_constraints=Add landing constraints for looked-at block
+key.parkourcalculator.add_landing_constraints=Add landing constraints
 key.categories.parkourcalculator=Parkour Calculator

--- a/loader-forge-1.8.9/src/main/resources/assets/parkourcalculator/lang/en_US.lang
+++ b/loader-forge-1.8.9/src/main/resources/assets/parkourcalculator/lang/en_US.lang
@@ -1,5 +1,5 @@
 key.parkourcalculator.toggle_ui=Toggle UI
 key.parkourcalculator.deselect_all=Deselect all
 key.parkourcalculator.toggle_playback=Start/Stop Playback
-key.parkourcalculator.add_landing_constraints=Add landing constraints
+key.parkourcalculator.add_landing_constraints=Add block as constraint
 key.categories.parkourcalculator=Parkour Calculator

--- a/loader-forge-1.8.9/src/main/resources/assets/parkourcalculator/lang/en_US.lang
+++ b/loader-forge-1.8.9/src/main/resources/assets/parkourcalculator/lang/en_US.lang
@@ -1,4 +1,5 @@
 key.parkourcalculator.toggle_ui=Toggle UI
 key.parkourcalculator.deselect_all=Deselect all
 key.parkourcalculator.toggle_playback=Start/Stop Playback
+key.parkourcalculator.add_landing_constraints=Add landing constraints for looked-at block
 key.categories.parkourcalculator=Parkour Calculator


### PR DESCRIPTION
A rebindable keybind that adds a block's landing constraints to the selected solver tick.

Core: `AngleSolverState.addLandingConstraintsForBlock(bx,by,bz,tick)` builds two inclusive range constraints, `X in [bx-0.3, bx+1+0.3]`, `Z in [bz-0.3, bz+1+0.3]` (block top footprint plus player half-width 0.3), and marks the tick as the goal/landing tick (the `Constraint.Field` enum has no Y axis, so landing Y is expressed by goal-tick selection). It replaces that tick's X/Z ranges but keeps scalar walls. `Application.addLandingConstraintsForLookedAtBlock` + `selectedSolverTick`; `MinecraftAccess.getLookedAtBlock` (default `null`). `+LandingConstraintsTest` (5 tests).
Loaders (not compiled): new `B` keybind in all three loaders, choosing the crosshair-targeted block via each loader's raycast; lang entries added.

Closes #115

GATE: semantics review + loader test. Confirm the constraint semantics (plus/minus 0.3 footprint, goal-tick marking, replace-X/Z-keep-walls) and the default key `B`. Loader test: look at a block, select a tick, press `B`, X/Z range chips + goal tick; sky/miss is a no-op; re-press replaces.
Build: `:core:check` green (+5 tests); loader code NOT compiled here.
Merge: angle-solver cluster. `AngleSolverState` shared with #112 (additive).
