### PR TITLE
feat(input-pane): configurable columns, per-tick pitch, and mouse buttons (#100, #101)

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
@@ -117,7 +117,8 @@ public final class Application {
 
     public void setupUi() {
         inputOverlay = new InputOverlay(inputData, settings, selection, this::onUserChange,
-                this::setStartToPlayer, playback, mc, boxController);
+                this::setStartToPlayer, this::saveSettings, playback, mc, boxController
+        );
 
         angleSolverState = new AngleSolverState();
         saveController.setAngleSolver(angleSolverState);
@@ -354,6 +355,10 @@ public final class Application {
 
     public boolean isEditingYaw() {
         return inputOverlay != null && inputOverlay.isEditingYaw();
+    }
+
+    public boolean isEditingPitch() {
+        return inputOverlay != null && inputOverlay.isEditingPitch();
     }
 
     public void navigateYaw(boolean forward) {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
@@ -117,7 +117,7 @@ public final class Application {
 
     public void setupUi() {
         inputOverlay = new InputOverlay(inputData, settings, selection, this::onUserChange,
-                this::setStartToPlayer, this::saveSettings, playback, mc, boxController
+                this::setStartToPlayer, playback, mc, boxController
         );
 
         angleSolverState = new AngleSolverState();
@@ -132,7 +132,7 @@ public final class Application {
         saveController.setSolverEngine(angleSolverEngine);
         AngleSolverWindow angleSolverWindow = new AngleSolverWindow(angleSolverState, settings, inputData::size, angleSolverEngine);
 
-        TickInfoPanel tickInfoPanel = new TickInfoPanel(boxController, selection, settings);
+        TickInfoPanel tickInfoPanel = new TickInfoPanel(boxController, inputData, selection, settings);
         PerfOverlay perfOverlay = new PerfOverlay();
         FileMenu fileMenu = new FileMenu(saveController, filePicker, settings, this::saveSettings);
         SettingsModal settingsModal = new SettingsModal(settings, this::saveSettings);
@@ -332,6 +332,7 @@ public final class Application {
     }
 
     public boolean shouldSuppressLeftClick() {
+        if (isPlaybackRunning()) return false;
         if (isControlPanelOpen()) return false;
         if (dragController.isDragging()) return true;
         if (!mc.isReady()) return false;
@@ -339,6 +340,7 @@ public final class Application {
     }
 
     public boolean shouldSuppressRightClick() {
+        if (isPlaybackRunning()) return false;
         if (isControlPanelOpen()) return false;
         if (yawGizmo.isEngaged()) return true;
         if (!mc.isReady()) return false;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/PlaybackController.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/PlaybackController.java
@@ -52,6 +52,9 @@ public final class PlaybackController {
     private float displayedYaw;
     private long lastFrameNanos;
 
+    private float currentTickPitch;
+    private boolean pitchEngaged;
+
     // Non-zero while the game sits paused: client ticks keep firing but the world does not advance,
     // so the schedule must freeze with it (gh-106). On resume the lerp clocks shift by the pause.
     private long pausedAtNanos;
@@ -162,6 +165,8 @@ public final class PlaybackController {
         currentTickYaw = yaw;
         displayTargetYaw = yaw;
         displayedYaw = yaw;
+        currentTickPitch = 0f;
+        pitchEngaged = false;
         tickEndNanos = 0L;
         lastFrameNanos = 0L;
         InputRow firstRow = inputData.get(from);
@@ -270,6 +275,14 @@ public final class PlaybackController {
             }
         }
         bridge.setYaw(currentTickYaw);
+        Float pitch = row.getPitch();
+        if (pitch != null) {
+            currentTickPitch = pitch;
+            pitchEngaged = true;
+        }
+        if (pitchEngaged) {
+            bridge.setPitch(currentTickPitch);
+        }
         tickEndNanos = System.nanoTime();
         nextTick++;
     }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/PlaybackController.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/PlaybackController.java
@@ -21,6 +21,8 @@ public final class PlaybackController {
     private static final long TICK_NANOS = 50_000_000L;
     private static final float MAX_FRAME_DT_SECONDS = 0.1f;
 
+    public static final float DEFAULT_PITCH = 40f;
+
     private final InputData inputData;
     private final SimulationRunner runner;
     private final Settings settings;
@@ -53,6 +55,8 @@ public final class PlaybackController {
     private long lastFrameNanos;
 
     private float currentTickPitch;
+    private float prevTickPitch;
+    private float displayedPitch;
     private boolean pitchEngaged;
 
     // Non-zero while the game sits paused: client ticks keep firing but the world does not advance,
@@ -165,8 +169,10 @@ public final class PlaybackController {
         currentTickYaw = yaw;
         displayTargetYaw = yaw;
         displayedYaw = yaw;
-        currentTickPitch = 0f;
-        pitchEngaged = false;
+        currentTickPitch = DEFAULT_PITCH;
+        prevTickPitch = DEFAULT_PITCH;
+        displayedPitch = DEFAULT_PITCH;
+        pitchEngaged = true;
         tickEndNanos = 0L;
         lastFrameNanos = 0L;
         InputRow firstRow = inputData.get(from);
@@ -275,16 +281,31 @@ public final class PlaybackController {
             }
         }
         bridge.setYaw(currentTickYaw);
-        Float pitch = row.getPitch();
-        if (pitch != null) {
-            currentTickPitch = pitch;
-            pitchEngaged = true;
-        }
-        if (pitchEngaged) {
-            bridge.setPitch(currentTickPitch);
-        }
+        prevTickPitch = currentTickPitch;
+        currentTickPitch = applyPitch(currentTickPitch, row);
+        bridge.setPitch(currentTickPitch);
         tickEndNanos = System.nanoTime();
         nextTick++;
+    }
+
+    private static float clampPitch(float pitch) {
+        if (pitch < -90f) return -90f;
+        if (pitch > 90f) return 90f;
+        return pitch;
+    }
+
+    public static float applyPitch(float current, InputRow row) {
+        Float pitch = row.getPitch();
+        if (pitch == null) return current;
+        float next;
+        if (row.isPitchLocked()) {
+            next = pitch;
+        } else if (pitch != 0f) {
+            next = current + pitch;
+        } else {
+            next = current;
+        }
+        return clampPitch(next);
     }
 
     /** Signed degrees from -> to taken the short way round, in [-180, 180]. */
@@ -300,6 +321,7 @@ public final class PlaybackController {
         if (!running || bridge == null) return;
         bridge.setYaw(displayedYaw);
         bridge.setHeadYaw(displayedYaw);
+        if (pitchEngaged) bridge.setPitch(displayedPitch);
         if (DebugFlags.DUMP_TICK_STATE) {
             // Negative index = warmup tick, so state going into tick 0 is visible.
             int t = nextTick - 1 - warmupRemaining;
@@ -341,5 +363,14 @@ public final class PlaybackController {
             displayedYaw += Math.signum(delta) * maxStep;
         }
         bridge.setYaw(displayedYaw);
+
+        float idealPitch = prevTickPitch + (currentTickPitch - prevTickPitch) * partial;
+        float pitchDelta = idealPitch - displayedPitch;
+        if (Math.abs(pitchDelta) <= maxStep) {
+            displayedPitch = idealPitch;
+        } else {
+            displayedPitch += Math.signum(pitchDelta) * maxStep;
+        }
+        if (pitchEngaged) bridge.setPitch(displayedPitch);
     }
 }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ports/PlaybackBridge.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ports/PlaybackBridge.java
@@ -28,6 +28,8 @@ public interface PlaybackBridge {
 
     default void setHeadYaw(float absoluteYaw) {}
 
+    default void setPitch(float absolutePitch) {}
+
     void releaseAllKeys();
 
     /** Close any open mod UI (control panel / GuiScreen) the same way the toggle key would. */

--- a/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveFile.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveFile.java
@@ -34,6 +34,7 @@ public final class SaveFile {
         public Float yaw;
         public boolean yawLocked;
         public Float pitch;
+        public boolean pitchLocked;
         public int speedAmplifier;
         public int jumpBoostAmplifier;
     }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveFile.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveFile.java
@@ -33,6 +33,7 @@ public final class SaveFile {
         public List<String> keys = new ArrayList<String>();
         public Float yaw;
         public boolean yawLocked;
+        public Float pitch;
         public int speedAmplifier;
         public int jumpBoostAmplifier;
     }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveIO.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveIO.java
@@ -276,6 +276,7 @@ public final class SaveIO {
         r.yaw = row.getYaw();
         r.yawLocked = row.isYawLocked();
         r.pitch = row.getPitch();
+        r.pitchLocked = row.isPitchLocked();
         r.speedAmplifier = row.getSpeedAmplifier();
         r.jumpBoostAmplifier = row.getJumpBoostAmplifier();
         return r;
@@ -294,6 +295,7 @@ public final class SaveIO {
         if (r != null) row.setYaw(r.yaw);
         if (r != null) row.setYawLocked(r.yawLocked);
         if (r != null) row.setPitch(r.pitch);
+        if (r != null) row.setPitchLocked(r.pitchLocked);
         if (r != null) {
             row.setSpeedAmplifier(r.speedAmplifier);
             row.setJumpBoostAmplifier(r.jumpBoostAmplifier);

--- a/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveIO.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveIO.java
@@ -275,6 +275,7 @@ public final class SaveIO {
         r.keys = keys;
         r.yaw = row.getYaw();
         r.yawLocked = row.isYawLocked();
+        r.pitch = row.getPitch();
         r.speedAmplifier = row.getSpeedAmplifier();
         r.jumpBoostAmplifier = row.getJumpBoostAmplifier();
         return r;
@@ -292,6 +293,7 @@ public final class SaveIO {
         }
         if (r != null) row.setYaw(r.yaw);
         if (r != null) row.setYawLocked(r.yawLocked);
+        if (r != null) row.setPitch(r.pitch);
         if (r != null) {
             row.setSpeedAmplifier(r.speedAmplifier);
             row.setJumpBoostAmplifier(r.jumpBoostAmplifier);

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputOverlay.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputOverlay.java
@@ -79,21 +79,15 @@ public final class InputOverlay {
     private static final String MENU_LOCK_YAW = "Lock yaw value";
     private static final String MENU_UNLOCK_YAW = "Unlock yaw value";
 
+    private static final String MENU_LOCK_PITCH = "Lock pitch value";
+    private static final String MENU_UNLOCK_PITCH = "Unlock pitch value";
+
     private static final String YAW_FORMAT_DISPLAY = "% 12.6f";
 
     private static final String DRAG_DROP_TYPE = "INPUT_ROW";
 
-    private static final String ID_COLUMNS_POPUP = "columns_popup";
-    private static final String BTN_COLUMNS = "Columns";
-    private static final String COLUMNS_GROUP_MOVEMENT = "Movement";
-    private static final String COLUMNS_GROUP_MODIFIERS = "Modifiers";
-    private static final String COLUMNS_GROUP_LOOK = "Look";
-    private static final String COLUMNS_GROUP_MOUSE = "Mouse";
-    private static final String COLUMNS_GROUP_EFFECTS = "Effects";
-    private static final String COL_TOGGLE_W_HINT = "W is always shown";
     private static final String PITCH_FORMAT_DISPLAY = "% 12.6f";
 
-    private static final int POTION_COLUMN_COUNT = 2;
     private static final int SOLVER_COLUMN_COUNT = 2; // Constraints + State
     private static final float SOLVER_CULL_OVERSCAN = 4f; // extra rows rendered above/below the viewport
     private static final float ROW_COUNT_INPUT_WIDTH = 240;
@@ -107,7 +101,6 @@ public final class InputOverlay {
     private final Settings settings;
     private final IntConsumer onDataChangedAt;
     private final Runnable onSetPlayerPosition;
-    private final Runnable onSettingsChanged;
     private final PlaybackController playback;
     private final MinecraftAccess mc;
     private final BoxController boxController;
@@ -130,6 +123,8 @@ public final class InputOverlay {
     private int carryYawCursorPos;
     private int hoveredRow = -1;
     private int pendingLockToggleRow = -1;
+    private int pitchCallbackRow = -1;
+    private int pendingPitchLockToggleRow = -1;
 
     private static final int CALLBACK_ALWAYS = ImGuiInputTextFlags.CallbackAlways;
     private static final int CALLBACK_CHAR_FILTER = ImGuiInputTextFlags.CallbackCharFilter;
@@ -164,6 +159,19 @@ public final class InputOverlay {
         }
     };
 
+    private final ImGuiInputTextCallback pitchLockCallback = new ImGuiInputTextCallback() {
+        @Override
+        public void accept(ImGuiInputTextCallbackData data) {
+            if (data.getEventFlag() == CALLBACK_CHAR_FILTER) {
+                char c = (char) data.getEventChar();
+                if (c == 'f' || c == 'F') {
+                    discardEventChar(data);
+                    if (pitchCallbackRow >= 0) pendingPitchLockToggleRow = pitchCallbackRow;
+                }
+            }
+        }
+    };
+
     private Supplier<Float> footerHeightProvider = () -> 0f;
 
     public void setFooterHeightProvider(Supplier<Float> provider) {
@@ -171,7 +179,7 @@ public final class InputOverlay {
     }
 
     public InputOverlay(InputData data, Settings settings, SelectionManager selection, IntConsumer onDataChangedAt,
-                        Runnable onSetPlayerPosition, Runnable onSettingsChanged, PlaybackController playback,
+                        Runnable onSetPlayerPosition, PlaybackController playback,
                         MinecraftAccess mc, BoxController boxController
     ) {
         this.data = data;
@@ -179,7 +187,6 @@ public final class InputOverlay {
         this.selection = selection;
         this.onDataChangedAt = onDataChangedAt;
         this.onSetPlayerPosition = onSetPlayerPosition;
-        this.onSettingsChanged = onSettingsChanged;
         this.playback = playback;
         this.mc = mc;
         this.boxController = boxController;
@@ -273,6 +280,18 @@ public final class InputOverlay {
         return settings.showColPitch;
     }
 
+    private boolean isSpeedColumnVisible() {
+        return settings.showColSpeed;
+    }
+
+    private boolean isJumpBoostColumnVisible() {
+        return settings.showColJumpBoost;
+    }
+
+    private int potionColumnCount() {
+        return (isSpeedColumnVisible() ? 1 : 0) + (isJumpBoostColumnVisible() ? 1 : 0);
+    }
+
     private int baseColumnCount() {
         int count = 1;
         for (InputRow.Key key : MOVEMENT_KEYS) if (isKeyColumnVisible(key)) count++;
@@ -283,16 +302,15 @@ public final class InputOverlay {
         return count;
     }
 
-    private int totalColumnCount(boolean potionColumns, boolean solverActive) {
+    private int totalColumnCount(boolean solverActive) {
         return baseColumnCount()
-                + (potionColumns ? POTION_COLUMN_COUNT : 0)
+                + potionColumnCount()
                 + (solverActive ? SOLVER_COLUMN_COUNT : 0);
     }
 
     public float desiredPaneWidth() {
-        boolean potion = settings.showPotionColumns;
         boolean solver = isSolverActive();
-        int columnCount = totalColumnCount(potion, solver);
+        int columnCount = totalColumnCount(solver);
 
         ImGuiStyle style = ImGui.getStyle();
         float cellPadX = style.getCellPadding().x;
@@ -312,8 +330,15 @@ public final class InputOverlay {
         for (InputRow.Key key : MOUSE_KEYS) {
             if (isKeyColumnVisible(key)) columnSum += ThemeManager.tableColumnWidth(headerLabel(key), 0f);
         }
-        if (potion) {
-            columnSum += ThemeManager.tableColumnWidth(COL_SPEED, AMP_COLUMN_WIDTH * scale) + ThemeManager.tableRightmostColumnWidth(COL_JUMP_BOOST, AMP_COLUMN_WIDTH * scale, ThemeManager.tableScrollbarSlack());
+        boolean speed = isSpeedColumnVisible();
+        boolean jump = isJumpBoostColumnVisible();
+        if (speed) {
+            columnSum += jump
+                    ? ThemeManager.tableColumnWidth(COL_SPEED, AMP_COLUMN_WIDTH * scale)
+                    : ThemeManager.tableRightmostColumnWidth(COL_SPEED, AMP_COLUMN_WIDTH * scale, ThemeManager.tableScrollbarSlack());
+        }
+        if (jump) {
+            columnSum += ThemeManager.tableRightmostColumnWidth(COL_JUMP_BOOST, AMP_COLUMN_WIDTH * scale, ThemeManager.tableScrollbarSlack());
         }
         if (solver) {
             columnSum += angleSolver.minConstraintsColumnWidth() + angleSolver.minStateColumnWidth();
@@ -353,17 +378,15 @@ public final class InputOverlay {
 
     private void renderBodyInternal() {
         renderMultiplayerWarning();
-        renderColumnsControl();
 
         boolean solverActive = isSolverActive();
-        boolean potionColumns = settings.showPotionColumns;
-        int columnCount = totalColumnCount(potionColumns, solverActive);
+        int columnCount = totalColumnCount(solverActive);
 
         int drawerRow = clampedExpandedRow();
         float footerH = footerHeightProvider.get();
 
         float avail = Math.max(TABLE_MIN_HEIGHT, ImGui.getContentRegionAvail().y - footerH);
-        renderInlineSolverBody(solverActive, drawerRow, potionColumns, columnCount, avail);
+        renderInlineSolverBody(solverActive, drawerRow, columnCount, avail);
 
         renderContextMenu();
         handleKeyboardShortcuts();
@@ -373,70 +396,6 @@ public final class InputOverlay {
         if (dragChangeStart >= 0) {
             notifyChange(dragChangeStart);
         }
-    }
-
-    private void renderColumnsControl() {
-        if (Controls.secondaryButton(BTN_COLUMNS)) {
-            ImGui.openPopup(ID_COLUMNS_POPUP);
-        }
-        TooltipUtil.onHover("Show or hide input columns. Hidden columns keep their values.");
-        renderColumnsPopup();
-    }
-
-    private void renderColumnsPopup() {
-        if (!ImGui.beginPopup(ID_COLUMNS_POPUP)) return;
-
-        columnsGroupLabel(COLUMNS_GROUP_MOVEMENT);
-        ImGui.beginDisabled(true);
-        Controls.checkbox(headerLabel(InputRow.Key.W) + "##col_w", true);
-        ImGui.endDisabled();
-        TooltipUtil.onHover(COL_TOGGLE_W_HINT);
-        keyColumnToggle(InputRow.Key.A, settings.showColA, v -> settings.showColA = v);
-        keyColumnToggle(InputRow.Key.S, settings.showColS, v -> settings.showColS = v);
-        keyColumnToggle(InputRow.Key.D, settings.showColD, v -> settings.showColD = v);
-
-        columnsGroupLabel(COLUMNS_GROUP_MODIFIERS);
-        keyColumnToggle(InputRow.Key.SPRINT, settings.showColSprint, v -> settings.showColSprint = v);
-        keyColumnToggle(InputRow.Key.SNEAK, settings.showColSneak, v -> settings.showColSneak = v);
-        keyColumnToggle(InputRow.Key.JUMP, settings.showColJump, v -> settings.showColJump = v);
-
-        columnsGroupLabel(COLUMNS_GROUP_LOOK);
-        columnToggle(COL_YAW, "##col_yaw", settings.showColYaw, v -> settings.showColYaw = v);
-        columnToggle(COL_PITCH, "##col_pitch", settings.showColPitch, v -> settings.showColPitch = v);
-
-        columnsGroupLabel(COLUMNS_GROUP_MOUSE);
-        keyColumnToggle(InputRow.Key.LEFT_CLICK, settings.showColLeftClick, v -> settings.showColLeftClick = v);
-        keyColumnToggle(InputRow.Key.RIGHT_CLICK, settings.showColRightClick, v -> settings.showColRightClick = v);
-
-        columnsGroupLabel(COLUMNS_GROUP_EFFECTS);
-        columnToggle("Speed / Jump Boost", "##col_potion", settings.showPotionColumns, v -> settings.showPotionColumns = v);
-
-        ImGui.endPopup();
-    }
-
-    private void columnsGroupLabel(String label) {
-        if (!label.equals(COLUMNS_GROUP_MOVEMENT)) ThemeManager.sectionSpacing();
-        ImGui.textDisabled(label);
-    }
-
-    private void keyColumnToggle(InputRow.Key key, boolean current, java.util.function.Consumer<Boolean> setter) {
-        String label = headerLabel(key) + "##col_" + key.name();
-        if (Controls.checkbox(label, current)) {
-            setter.accept(!current);
-            notifyColumnsChanged();
-        }
-        TooltipUtil.onHover(headerTooltip(key));
-    }
-
-    private void columnToggle(String label, String id, boolean current, java.util.function.Consumer<Boolean> setter) {
-        if (Controls.checkbox(label + id, current)) {
-            setter.accept(!current);
-            notifyColumnsChanged();
-        }
-    }
-
-    private void notifyColumnsChanged() {
-        if (onSettingsChanged != null) onSettingsChanged.run();
     }
 
     private float tableContentHeight(int rowCount) {
@@ -456,13 +415,13 @@ public final class InputOverlay {
 
     // One scrolling child so expand/collapse keeps its scroll; an expanded tick splits the rows into two
     // segments around the inline drawer (else one culled segment).
-    private void renderInlineSolverBody(boolean solverActive, int drawerRow, boolean potionColumns, int columnCount, float avail) {
+    private void renderInlineSolverBody(boolean solverActive, int drawerRow, int columnCount, float avail) {
         // Sticky header: a header-only twin table above the scroll child. The child always shows
         // its scrollbar so the twin's width (content minus scrollbar) matches the rows exactly.
         float headerTop = ImGui.getCursorPosY();
         float headerW = ImGui.getContentRegionAvail().x - ImGui.getStyle().getScrollbarSize();
         if (ThemeManager.beginStandardTableWithFlags("##tas-header", columnCount, ThemeManager.standardTableFlagsNoScroll(), headerW, 0f)) {
-            setupColumns(potionColumns, solverActive, true, false);
+            setupColumns(solverActive, true, false);
             ThemeManager.endStandardTable();
         }
         ImGui.setCursorPosY(ImGui.getCursorPosY() - ImGui.getStyle().getItemSpacing().y); // rows sit flush under the header
@@ -489,7 +448,7 @@ public final class InputOverlay {
         boolean tickHead = !startOpen;
 
         if (startOpen) {
-            renderInlineSegment("##tas-seg-start", columnCount, potionColumns, solverActive, true, 0, 0, viewTop, viewBot, dragDrop);
+            renderInlineSegment("##tas-seg-start", columnCount, solverActive, true, 0, 0, viewTop, viewBot, dragDrop);
             ImGui.setCursorPosY(ImGui.getCursorPosY() - spacingY);
             float startDrawerTop = ImGui.getCursorScreenPos().y;
             startState.renderDrawer(ImGui.getContentRegionAvail().x);
@@ -500,9 +459,9 @@ public final class InputOverlay {
         }
 
         if (drawerRow < 0) {
-            renderInlineSegment("##tas-seg-a", columnCount, potionColumns, solverActive, tickHead, 0, total, viewTop, viewBot, dragDrop);
+            renderInlineSegment("##tas-seg-a", columnCount, solverActive, tickHead, 0, total, viewTop, viewBot, dragDrop);
         } else {
-            renderInlineSegment("##tas-seg-a", columnCount, potionColumns, solverActive, tickHead, 0, drawerRow + 1, viewTop, viewBot, dragDrop);
+            renderInlineSegment("##tas-seg-a", columnCount, solverActive, tickHead, 0, drawerRow + 1, viewTop, viewBot, dragDrop);
             // The expanded tick is the last row in segment A, so the gutter rect it carried out still bounds it.
             float unionTop = angleSolver.gutterMinY();
             float unionLeft = angleSolver.gutterMinX();
@@ -513,7 +472,7 @@ public final class InputOverlay {
             float unionBottom = ImGui.getCursorScreenPos().y - spacingY;
             if (drawerRow + 1 < total) {
                 ImGui.setCursorPosY(ImGui.getCursorPosY() - spacingY);
-                renderInlineSegment("##tas-seg-b", columnCount, potionColumns, solverActive, false, drawerRow + 1, total, viewTop, viewBot, dragDrop);
+                renderInlineSegment("##tas-seg-b", columnCount, solverActive, false, drawerRow + 1, total, viewTop, viewBot, dragDrop);
             }
             drawDrawerDecorations(angleSolver.drawerDrawList(), clipMin, clipSize,
                     unionLeft, unionTop, unionRight, drawerTop, unionBottom);
@@ -551,13 +510,13 @@ public final class InputOverlay {
         dl.popClipRect();
     }
 
-    private void renderInlineSegment(String id, int columnCount, boolean potionColumns, boolean solverActive, boolean head, int from, int to, float viewTop, float viewBot, DragDropState dragDrop) {
+    private void renderInlineSegment(String id, int columnCount, boolean solverActive, boolean head, int from, int to, float viewTop, float viewBot, DragDropState dragDrop) {
         int flags = ThemeManager.standardTableFlagsNoScroll();
         if (!ThemeManager.beginStandardTableWithFlags(id, columnCount, flags, 0f, 0f)) return;
-        setupColumns(potionColumns, solverActive, false, false); // headers live in the sticky twin table above the scroll child
-        if (head && hasStartRow()) renderStartRowCells(potionColumns, true);
+        setupColumns(solverActive, false, false); // headers live in the sticky twin table above the scroll child
+        if (head && hasStartRow()) renderStartRowCells(true);
         int clampedTo = Math.min(to, data.getRows().size());
-        renderSolverRowsCulled(from, clampedTo, viewTop, viewBot, dragDrop, potionColumns, solverActive);
+        renderSolverRowsCulled(from, clampedTo, viewTop, viewBot, dragDrop, solverActive);
         ThemeManager.endStandardTable();
     }
 
@@ -573,7 +532,7 @@ public final class InputOverlay {
         ThemeManager.popTextColor();
     }
 
-    private void setupColumns(boolean potionColumns, boolean solverActive, boolean renderHeaders, boolean scrollFreeze) {
+    private void setupColumns(boolean solverActive, boolean renderHeaders, boolean scrollFreeze) {
         float scale = uiScale();
         ImGui.tableSetupColumn(COL_INDEX,
                 ImGuiTableColumnFlags.WidthFixed | ImGuiTableColumnFlags.NoResize,
@@ -588,8 +547,15 @@ public final class InputOverlay {
         if (isPitchColumnVisible()) {
             ImGui.tableSetupColumn(COL_PITCH, ImGuiTableColumnFlags.WidthFixed, ThemeManager.tableColumnWidth(COL_PITCH, yawColumnWidth()));
         }
-        if (potionColumns) {
-            ImGui.tableSetupColumn(COL_SPEED, ImGuiTableColumnFlags.WidthFixed, ThemeManager.tableColumnWidth(COL_SPEED, AMP_COLUMN_WIDTH * scale));
+        boolean speed = isSpeedColumnVisible();
+        boolean jump = isJumpBoostColumnVisible();
+        if (speed) {
+            float speedW = jump
+                    ? ThemeManager.tableColumnWidth(COL_SPEED, AMP_COLUMN_WIDTH * scale)
+                    : ThemeManager.tableRightmostColumnWidth(COL_SPEED, AMP_COLUMN_WIDTH * scale, ThemeManager.tableScrollbarSlack());
+            ImGui.tableSetupColumn(COL_SPEED, ImGuiTableColumnFlags.WidthFixed, speedW);
+        }
+        if (jump) {
             ImGui.tableSetupColumn(COL_JUMP_BOOST, ImGuiTableColumnFlags.WidthFixed, ThemeManager.tableRightmostColumnWidth(COL_JUMP_BOOST, AMP_COLUMN_WIDTH * scale, ThemeManager.tableScrollbarSlack()));
         }
         if (solverActive) {
@@ -597,10 +563,10 @@ public final class InputOverlay {
             ImGui.tableSetupColumn(angleSolver.stateColumnHeaderLabel(), ImGuiTableColumnFlags.WidthStretch, 0.8f);
         }
         if (scrollFreeze) ImGui.tableSetupScrollFreeze(1, 1);
-        if (renderHeaders) renderColumnHeadersWithTooltips(potionColumns, solverActive);
+        if (renderHeaders) renderColumnHeadersWithTooltips(solverActive);
     }
 
-    private void renderColumnHeadersWithTooltips(boolean potionColumns, boolean solverActive) {
+    private void renderColumnHeadersWithTooltips(boolean solverActive) {
         ThemeManager.tableHeaderRow();
         ThemeManager.paintTableHeader();
         int col = 0;
@@ -621,10 +587,12 @@ public final class InputOverlay {
             ThemeManager.tableHeaderCentered(COL_PITCH);
             TooltipUtil.onHover(headerColTooltip(COL_PITCH));
         }
-        if (potionColumns) {
+        if (isSpeedColumnVisible()) {
             ImGui.tableSetColumnIndex(col++);
             ThemeManager.tableHeaderCentered(COL_SPEED);
             TooltipUtil.onHover(headerColTooltip(COL_SPEED));
+        }
+        if (isJumpBoostColumnVisible()) {
             ImGui.tableSetColumnIndex(col++);
             ThemeManager.tableHeaderCentered(COL_JUMP_BOOST);
             TooltipUtil.onHover(headerColTooltip(COL_JUMP_BOOST));
@@ -660,7 +628,7 @@ public final class InputOverlay {
         switch (col) {
             case COL_INDEX: return "Tick number (1-based). Each row is one game tick.";
             case COL_YAW: return "Yaw in degrees (-180 to 180). Empty = inherit previous tick's yaw.";
-            case COL_PITCH: return "Pitch in degrees (-90 up to 90 down). Empty = inherit previous tick's pitch.";
+            case COL_PITCH: return "Pitch turn per tick; press F to lock a cell to an absolute pitch (-90 up to 90 down). Empty = inherit previous tick's pitch.";
             case COL_SPEED: return "Speed potion amplifier (none = no effect).";
             case COL_JUMP_BOOST: return "Jump Boost potion amplifier (none = no effect).";
             default: return col;
@@ -693,7 +661,7 @@ public final class InputOverlay {
         }
     }
 
-    private void renderSolverRowsCulled(int from, int to, float viewTop, float viewBot, DragDropState dragDrop, boolean potionColumns, boolean solverActive) {
+    private void renderSolverRowsCulled(int from, int to, float viewTop, float viewBot, DragDropState dragDrop, boolean solverActive) {
         final List<InputRow> rows = data.getRows();
         final float baseRowH = ThemeManager.tableRowHeight();
 
@@ -707,7 +675,7 @@ public final class InputOverlay {
         if (lead > 0f) ImGui.tableNextRow(0, lead);
 
         while (i < to && y <= viewBot) {
-            renderRow(i, rows.get(i), dragDrop, potionColumns, solverActive);
+            renderRow(i, rows.get(i), dragDrop, solverActive);
             y += solverActive ? angleSolver.rowHeight(i, baseRowH) : baseRowH;
             i++;
         }
@@ -738,8 +706,8 @@ public final class InputOverlay {
     private float startGMinY;
     private float startGMaxX;
 
-    private void renderStartRowCells(boolean potionColumns, boolean withChevron) {
-        int columnCount = totalColumnCount(potionColumns, isSolverActive());
+    private void renderStartRowCells(boolean withChevron) {
+        int columnCount = totalColumnCount(isSolverActive());
         float s = uiScale();
         float rowH = ThemeManager.tableRowHeight();
         ImGui.tableNextRow(0, rowH);
@@ -797,7 +765,7 @@ public final class InputOverlay {
         ThemeManager.tableRightmostCellTrailingPad();
     }
 
-    private void renderRow(int index, InputRow row, DragDropState dragDrop, boolean potionColumns, boolean solverActive) {
+    private void renderRow(int index, InputRow row, DragDropState dragDrop, boolean solverActive) {
         ImGui.pushID(row.getId());
         float baseRowH = ThemeManager.tableRowHeight();
         // Wrapping constraint/state chips grow the row; size it to last frame's content so single-line
@@ -830,9 +798,7 @@ public final class InputOverlay {
         renderKeyColumns(row, index, rowH);
         if (isYawColumnVisible()) renderYawColumn(row, index, centerY);
         if (isPitchColumnVisible()) renderPitchColumn(row, index, centerY);
-        if (potionColumns) {
-            renderPotionColumns(row, index);
-        }
+        renderPotionColumns(row, index);
         if (solverActive) {
             ImGui.tableNextColumn();
             angleSolver.renderConstraintsCell(index, rowH);
@@ -1018,7 +984,7 @@ public final class InputOverlay {
         }
         yawCallbackRow = rowIndex;
         boolean changed = Controls.tableInputText(ID_YAW_INPUT, yawInput, inputW, CALLBACK_ALWAYS | CALLBACK_CHAR_FILTER, yawSelectionCallback);
-        if (locked) drawYawLockIcon(lockStripX);
+        if (locked) drawLockIcon(lockStripX);
         if (ImGui.isItemActivated()) {
             editingYawRow = rowIndex;
         }
@@ -1040,7 +1006,7 @@ public final class InputOverlay {
     }
 
     /** Small padlock centered in the reserved strip left of the yaw input, so it never overlaps the value. */
-    private void drawYawLockIcon(float stripLeftX) {
+    private void drawLockIcon(float stripLeftX) {
         ImDrawList dl = ImGui.getWindowDrawList();
         ImVec2 mn = ImGui.getItemRectMin();
         ImVec2 mx = ImGui.getItemRectMax();
@@ -1071,15 +1037,19 @@ public final class InputOverlay {
 
         boolean selectedRow = selection.isSelected(rowIndex);
         boolean populated = pitch != null;
+        boolean locked = row.isPitchLocked();
         if (selectedRow) ThemeManager.pushSelectedFrameBg();
         if (populated) ThemeManager.pushPopulatedFrameBorder();
         float inputW = yawInputWidth();
+        float lockStripX = ImGui.getCursorScreenPos().x;
         ImGui.setCursorPosX(ImGui.getCursorPosX() + yawLockStripWidth());
         if (pendingPitchFocusRow == rowIndex) {
             ImGui.setKeyboardFocusHere();
             pendingPitchFocusRow = -1;
         }
-        boolean changed = Controls.tableInputText(ID_PITCH_INPUT, pitchInput, inputW, 0, null);
+        pitchCallbackRow = rowIndex;
+        boolean changed = Controls.tableInputText(ID_PITCH_INPUT, pitchInput, inputW, CALLBACK_CHAR_FILTER, pitchLockCallback);
+        if (locked) drawLockIcon(lockStripX);
         if (ImGui.isItemActivated()) {
             editingPitchRow = rowIndex;
         }
@@ -1089,6 +1059,11 @@ public final class InputOverlay {
         if (populated) ThemeManager.popPopulatedFrameBorder();
         if (selectedRow) ThemeManager.popSelectedFrameBg();
 
+        if (pendingPitchLockToggleRow == rowIndex) {
+            row.setPitchLocked(!row.isPitchLocked());
+            pendingPitchLockToggleRow = -1;
+            notifyChange(rowIndex);
+        }
         if (changed) {
             parseAndSetPitch(row);
             notifyChange(rowIndex);
@@ -1150,34 +1125,38 @@ public final class InputOverlay {
 
     private void renderPotionColumns(InputRow row, int rowIndex) {
         float ampW = AMP_CELL_WIDTH * uiScale();
-        ImGui.tableNextColumn();
-        ampBuf.set(row.getSpeedAmplifier());
-        ThemeManager.centerNextItem(ampW);
-        if (Controls.tableCombo(ID_SPEED_SUFFIX, ampBuf, AMP_LABELS, ampW)) {
-            row.setSpeedAmplifier(ampBuf.get());
-            notifyChange(rowIndex);
+        if (isSpeedColumnVisible()) {
+            ImGui.tableNextColumn();
+            ampBuf.set(row.getSpeedAmplifier());
+            ThemeManager.centerNextItem(ampW);
+            if (Controls.tableCombo(ID_SPEED_SUFFIX, ampBuf, AMP_LABELS, ampW)) {
+                row.setSpeedAmplifier(ampBuf.get());
+                notifyChange(rowIndex);
+            }
         }
-
-        ImGui.tableNextColumn();
-        ampBuf.set(row.getJumpBoostAmplifier());
-        ThemeManager.centerNextItem(ampW);
-        boolean jumpChanged = Controls.tableCombo(ID_JUMP_SUFFIX, ampBuf, AMP_LABELS, ampW);
-        if (jumpChanged) {
-            row.setJumpBoostAmplifier(ampBuf.get());
-            notifyChange(rowIndex);
+        if (isJumpBoostColumnVisible()) {
+            ImGui.tableNextColumn();
+            ampBuf.set(row.getJumpBoostAmplifier());
+            ThemeManager.centerNextItem(ampW);
+            if (Controls.tableCombo(ID_JUMP_SUFFIX, ampBuf, AMP_LABELS, ampW)) {
+                row.setJumpBoostAmplifier(ampBuf.get());
+                notifyChange(rowIndex);
+            }
         }
     }
 
     private void renderApplyPotionOptions() {
-        if (!settings.showPotionColumns || data.getRows().isEmpty()) return;
+        boolean speed = isSpeedColumnVisible();
+        boolean jump = isJumpBoostColumnVisible();
+        if ((!speed && !jump) || data.getRows().isEmpty()) return;
 
         InputRow first = data.get(0);
         ThemeManager.paddedSeparator();
-        if (contextButton(MENU_APPLY_SPEED_TO_ALL)) {
+        if (speed && contextButton(MENU_APPLY_SPEED_TO_ALL)) {
             applyAmplifierToAll(true, first.getSpeedAmplifier());
             notifyFullResim();
         }
-        if (contextButton(MENU_APPLY_JUMP_TO_ALL)) {
+        if (jump && contextButton(MENU_APPLY_JUMP_TO_ALL)) {
             applyAmplifierToAll(false, first.getJumpBoostAmplifier());
             notifyFullResim();
         }
@@ -1261,6 +1240,7 @@ public final class InputOverlay {
 
         renderApplyPotionOptions();
         renderYawLockOption();
+        renderPitchLockOption();
 
         ThemeManager.paddedSeparator();
         renderRowCountInput();
@@ -1294,6 +1274,33 @@ public final class InputOverlay {
         for (int idx : selection.getSelectedRows()) {
             if (idx < 0 || idx >= data.size()) continue;
             data.get(idx).setYawLocked(locked);
+            if (idx < dirtyTick) dirtyTick = idx;
+        }
+        if (dirtyTick != Integer.MAX_VALUE) notifyChange(dirtyTick);
+    }
+
+    private void renderPitchLockOption() {
+        if (!isPitchColumnVisible() || selection.isEmpty()) return;
+        boolean anyUnlocked = false;
+        for (int idx : selection.getSelected()) {
+            if (idx >= 0 && idx < data.size() && !data.get(idx).isPitchLocked()) {
+                anyUnlocked = true;
+                break;
+            }
+        }
+        ThemeManager.paddedSeparator();
+        if (anyUnlocked) {
+            if (contextButton(MENU_LOCK_PITCH)) setPitchLockForSelection(true);
+        } else {
+            if (contextButton(MENU_UNLOCK_PITCH)) setPitchLockForSelection(false);
+        }
+    }
+
+    private void setPitchLockForSelection(boolean locked) {
+        int dirtyTick = Integer.MAX_VALUE;
+        for (int idx : selection.getSelected()) {
+            if (idx < 0 || idx >= data.size()) continue;
+            data.get(idx).setPitchLocked(locked);
             if (idx < dirtyTick) dirtyTick = idx;
         }
         if (dirtyTick != Integer.MAX_VALUE) notifyChange(dirtyTick);

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputOverlay.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputOverlay.java
@@ -36,6 +36,7 @@ public final class InputOverlay {
     private static final String COL_INDEX = "Tick";
     private static final String START_LABEL = "Start";
     private static final String COL_YAW = "Yaw";
+    private static final String COL_PITCH = "Pit";
     private static final String COL_SPEED = "Speed";
     private static final String COL_JUMP_BOOST = "Jump";
     private static final float INDEX_DIGIT_WIDTH = 32f;
@@ -48,9 +49,13 @@ public final class InputOverlay {
     private static final InputRow.Key[] MODIFIER_KEYS = {
             InputRow.Key.SPRINT, InputRow.Key.SNEAK, InputRow.Key.JUMP
     };
+    private static final InputRow.Key[] MOUSE_KEYS = {
+            InputRow.Key.LEFT_CLICK, InputRow.Key.RIGHT_CLICK
+    };
 
     private static final String ID_SPEED_SUFFIX = "##speed";
     private static final String ID_JUMP_SUFFIX = "##jump";
+    private static final String ID_PITCH_INPUT = "##pitch";
 
     private static final String MENU_APPLY_SPEED_TO_ALL = "Apply tick 1 Speed to all rows";
     private static final String MENU_APPLY_JUMP_TO_ALL = "Apply tick 1 Jump to all rows";
@@ -78,7 +83,16 @@ public final class InputOverlay {
 
     private static final String DRAG_DROP_TYPE = "INPUT_ROW";
 
-    private static final int BASE_COLUMN_COUNT = 9;
+    private static final String ID_COLUMNS_POPUP = "columns_popup";
+    private static final String BTN_COLUMNS = "Columns";
+    private static final String COLUMNS_GROUP_MOVEMENT = "Movement";
+    private static final String COLUMNS_GROUP_MODIFIERS = "Modifiers";
+    private static final String COLUMNS_GROUP_LOOK = "Look";
+    private static final String COLUMNS_GROUP_MOUSE = "Mouse";
+    private static final String COLUMNS_GROUP_EFFECTS = "Effects";
+    private static final String COL_TOGGLE_W_HINT = "W is always shown";
+    private static final String PITCH_FORMAT_DISPLAY = "% 12.6f";
+
     private static final int POTION_COLUMN_COUNT = 2;
     private static final int SOLVER_COLUMN_COUNT = 2; // Constraints + State
     private static final float SOLVER_CULL_OVERSCAN = 4f; // extra rows rendered above/below the viewport
@@ -93,6 +107,7 @@ public final class InputOverlay {
     private final Settings settings;
     private final IntConsumer onDataChangedAt;
     private final Runnable onSetPlayerPosition;
+    private final Runnable onSettingsChanged;
     private final PlaybackController playback;
     private final MinecraftAccess mc;
     private final BoxController boxController;
@@ -100,11 +115,14 @@ public final class InputOverlay {
     private final SelectionManager selection;
     private final KeyDragSelect keyDragSelect = new KeyDragSelect();
     private final ImString yawInput = new ImString(32);
+    private final ImString pitchInput = new ImString(32);
     private final ImInt rowsToAdd = new ImInt(1);
     private final ImInt ampBuf = new ImInt();
 
     private int draggingRowIndex = -1;
     private int editingYawRow = -1;
+    private int editingPitchRow = -1;
+    private int pendingPitchFocusRow = -1;
     private int pendingYawFocusRow = -1;
     private int collapseYawSelectionRow = -1;
     private int collapseYawFramesLeft;
@@ -153,13 +171,15 @@ public final class InputOverlay {
     }
 
     public InputOverlay(InputData data, Settings settings, SelectionManager selection, IntConsumer onDataChangedAt,
-                        Runnable onSetPlayerPosition, PlaybackController playback, MinecraftAccess mc, BoxController boxController
+                        Runnable onSetPlayerPosition, Runnable onSettingsChanged, PlaybackController playback,
+                        MinecraftAccess mc, BoxController boxController
     ) {
         this.data = data;
         this.settings = settings;
         this.selection = selection;
         this.onDataChangedAt = onDataChangedAt;
         this.onSetPlayerPosition = onSetPlayerPosition;
+        this.onSettingsChanged = onSettingsChanged;
         this.playback = playback;
         this.mc = mc;
         this.boxController = boxController;
@@ -230,10 +250,49 @@ public final class InputOverlay {
         return ImGui.getFrameHeight() * 0.8f;
     }
 
+    private boolean isKeyColumnVisible(InputRow.Key key) {
+        switch (key) {
+            case W: return true;
+            case A: return settings.showColA;
+            case S: return settings.showColS;
+            case D: return settings.showColD;
+            case SPRINT: return settings.showColSprint;
+            case SNEAK: return settings.showColSneak;
+            case JUMP: return settings.showColJump;
+            case LEFT_CLICK: return settings.showColLeftClick;
+            case RIGHT_CLICK: return settings.showColRightClick;
+            default: return true;
+        }
+    }
+
+    private boolean isYawColumnVisible() {
+        return settings.showColYaw;
+    }
+
+    private boolean isPitchColumnVisible() {
+        return settings.showColPitch;
+    }
+
+    private int baseColumnCount() {
+        int count = 1;
+        for (InputRow.Key key : MOVEMENT_KEYS) if (isKeyColumnVisible(key)) count++;
+        for (InputRow.Key key : MODIFIER_KEYS) if (isKeyColumnVisible(key)) count++;
+        for (InputRow.Key key : MOUSE_KEYS) if (isKeyColumnVisible(key)) count++;
+        if (isYawColumnVisible()) count++;
+        if (isPitchColumnVisible()) count++;
+        return count;
+    }
+
+    private int totalColumnCount(boolean potionColumns, boolean solverActive) {
+        return baseColumnCount()
+                + (potionColumns ? POTION_COLUMN_COUNT : 0)
+                + (solverActive ? SOLVER_COLUMN_COUNT : 0);
+    }
+
     public float desiredPaneWidth() {
         boolean potion = settings.showPotionColumns;
         boolean solver = isSolverActive();
-        int columnCount = BASE_COLUMN_COUNT + (potion ? POTION_COLUMN_COUNT : 0) + (solver ? SOLVER_COLUMN_COUNT : 0);
+        int columnCount = totalColumnCount(potion, solver);
 
         ImGuiStyle style = ImGui.getStyle();
         float cellPadX = style.getCellPadding().x;
@@ -241,12 +300,17 @@ public final class InputOverlay {
         float borderSlop = 2f;
         float scale = uiScale();
 
-        float columnSum = ThemeManager.tableLeftmostColumnWidth(COL_INDEX, indexColumnDataWidth()) + ThemeManager.tableColumnWidth(COL_YAW, yawColumnWidth());
+        float columnSum = ThemeManager.tableLeftmostColumnWidth(COL_INDEX, indexColumnDataWidth());
+        if (isYawColumnVisible()) columnSum += ThemeManager.tableColumnWidth(COL_YAW, yawColumnWidth());
+        if (isPitchColumnVisible()) columnSum += ThemeManager.tableColumnWidth(COL_PITCH, yawColumnWidth());
         for (InputRow.Key key : MOVEMENT_KEYS) {
-            columnSum += ThemeManager.tableColumnWidth(headerLabel(key), 0f);
+            if (isKeyColumnVisible(key)) columnSum += ThemeManager.tableColumnWidth(headerLabel(key), 0f);
         }
         for (InputRow.Key key : MODIFIER_KEYS) {
-            columnSum += ThemeManager.tableColumnWidth(headerLabel(key), 0f);
+            if (isKeyColumnVisible(key)) columnSum += ThemeManager.tableColumnWidth(headerLabel(key), 0f);
+        }
+        for (InputRow.Key key : MOUSE_KEYS) {
+            if (isKeyColumnVisible(key)) columnSum += ThemeManager.tableColumnWidth(headerLabel(key), 0f);
         }
         if (potion) {
             columnSum += ThemeManager.tableColumnWidth(COL_SPEED, AMP_COLUMN_WIDTH * scale) + ThemeManager.tableRightmostColumnWidth(COL_JUMP_BOOST, AMP_COLUMN_WIDTH * scale, ThemeManager.tableScrollbarSlack());
@@ -259,10 +323,8 @@ public final class InputOverlay {
         return contentW + 2f * winPadX;
     }
 
-    // Smallest width that still shows the frozen Tick column plus W/A/S/D; everything
-    // past it (modifiers, yaw, potions) is reached by the table's horizontal scroll.
     public float minUsablePaneWidth() {
-        int columnCount = 1 + MOVEMENT_KEYS.length;
+        int columnCount = 1;
 
         ImGuiStyle style = ImGui.getStyle();
         float cellPadX = style.getCellPadding().x;
@@ -271,7 +333,9 @@ public final class InputOverlay {
 
         float columnSum = ThemeManager.tableLeftmostColumnWidth(COL_INDEX, indexColumnDataWidth());
         for (InputRow.Key key : MOVEMENT_KEYS) {
+            if (!isKeyColumnVisible(key)) continue;
             columnSum += ThemeManager.tableColumnWidth(headerLabel(key), 0f);
+            columnCount++;
         }
 
         float contentW = columnSum + 2f * cellPadX * columnCount + borderSlop;
@@ -289,10 +353,11 @@ public final class InputOverlay {
 
     private void renderBodyInternal() {
         renderMultiplayerWarning();
+        renderColumnsControl();
 
         boolean solverActive = isSolverActive();
         boolean potionColumns = settings.showPotionColumns;
-        int columnCount = BASE_COLUMN_COUNT + (potionColumns ? POTION_COLUMN_COUNT : 0) + (solverActive ? SOLVER_COLUMN_COUNT : 0);
+        int columnCount = totalColumnCount(potionColumns, solverActive);
 
         int drawerRow = clampedExpandedRow();
         float footerH = footerHeightProvider.get();
@@ -308,6 +373,70 @@ public final class InputOverlay {
         if (dragChangeStart >= 0) {
             notifyChange(dragChangeStart);
         }
+    }
+
+    private void renderColumnsControl() {
+        if (Controls.secondaryButton(BTN_COLUMNS)) {
+            ImGui.openPopup(ID_COLUMNS_POPUP);
+        }
+        TooltipUtil.onHover("Show or hide input columns. Hidden columns keep their values.");
+        renderColumnsPopup();
+    }
+
+    private void renderColumnsPopup() {
+        if (!ImGui.beginPopup(ID_COLUMNS_POPUP)) return;
+
+        columnsGroupLabel(COLUMNS_GROUP_MOVEMENT);
+        ImGui.beginDisabled(true);
+        Controls.checkbox(headerLabel(InputRow.Key.W) + "##col_w", true);
+        ImGui.endDisabled();
+        TooltipUtil.onHover(COL_TOGGLE_W_HINT);
+        keyColumnToggle(InputRow.Key.A, settings.showColA, v -> settings.showColA = v);
+        keyColumnToggle(InputRow.Key.S, settings.showColS, v -> settings.showColS = v);
+        keyColumnToggle(InputRow.Key.D, settings.showColD, v -> settings.showColD = v);
+
+        columnsGroupLabel(COLUMNS_GROUP_MODIFIERS);
+        keyColumnToggle(InputRow.Key.SPRINT, settings.showColSprint, v -> settings.showColSprint = v);
+        keyColumnToggle(InputRow.Key.SNEAK, settings.showColSneak, v -> settings.showColSneak = v);
+        keyColumnToggle(InputRow.Key.JUMP, settings.showColJump, v -> settings.showColJump = v);
+
+        columnsGroupLabel(COLUMNS_GROUP_LOOK);
+        columnToggle(COL_YAW, "##col_yaw", settings.showColYaw, v -> settings.showColYaw = v);
+        columnToggle(COL_PITCH, "##col_pitch", settings.showColPitch, v -> settings.showColPitch = v);
+
+        columnsGroupLabel(COLUMNS_GROUP_MOUSE);
+        keyColumnToggle(InputRow.Key.LEFT_CLICK, settings.showColLeftClick, v -> settings.showColLeftClick = v);
+        keyColumnToggle(InputRow.Key.RIGHT_CLICK, settings.showColRightClick, v -> settings.showColRightClick = v);
+
+        columnsGroupLabel(COLUMNS_GROUP_EFFECTS);
+        columnToggle("Speed / Jump Boost", "##col_potion", settings.showPotionColumns, v -> settings.showPotionColumns = v);
+
+        ImGui.endPopup();
+    }
+
+    private void columnsGroupLabel(String label) {
+        if (!label.equals(COLUMNS_GROUP_MOVEMENT)) ThemeManager.sectionSpacing();
+        ImGui.textDisabled(label);
+    }
+
+    private void keyColumnToggle(InputRow.Key key, boolean current, java.util.function.Consumer<Boolean> setter) {
+        String label = headerLabel(key) + "##col_" + key.name();
+        if (Controls.checkbox(label, current)) {
+            setter.accept(!current);
+            notifyColumnsChanged();
+        }
+        TooltipUtil.onHover(headerTooltip(key));
+    }
+
+    private void columnToggle(String label, String id, boolean current, java.util.function.Consumer<Boolean> setter) {
+        if (Controls.checkbox(label + id, current)) {
+            setter.accept(!current);
+            notifyColumnsChanged();
+        }
+    }
+
+    private void notifyColumnsChanged() {
+        if (onSettingsChanged != null) onSettingsChanged.run();
     }
 
     private float tableContentHeight(int rowCount) {
@@ -450,15 +579,15 @@ public final class InputOverlay {
                 ImGuiTableColumnFlags.WidthFixed | ImGuiTableColumnFlags.NoResize,
                 ThemeManager.tableLeftmostColumnWidth(COL_INDEX, indexColumnDataWidth())
         );
-        for (InputRow.Key key : MOVEMENT_KEYS) {
-            String label = headerLabel(key);
-            ImGui.tableSetupColumn(label, ImGuiTableColumnFlags.WidthFixed, ThemeManager.tableNumericColumnWidth(label, 0f));
+        setupKeyColumns(MOVEMENT_KEYS);
+        setupKeyColumns(MODIFIER_KEYS);
+        setupKeyColumns(MOUSE_KEYS);
+        if (isYawColumnVisible()) {
+            ImGui.tableSetupColumn(COL_YAW, ImGuiTableColumnFlags.WidthFixed, ThemeManager.tableColumnWidth(COL_YAW, yawColumnWidth()));
         }
-        for (InputRow.Key key : MODIFIER_KEYS) {
-            String label = headerLabel(key);
-            ImGui.tableSetupColumn(label, ImGuiTableColumnFlags.WidthFixed, ThemeManager.tableNumericColumnWidth(label, 0f));
+        if (isPitchColumnVisible()) {
+            ImGui.tableSetupColumn(COL_PITCH, ImGuiTableColumnFlags.WidthFixed, ThemeManager.tableColumnWidth(COL_PITCH, yawColumnWidth()));
         }
-        ImGui.tableSetupColumn(COL_YAW, ImGuiTableColumnFlags.WidthFixed, ThemeManager.tableColumnWidth(COL_YAW, yawColumnWidth()));
         if (potionColumns) {
             ImGui.tableSetupColumn(COL_SPEED, ImGuiTableColumnFlags.WidthFixed, ThemeManager.tableColumnWidth(COL_SPEED, AMP_COLUMN_WIDTH * scale));
             ImGui.tableSetupColumn(COL_JUMP_BOOST, ImGuiTableColumnFlags.WidthFixed, ThemeManager.tableRightmostColumnWidth(COL_JUMP_BOOST, AMP_COLUMN_WIDTH * scale, ThemeManager.tableScrollbarSlack()));
@@ -481,9 +610,17 @@ public final class InputOverlay {
         TooltipUtil.onHover(headerColTooltip(COL_INDEX));
         col = renderKeyColumnHeaders(MOVEMENT_KEYS, col);
         col = renderKeyColumnHeaders(MODIFIER_KEYS, col);
-        ImGui.tableSetColumnIndex(col++);
-        ThemeManager.tableHeaderCentered(COL_YAW);
-        TooltipUtil.onHover(headerColTooltip(COL_YAW));
+        col = renderKeyColumnHeaders(MOUSE_KEYS, col);
+        if (isYawColumnVisible()) {
+            ImGui.tableSetColumnIndex(col++);
+            ThemeManager.tableHeaderCentered(COL_YAW);
+            TooltipUtil.onHover(headerColTooltip(COL_YAW));
+        }
+        if (isPitchColumnVisible()) {
+            ImGui.tableSetColumnIndex(col++);
+            ThemeManager.tableHeaderCentered(COL_PITCH);
+            TooltipUtil.onHover(headerColTooltip(COL_PITCH));
+        }
         if (potionColumns) {
             ImGui.tableSetColumnIndex(col++);
             ThemeManager.tableHeaderCentered(COL_SPEED);
@@ -501,8 +638,17 @@ public final class InputOverlay {
         ThemeManager.tableRightmostCellTrailingPad();
     }
 
+    private void setupKeyColumns(InputRow.Key[] keys) {
+        for (InputRow.Key key : keys) {
+            if (!isKeyColumnVisible(key)) continue;
+            String label = headerLabel(key);
+            ImGui.tableSetupColumn(label, ImGuiTableColumnFlags.WidthFixed, ThemeManager.tableNumericColumnWidth(label, 0f));
+        }
+    }
+
     private int renderKeyColumnHeaders(InputRow.Key[] keys, int col) {
         for (InputRow.Key key : keys) {
+            if (!isKeyColumnVisible(key)) continue;
             ImGui.tableSetColumnIndex(col++);
             ThemeManager.tableHeaderCentered(headerLabel(key));
             TooltipUtil.onHover(headerTooltip(key));
@@ -514,6 +660,7 @@ public final class InputOverlay {
         switch (col) {
             case COL_INDEX: return "Tick number (1-based). Each row is one game tick.";
             case COL_YAW: return "Yaw in degrees (-180 to 180). Empty = inherit previous tick's yaw.";
+            case COL_PITCH: return "Pitch in degrees (-90 up to 90 down). Empty = inherit previous tick's pitch.";
             case COL_SPEED: return "Speed potion amplifier (none = no effect).";
             case COL_JUMP_BOOST: return "Jump Boost potion amplifier (none = no effect).";
             default: return col;
@@ -525,6 +672,8 @@ public final class InputOverlay {
             case SPRINT: return "Spr";
             case SNEAK: return "Snk";
             case JUMP: return "Spc";
+            case LEFT_CLICK: return "LMB";
+            case RIGHT_CLICK: return "RMB";
             default: return key.name();
         }
     }
@@ -538,6 +687,8 @@ public final class InputOverlay {
             case SPRINT: return "Sprint hold (Ctrl)";
             case SNEAK: return "Sneak hold (Shift)";
             case JUMP: return "Jump (Space)";
+            case LEFT_CLICK: return "Left click / attack (hold)";
+            case RIGHT_CLICK: return "Right click / use (hold)";
             default: return key.name();
         }
     }
@@ -588,7 +739,7 @@ public final class InputOverlay {
     private float startGMaxX;
 
     private void renderStartRowCells(boolean potionColumns, boolean withChevron) {
-        int columnCount = BASE_COLUMN_COUNT + (potionColumns ? POTION_COLUMN_COUNT : 0) + (isSolverActive() ? SOLVER_COLUMN_COUNT : 0);
+        int columnCount = totalColumnCount(potionColumns, isSolverActive());
         float s = uiScale();
         float rowH = ThemeManager.tableRowHeight();
         ImGui.tableNextRow(0, rowH);
@@ -677,7 +828,8 @@ public final class InputOverlay {
         }
 
         renderKeyColumns(row, index, rowH);
-        renderYawColumn(row, index, centerY);
+        if (isYawColumnVisible()) renderYawColumn(row, index, centerY);
+        if (isPitchColumnVisible()) renderPitchColumn(row, index, centerY);
         if (potionColumns) {
             renderPotionColumns(row, index);
         }
@@ -798,10 +950,14 @@ public final class InputOverlay {
     }
 
     private void renderKeyColumns(InputRow row, int rowIndex, float rowH) {
-        for (InputRow.Key key : MOVEMENT_KEYS) {
-            renderKeyCell(row, rowIndex, key, rowH);
-        }
-        for (InputRow.Key key : MODIFIER_KEYS) {
+        renderKeyCells(row, rowIndex, rowH, MOVEMENT_KEYS);
+        renderKeyCells(row, rowIndex, rowH, MODIFIER_KEYS);
+        renderKeyCells(row, rowIndex, rowH, MOUSE_KEYS);
+    }
+
+    private void renderKeyCells(InputRow row, int rowIndex, float rowH, InputRow.Key[] keys) {
+        for (InputRow.Key key : keys) {
+            if (!isKeyColumnVisible(key)) continue;
             renderKeyCell(row, rowIndex, key, rowH);
         }
     }
@@ -902,6 +1058,43 @@ public final class InputOverlay {
         dl.addCircle(cx, bodyTop, shackleR, color, 12, 1.5f);
     }
 
+    private void renderPitchColumn(InputRow row, int rowIndex, float centerY) {
+        ImGui.tableNextColumn();
+        if (centerY > 0f) ImGui.setCursorPosY(ImGui.getCursorPosY() + centerY);
+
+        Float pitch = row.getPitch();
+        if (pitch == null) {
+            pitchInput.set("");
+        } else {
+            pitchInput.set(String.format(Locale.ROOT, PITCH_FORMAT_DISPLAY, pitch));
+        }
+
+        boolean selectedRow = selection.isSelected(rowIndex);
+        boolean populated = pitch != null;
+        if (selectedRow) ThemeManager.pushSelectedFrameBg();
+        if (populated) ThemeManager.pushPopulatedFrameBorder();
+        float inputW = yawInputWidth();
+        ImGui.setCursorPosX(ImGui.getCursorPosX() + yawLockStripWidth());
+        if (pendingPitchFocusRow == rowIndex) {
+            ImGui.setKeyboardFocusHere();
+            pendingPitchFocusRow = -1;
+        }
+        boolean changed = Controls.tableInputText(ID_PITCH_INPUT, pitchInput, inputW, 0, null);
+        if (ImGui.isItemActivated()) {
+            editingPitchRow = rowIndex;
+        }
+        if (editingPitchRow == rowIndex && ImGui.isItemDeactivated()) {
+            editingPitchRow = -1;
+        }
+        if (populated) ThemeManager.popPopulatedFrameBorder();
+        if (selectedRow) ThemeManager.popSelectedFrameBg();
+
+        if (changed) {
+            parseAndSetPitch(row);
+            notifyChange(rowIndex);
+        }
+    }
+
     public boolean isEditingYaw() {
         return editingYawRow >= 0;
     }
@@ -909,6 +1102,11 @@ public final class InputOverlay {
     public String playbackStatusHint() {
         return playback != null ? playback.statusHint() : "";
     }
+
+    public boolean isEditingPitch() {
+        return editingPitchRow >= 0;
+    }
+
 
     public void navigateYaw(boolean forward) {
         int from = editingYawRow;
@@ -1002,6 +1200,21 @@ public final class InputOverlay {
         } else {
             try {
                 row.setYaw(Float.parseFloat(text));
+            } catch (NumberFormatException ignored) {
+            }
+        }
+    }
+
+    private void parseAndSetPitch(InputRow row) {
+        String text = pitchInput.get().trim();
+        if (text.isEmpty()) {
+            row.setPitch(null);
+        } else {
+            try {
+                float p = Float.parseFloat(text);
+                if (p < -90f) p = -90f;
+                if (p > 90f) p = 90f;
+                row.setPitch(p);
             } catch (NumberFormatException ignored) {
             }
         }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputRow.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputRow.java
@@ -13,11 +13,13 @@ public class InputRow {
     private final Set<Key> activeKeys = EnumSet.noneOf(Key.class);
     private Float yaw;
     private boolean yawLocked;
+    private Float pitch;
     private int speedAmplifier;
     private int jumpBoostAmplifier;
 
+    // LEFT_CLICK / RIGHT_CLICK appended last to keep existing ordinals stable for old saves.
     public enum Key {
-        W, A, S, D, SPRINT, SNEAK, JUMP
+        W, A, S, D, SPRINT, SNEAK, JUMP, LEFT_CLICK, RIGHT_CLICK
     }
 
     public InputRow() {
@@ -56,6 +58,14 @@ public class InputRow {
         this.yawLocked = yawLocked;
     }
 
+    public Float getPitch() {
+        return pitch;
+    }
+
+    public void setPitch(Float pitch) {
+        this.pitch = pitch;
+    }
+
     public int getSpeedAmplifier() {
         return speedAmplifier;
     }
@@ -83,6 +93,7 @@ public class InputRow {
         copy.activeKeys.addAll(this.activeKeys);
         copy.yaw = this.yaw;
         copy.yawLocked = this.yawLocked;
+        copy.pitch = this.pitch;
         copy.speedAmplifier = this.speedAmplifier;
         copy.jumpBoostAmplifier = this.jumpBoostAmplifier;
         return copy;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputRow.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputRow.java
@@ -14,6 +14,7 @@ public class InputRow {
     private Float yaw;
     private boolean yawLocked;
     private Float pitch;
+    private boolean pitchLocked;
     private int speedAmplifier;
     private int jumpBoostAmplifier;
 
@@ -66,6 +67,14 @@ public class InputRow {
         this.pitch = pitch;
     }
 
+    public boolean isPitchLocked() {
+        return pitchLocked;
+    }
+
+    public void setPitchLocked(boolean pitchLocked) {
+        this.pitchLocked = pitchLocked;
+    }
+
     public int getSpeedAmplifier() {
         return speedAmplifier;
     }
@@ -94,6 +103,7 @@ public class InputRow {
         copy.yaw = this.yaw;
         copy.yawLocked = this.yawLocked;
         copy.pitch = this.pitch;
+        copy.pitchLocked = this.pitchLocked;
         copy.speedAmplifier = this.speedAmplifier;
         copy.jumpBoostAmplifier = this.jumpBoostAmplifier;
         return copy;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/Settings.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/Settings.java
@@ -27,6 +27,17 @@ public final class Settings {
     private static final boolean DEFAULT_SHOW_POTION_COLUMNS = false;
     private static final boolean DEFAULT_HIGHLIGHT_ON_GROUND_ROWS = true;
 
+    private static final boolean DEFAULT_SHOW_COL_A = true;
+    private static final boolean DEFAULT_SHOW_COL_S = true;
+    private static final boolean DEFAULT_SHOW_COL_D = true;
+    private static final boolean DEFAULT_SHOW_COL_SPRINT = true;
+    private static final boolean DEFAULT_SHOW_COL_SNEAK = true;
+    private static final boolean DEFAULT_SHOW_COL_JUMP = true;
+    private static final boolean DEFAULT_SHOW_COL_YAW = true;
+    private static final boolean DEFAULT_SHOW_COL_PITCH = false;
+    private static final boolean DEFAULT_SHOW_COL_LEFT_CLICK = false;
+    private static final boolean DEFAULT_SHOW_COL_RIGHT_CLICK = false;
+
     private static final boolean DEFAULT_VIEW_TICK_INFO = true;
     private static final boolean DEFAULT_VIEW_PERF_INFO = false;
     private static final boolean DEFAULT_VIEW_ANGLE_SOLVER = false;
@@ -81,6 +92,17 @@ public final class Settings {
     public boolean showSubtick = DEFAULT_SHOW_SUBTICK;
     public boolean showPotionColumns = DEFAULT_SHOW_POTION_COLUMNS;
     public boolean highlightOnGroundRows = DEFAULT_HIGHLIGHT_ON_GROUND_ROWS;
+
+    public boolean showColA = DEFAULT_SHOW_COL_A;
+    public boolean showColS = DEFAULT_SHOW_COL_S;
+    public boolean showColD = DEFAULT_SHOW_COL_D;
+    public boolean showColSprint = DEFAULT_SHOW_COL_SPRINT;
+    public boolean showColSneak = DEFAULT_SHOW_COL_SNEAK;
+    public boolean showColJump = DEFAULT_SHOW_COL_JUMP;
+    public boolean showColYaw = DEFAULT_SHOW_COL_YAW;
+    public boolean showColPitch = DEFAULT_SHOW_COL_PITCH;
+    public boolean showColLeftClick = DEFAULT_SHOW_COL_LEFT_CLICK;
+    public boolean showColRightClick = DEFAULT_SHOW_COL_RIGHT_CLICK;
 
     public float yawFlickSpeed = DEFAULT_YAW_FLICK_SPEED;
 
@@ -143,6 +165,16 @@ public final class Settings {
         showSubtick = DEFAULT_SHOW_SUBTICK;
         showPotionColumns = DEFAULT_SHOW_POTION_COLUMNS;
         highlightOnGroundRows = DEFAULT_HIGHLIGHT_ON_GROUND_ROWS;
+        showColA = DEFAULT_SHOW_COL_A;
+        showColS = DEFAULT_SHOW_COL_S;
+        showColD = DEFAULT_SHOW_COL_D;
+        showColSprint = DEFAULT_SHOW_COL_SPRINT;
+        showColSneak = DEFAULT_SHOW_COL_SNEAK;
+        showColJump = DEFAULT_SHOW_COL_JUMP;
+        showColYaw = DEFAULT_SHOW_COL_YAW;
+        showColPitch = DEFAULT_SHOW_COL_PITCH;
+        showColLeftClick = DEFAULT_SHOW_COL_LEFT_CLICK;
+        showColRightClick = DEFAULT_SHOW_COL_RIGHT_CLICK;
         yawFlickSpeed = DEFAULT_YAW_FLICK_SPEED;
         autoSave = DEFAULT_AUTO_SAVE;
         pathRenderDistance = DEFAULT_PATH_RENDER_DISTANCE;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/Settings.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/Settings.java
@@ -24,7 +24,8 @@ public final class Settings {
     private static final boolean DEFAULT_SHOW_HITBOX = false;
     private static final boolean DEFAULT_SHOW_FULL_HITBOX = false;
     private static final boolean DEFAULT_SHOW_SUBTICK = false;
-    private static final boolean DEFAULT_SHOW_POTION_COLUMNS = false;
+    private static final boolean DEFAULT_SHOW_COL_SPEED = false;
+    private static final boolean DEFAULT_SHOW_COL_JUMP_BOOST = false;
     private static final boolean DEFAULT_HIGHLIGHT_ON_GROUND_ROWS = true;
 
     private static final boolean DEFAULT_SHOW_COL_A = true;
@@ -90,7 +91,8 @@ public final class Settings {
     public boolean showHitbox = DEFAULT_SHOW_HITBOX;
     public boolean showFullHitbox = DEFAULT_SHOW_FULL_HITBOX;
     public boolean showSubtick = DEFAULT_SHOW_SUBTICK;
-    public boolean showPotionColumns = DEFAULT_SHOW_POTION_COLUMNS;
+    public boolean showColSpeed = DEFAULT_SHOW_COL_SPEED;
+    public boolean showColJumpBoost = DEFAULT_SHOW_COL_JUMP_BOOST;
     public boolean highlightOnGroundRows = DEFAULT_HIGHLIGHT_ON_GROUND_ROWS;
 
     public boolean showColA = DEFAULT_SHOW_COL_A;
@@ -163,7 +165,8 @@ public final class Settings {
         showHitbox = DEFAULT_SHOW_HITBOX;
         showFullHitbox = DEFAULT_SHOW_FULL_HITBOX;
         showSubtick = DEFAULT_SHOW_SUBTICK;
-        showPotionColumns = DEFAULT_SHOW_POTION_COLUMNS;
+        showColSpeed = DEFAULT_SHOW_COL_SPEED;
+        showColJumpBoost = DEFAULT_SHOW_COL_JUMP_BOOST;
         highlightOnGroundRows = DEFAULT_HIGHLIGHT_ON_GROUND_ROWS;
         showColA = DEFAULT_SHOW_COL_A;
         showColS = DEFAULT_SHOW_COL_S;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/SettingsModal.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/SettingsModal.java
@@ -29,8 +29,20 @@ public final class SettingsModal {
     private static final String TT_HITBOX = "Draws the player's hitbox at the currently selected tick.";
     private static final String TT_FULL_HITBOX = "Draws hitboxes for every tick in the TAS, not just the active one. Heavy on long TASes.";
     private static final String TT_SUBTICK = "Renders the interpolated path between adjacent ticks, exposing collision moments inside a tick.";
-    private static final String TT_POTION_COLS = "Adds Speed and Jump Boost amplifier columns to the input table.";
+    private static final String TT_COL_SPEED_AMP = "Adds a per-tick Speed potion amplifier column to the input table.";
+    private static final String TT_COL_JUMP_BOOST_AMP = "Adds a per-tick Jump Boost potion amplifier column to the input table.";
     private static final String TT_GROUND_HIGHLIGHT = "Tints input rows whose simulated tick ended on the ground. Color is editable in Render Colors.";
+    private static final String TT_COL_W = "W (forward) is always shown and can't be hidden.";
+    private static final String TT_COL_A = "Strafe-left (A) column.";
+    private static final String TT_COL_S = "Backward (S) column.";
+    private static final String TT_COL_D = "Strafe-right (D) column.";
+    private static final String TT_COL_SPRINT = "Sprint (Ctrl) column.";
+    private static final String TT_COL_SNEAK = "Sneak (Shift) column.";
+    private static final String TT_COL_JUMP = "Jump (Space) column.";
+    private static final String TT_COL_YAW = "Yaw angle column.";
+    private static final String TT_COL_PITCH = "Pitch angle column.";
+    private static final String TT_COL_LMB = "Left click / attack column.";
+    private static final String TT_COL_RMB = "Right click / use column.";
     private static final String TT_YAW_TURN_RATE = "Caps how fast the macro rotates the camera during playback (deg per second).";
     private static final String TT_PATH_DIST = "Maximum world distance for the simulated path overlay.";
     private static final String TT_PATH_UNLIMITED = "Disables the distance cap. Heavy on long TASes.";
@@ -99,6 +111,10 @@ public final class SettingsModal {
             }
             if (Controls.beginTab("Visualization")) {
                 renderVisualization();
+                Controls.endTab();
+            }
+            if (Controls.beginTab("Input Table")) {
+                renderInputTable();
                 Controls.endTab();
             }
             if (Controls.beginTab("Playback")) {
@@ -236,11 +252,31 @@ public final class SettingsModal {
             checkboxRow("Unlimited path render distance", "##unlimited_path", settings.unlimitedPathRender, TT_PATH_UNLIMITED, v -> settings.unlimitedPathRender = v);
             ThemeManager.endStandardFormTable();
         }
+    }
+
+    private void renderInputTable() {
+        ThemeManager.sectionSpacing();
+        sectionHeader("Visible columns");
+        if (beginLayoutTable("##settings_columns")) {
+            disabledCheckboxRow("Forward (W)", "##col_w", true, TT_COL_W);
+            checkboxRow("Strafe left (A)", "##col_a", settings.showColA, TT_COL_A, v -> settings.showColA = v);
+            checkboxRow("Backward (S)", "##col_s", settings.showColS, TT_COL_S, v -> settings.showColS = v);
+            checkboxRow("Strafe right (D)", "##col_d", settings.showColD, TT_COL_D, v -> settings.showColD = v);
+            checkboxRow("Sprint", "##col_sprint", settings.showColSprint, TT_COL_SPRINT, v -> settings.showColSprint = v);
+            checkboxRow("Sneak", "##col_sneak", settings.showColSneak, TT_COL_SNEAK, v -> settings.showColSneak = v);
+            checkboxRow("Jump", "##col_jump", settings.showColJump, TT_COL_JUMP, v -> settings.showColJump = v);
+            checkboxRow("Yaw", "##col_yaw", settings.showColYaw, TT_COL_YAW, v -> settings.showColYaw = v);
+            checkboxRow("Pitch", "##col_pitch", settings.showColPitch, TT_COL_PITCH, v -> settings.showColPitch = v);
+            checkboxRow("Left click (LMB)", "##col_lmb", settings.showColLeftClick, TT_COL_LMB, v -> settings.showColLeftClick = v);
+            checkboxRow("Right click (RMB)", "##col_rmb", settings.showColRightClick, TT_COL_RMB, v -> settings.showColRightClick = v);
+            checkboxRow("Speed", "##show_speed", settings.showColSpeed, TT_COL_SPEED_AMP, v -> settings.showColSpeed = v);
+            checkboxRow("Jump Boost", "##show_jump_boost", settings.showColJumpBoost, TT_COL_JUMP_BOOST_AMP, v -> settings.showColJumpBoost = v);
+            ThemeManager.endStandardFormTable();
+        }
 
         ThemeManager.sectionSpacing();
-        sectionHeader("Editor table");
-        if (beginLayoutTable("##settings_editor")) {
-            checkboxRow("Show potion effect columns", "##show_potion", settings.showPotionColumns, TT_POTION_COLS, v -> settings.showPotionColumns = v);
+        sectionHeader("Row highlighting");
+        if (beginLayoutTable("##settings_row_highlight")) {
             checkboxRow("Highlight on-ground ticks", "##highlight_on_ground", settings.highlightOnGroundRows, TT_GROUND_HIGHLIGHT, v -> settings.highlightOnGroundRows = v);
             ThemeManager.endStandardFormTable();
         }
@@ -328,6 +364,15 @@ public final class SettingsModal {
                 setter.accept(!current);
                 onChanged.run();
             }
+            tooltipForLastItem(tooltip);
+        });
+    }
+
+    private void disabledCheckboxRow(String label, String id, boolean current, String tooltip) {
+        row(label, () -> {
+            ImGui.beginDisabled(true);
+            Controls.checkbox(id, current);
+            ImGui.endDisabled();
             tooltipForLastItem(tooltip);
         });
     }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/TickInfoPanel.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/TickInfoPanel.java
@@ -1,5 +1,6 @@
 package de.legoshi.parkourcalc.core.ui;
 
+import de.legoshi.parkourcalc.core.PlaybackController;
 import de.legoshi.parkourcalc.core.imgui.RenderInterface;
 import de.legoshi.parkourcalc.core.sim.TickState;
 import de.legoshi.parkourcalc.core.ui.theme.ThemeManager;
@@ -28,6 +29,7 @@ public final class TickInfoPanel implements RenderInterface {
     private static final String COL_Z = "Z";
 
     private final BoxController boxController;
+    private final InputData inputData;
     private final SelectionManager selection;
     private final Settings settings;
     private int rowCounter;
@@ -37,10 +39,20 @@ public final class TickInfoPanel implements RenderInterface {
     private String fmtNumSingle;
     private String numSample;
 
-    public TickInfoPanel(BoxController boxController, SelectionManager selection, Settings settings) {
+    public TickInfoPanel(BoxController boxController, InputData inputData, SelectionManager selection, Settings settings) {
         this.boxController = boxController;
+        this.inputData = inputData;
         this.selection = selection;
         this.settings = settings;
+    }
+
+    private float effectivePitch(int idx) {
+        float p = PlaybackController.DEFAULT_PITCH;
+        int n = Math.min(idx + 1, inputData.size());
+        for (int i = 0; i < n; i++) {
+            p = PlaybackController.applyPitch(p, inputData.get(i));
+        }
+        return p;
     }
 
     private void rebuildFormats() {
@@ -110,6 +122,7 @@ public final class TickInfoPanel implements RenderInterface {
             rowInt("Tick", idx, "Tick number (1-based), matching the input table's Tick column.");
         }
         rowNum("Yaw", appliedYaw, "Facing applied during this tick (drives this tick's movement). MC convention: 0 = +Z, increases CW looking down.");
+        rowNum("Pitch", effectivePitch(idx), "Camera pitch held during this tick (-90 up, 90 down). Defaults to 40; each row adds a relative turn unless locked to an absolute value. Display only; pitch does not affect movement.");
 
         if (prev != null) {
             double dx = cur.position.x - prev.position.x;

--- a/core/src/test/java/de/legoshi/parkourcalc/core/ColumnVisibilitySettingsTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/ColumnVisibilitySettingsTest.java
@@ -1,0 +1,63 @@
+package de.legoshi.parkourcalc.core;
+
+import de.legoshi.parkourcalc.core.ui.Settings;
+import de.legoshi.parkourcalc.core.ui.SettingsIO;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ColumnVisibilitySettingsTest {
+
+    @Test
+    public void newColumnsDefaultHiddenLegacyColumnsDefaultVisible() {
+        Settings s = new Settings();
+        assertTrue(s.showColA);
+        assertTrue(s.showColS);
+        assertTrue(s.showColD);
+        assertTrue(s.showColSprint);
+        assertTrue(s.showColSneak);
+        assertTrue(s.showColJump);
+        assertTrue(s.showColYaw);
+        assertFalse(s.showColPitch);
+        assertFalse(s.showColLeftClick);
+        assertFalse(s.showColRightClick);
+    }
+
+    @Test
+    public void columnVisibilityPersistsAcrossSaveAndLoad() throws Exception {
+        Path file = Files.createTempDirectory("pkc-colvis").resolve("settings.json");
+
+        Settings saved = new Settings();
+        saved.showColD = false;
+        saved.showColSneak = false;
+        saved.showColPitch = true;
+        saved.showColLeftClick = true;
+        SettingsIO.save(file, saved);
+
+        Settings loaded = new Settings();
+        SettingsIO.load(file, loaded);
+
+        assertFalse("hidden legacy column must persist", loaded.showColD);
+        assertFalse(loaded.showColSneak);
+        assertTrue("opted-in new column must persist", loaded.showColPitch);
+        assertTrue(loaded.showColLeftClick);
+        assertTrue(loaded.showColA);
+        assertFalse(loaded.showColRightClick);
+    }
+
+    @Test
+    public void resetRestoresColumnDefaults() {
+        Settings s = new Settings();
+        s.showColA = false;
+        s.showColPitch = true;
+        s.showColRightClick = true;
+        s.reset();
+        assertTrue(s.showColA);
+        assertFalse(s.showColPitch);
+        assertFalse(s.showColRightClick);
+    }
+}

--- a/core/src/test/java/de/legoshi/parkourcalc/core/InputRowSaveRoundTripTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/InputRowSaveRoundTripTest.java
@@ -44,6 +44,7 @@ public class InputRowSaveRoundTripTest {
         r0.setKeyActive(InputRow.Key.LEFT_CLICK, true);
         r0.setYaw(45.5f);
         r0.setPitch(-12.25f);
+        r0.setPitchLocked(true);
         in.getRows().add(r0);
 
         InputRow r1 = new InputRow();
@@ -61,12 +62,14 @@ public class InputRowSaveRoundTripTest {
         assertFalse(o0.isKeyActive(InputRow.Key.RIGHT_CLICK));
         assertEquals(Float.valueOf(45.5f), o0.getYaw());
         assertEquals(Float.valueOf(-12.25f), o0.getPitch());
+        assertTrue("pitch lock must survive a round-trip", o0.isPitchLocked());
 
         InputRow o1 = out.get(1);
         assertTrue(o1.isKeyActive(InputRow.Key.RIGHT_CLICK));
         assertTrue(o1.isKeyActive(InputRow.Key.SPRINT));
         assertFalse(o1.isKeyActive(InputRow.Key.LEFT_CLICK));
         assertEquals(Float.valueOf(90f), o1.getPitch());
+        assertFalse("an untouched pitch lock stays false", o1.isPitchLocked());
     }
 
     @Test

--- a/core/src/test/java/de/legoshi/parkourcalc/core/InputRowSaveRoundTripTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/InputRowSaveRoundTripTest.java
@@ -1,0 +1,125 @@
+package de.legoshi.parkourcalc.core;
+
+import de.legoshi.parkourcalc.core.save.FileSystemSaveStore;
+import de.legoshi.parkourcalc.core.save.Result;
+import de.legoshi.parkourcalc.core.save.SaveFile;
+import de.legoshi.parkourcalc.core.save.SaveIO;
+import de.legoshi.parkourcalc.core.sim.Vec3dCore;
+import de.legoshi.parkourcalc.core.ui.InputData;
+import de.legoshi.parkourcalc.core.ui.InputRow;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class InputRowSaveRoundTripTest {
+
+    private static FileSystemSaveStore store(Path dir) {
+        return new FileSystemSaveStore(dir, "test", "1.8.9", () -> null);
+    }
+
+    private static InputData saveAndReload(FileSystemSaveStore store, InputData in) {
+        Result<String> saved = SaveIO.save(store, "run", in, Vec3dCore.ZERO, Vec3dCore.ZERO, 0f, null, null, false);
+        assertTrue("save should succeed: " + saved.error, saved.ok);
+        Result<SaveFile> loaded = SaveIO.load(store, "run");
+        assertTrue("load should succeed: " + loaded.error, loaded.ok);
+        InputData out = new InputData();
+        SaveIO.applyRowsTo(loaded.value, out);
+        return out;
+    }
+
+    @Test
+    public void pitchAndMouseButtonsRoundTrip() throws Exception {
+        FileSystemSaveStore store = store(Files.createTempDirectory("pkc-rt-pitch-mouse"));
+
+        InputData in = new InputData();
+        InputRow r0 = new InputRow();
+        r0.setKeyActive(InputRow.Key.W, true);
+        r0.setKeyActive(InputRow.Key.LEFT_CLICK, true);
+        r0.setYaw(45.5f);
+        r0.setPitch(-12.25f);
+        in.getRows().add(r0);
+
+        InputRow r1 = new InputRow();
+        r1.setKeyActive(InputRow.Key.RIGHT_CLICK, true);
+        r1.setKeyActive(InputRow.Key.SPRINT, true);
+        r1.setPitch(90f);
+        in.getRows().add(r1);
+
+        InputData out = saveAndReload(store, in);
+        assertEquals(2, out.size());
+
+        InputRow o0 = out.get(0);
+        assertTrue(o0.isKeyActive(InputRow.Key.W));
+        assertTrue(o0.isKeyActive(InputRow.Key.LEFT_CLICK));
+        assertFalse(o0.isKeyActive(InputRow.Key.RIGHT_CLICK));
+        assertEquals(Float.valueOf(45.5f), o0.getYaw());
+        assertEquals(Float.valueOf(-12.25f), o0.getPitch());
+
+        InputRow o1 = out.get(1);
+        assertTrue(o1.isKeyActive(InputRow.Key.RIGHT_CLICK));
+        assertTrue(o1.isKeyActive(InputRow.Key.SPRINT));
+        assertFalse(o1.isKeyActive(InputRow.Key.LEFT_CLICK));
+        assertEquals(Float.valueOf(90f), o1.getPitch());
+    }
+
+    @Test
+    public void absentPitchRoundTripsAsNull() throws Exception {
+        FileSystemSaveStore store = store(Files.createTempDirectory("pkc-rt-nopitch"));
+
+        InputData in = new InputData();
+        InputRow r0 = new InputRow();
+        r0.setYaw(10f);
+        in.getRows().add(r0);
+
+        InputRow o0 = saveAndReload(store, in).get(0);
+        assertEquals(Float.valueOf(10f), o0.getYaw());
+        assertNull("an unset pitch must stay null (inherit) across a round-trip", o0.getPitch());
+    }
+
+    @Test
+    public void oldFormatRowWithoutPitchOrMouseLoadsWithDefaults() {
+        String json = "{\n" +
+                "  \"version\": 1,\n" +
+                "  \"start\": { \"pos\": [0.0, 0.0, 0.0], \"vel\": [0.0, 0.0, 0.0], \"yaw\": 0.0 },\n" +
+                "  \"rows\": [\n" +
+                "    { \"keys\": [\"W\", \"SPRINT\"], \"yaw\": 12.0, \"yawLocked\": false, \"speedAmplifier\": 0, \"jumpBoostAmplifier\": 0 }\n" +
+                "  ]\n" +
+                "}";
+
+        SaveFile file = SaveIO.parseSafe(json);
+        assertNotNull(file);
+        InputData out = new InputData();
+        SaveIO.applyRowsTo(file, out);
+
+        assertEquals(1, out.size());
+        InputRow o0 = out.get(0);
+        assertTrue(o0.isKeyActive(InputRow.Key.W));
+        assertTrue(o0.isKeyActive(InputRow.Key.SPRINT));
+        assertEquals(Float.valueOf(12.0f), o0.getYaw());
+        assertFalse(o0.isKeyActive(InputRow.Key.LEFT_CLICK));
+        assertFalse(o0.isKeyActive(InputRow.Key.RIGHT_CLICK));
+        assertNull("missing pitch field must load as null (inherit)", o0.getPitch());
+    }
+
+    @Test
+    public void unknownKeyNamesInSaveAreIgnored() {
+        String json = "{\n" +
+                "  \"version\": 1,\n" +
+                "  \"start\": { \"pos\": [0.0, 0.0, 0.0], \"vel\": [0.0, 0.0, 0.0], \"yaw\": 0.0 },\n" +
+                "  \"rows\": [ { \"keys\": [\"W\", \"MIDDLE_CLICK\"], \"yaw\": 0.0 } ]\n" +
+                "}";
+        SaveFile file = SaveIO.parseSafe(json);
+        assertNotNull(file);
+        InputData out = new InputData();
+        SaveIO.applyRowsTo(file, out);
+        assertEquals(1, out.size());
+        assertTrue(out.get(0).isKeyActive(InputRow.Key.W));
+    }
+}

--- a/loader-fabric-1.21.10/src/client/java/de/legoshi/parkourcalc/fabric/FabricPlaybackBridge.java
+++ b/loader-fabric-1.21.10/src/client/java/de/legoshi/parkourcalc/fabric/FabricPlaybackBridge.java
@@ -125,6 +125,14 @@ public final class FabricPlaybackBridge implements PlaybackBridge {
     }
 
     @Override
+    public void setPitch(float absolutePitch) {
+        ClientPlayerEntity p = MinecraftClient.getInstance().player;
+        if (p == null) return;
+        p.setPitch(absolutePitch);
+        p.lastPitch = absolutePitch;
+    }
+
+    @Override
     public void releaseAllKeys() {
         for (InputRow.Key k : InputRow.Key.values()) {
             setKey(k, false);
@@ -190,6 +198,8 @@ public final class FabricPlaybackBridge implements PlaybackBridge {
             case JUMP -> o.jumpKey;
             case SNEAK -> o.sneakKey;
             case SPRINT -> o.sprintKey;
+            case LEFT_CLICK -> o.attackKey;
+            case RIGHT_CLICK -> o.useKey;
         };
     }
 }

--- a/loader-fabric-1.21.10/src/client/java/de/legoshi/parkourcalc/fabric/FabricPlaybackBridge.java
+++ b/loader-fabric-1.21.10/src/client/java/de/legoshi/parkourcalc/fabric/FabricPlaybackBridge.java
@@ -4,6 +4,7 @@ import de.legoshi.parkourcalc.core.ports.PlaybackBridge;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.InputRow;
 import de.legoshi.parkourcalc.fabric.mixin.ClientPlayerEntityAccessor;
+import de.legoshi.parkourcalc.fabric.mixin.KeyBindingAccessor;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.input.Input;
 import net.minecraft.client.network.ClientPlayerEntity;
@@ -106,7 +107,16 @@ public final class FabricPlaybackBridge implements PlaybackBridge {
     public void setKey(InputRow.Key key, boolean pressed) {
         currentRow.setKeyActive(key, pressed);
         KeyBinding kb = bindFor(key);
-        if (kb != null) kb.setPressed(pressed);
+        if (kb == null) return;
+        kb.setPressed(pressed);
+        if (pressed && isClickKey(key)) {
+            KeyBindingAccessor acc = (KeyBindingAccessor) kb;
+            acc.pkc$setTimesPressed(acc.pkc$getTimesPressed() + 1);
+        }
+    }
+
+    private static boolean isClickKey(InputRow.Key key) {
+        return key == InputRow.Key.LEFT_CLICK || key == InputRow.Key.RIGHT_CLICK;
     }
 
     @Override

--- a/loader-fabric-1.21.10/src/client/java/de/legoshi/parkourcalc/fabric/mixin/KeyBindingAccessor.java
+++ b/loader-fabric-1.21.10/src/client/java/de/legoshi/parkourcalc/fabric/mixin/KeyBindingAccessor.java
@@ -1,0 +1,13 @@
+package de.legoshi.parkourcalc.fabric.mixin;
+
+import net.minecraft.client.option.KeyBinding;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(KeyBinding.class)
+public interface KeyBindingAccessor {
+
+    @Accessor("timesPressed") int pkc$getTimesPressed();
+
+    @Accessor("timesPressed") void pkc$setTimesPressed(int timesPressed);
+}

--- a/loader-fabric-1.21.10/src/client/resources/parkourcalculator.client.mixins.json
+++ b/loader-fabric-1.21.10/src/client/resources/parkourcalculator.client.mixins.json
@@ -9,6 +9,7 @@
     "FallDamageSuppressMixin",
     "GameRendererMixin",
     "InGameHudMixin",
+    "KeyBindingAccessor",
     "KeyboardMixin",
     "LandingParticleSuppressMixin",
     "MinecraftClientMixin",

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12PlaybackBridge.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12PlaybackBridge.java
@@ -133,6 +133,14 @@ public final class Forge12PlaybackBridge implements PlaybackBridge {
     }
 
     @Override
+    public void setPitch(float absolutePitch) {
+        EntityPlayerSP p = Minecraft.getMinecraft().player;
+        if (p == null) return;
+        p.rotationPitch = absolutePitch;
+        p.prevRotationPitch = absolutePitch;
+    }
+
+    @Override
     public void releaseAllKeys() {
         for (InputRow.Key k : InputRow.Key.values()) {
             setKey(k, false);
@@ -220,6 +228,8 @@ public final class Forge12PlaybackBridge implements PlaybackBridge {
             case JUMP: return o.keyBindJump;
             case SNEAK: return o.keyBindSneak;
             case SPRINT: return o.keyBindSprint;
+            case LEFT_CLICK: return o.keyBindAttack;
+            case RIGHT_CLICK: return o.keyBindUseItem;
         }
         return null;
     }

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12PlaybackBridge.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12PlaybackBridge.java
@@ -114,7 +114,15 @@ public final class Forge12PlaybackBridge implements PlaybackBridge {
     public void setKey(InputRow.Key key, boolean pressed) {
         currentRow.setKeyActive(key, pressed);
         KeyBinding kb = bindFor(key);
-        if (kb != null) KeyBinding.setKeyBindState(kb.getKeyCode(), pressed);
+        if (kb == null) return;
+        KeyBinding.setKeyBindState(kb.getKeyCode(), pressed);
+        if (pressed && isClickKey(key)) {
+            KeyBinding.onTick(kb.getKeyCode());
+        }
+    }
+
+    private static boolean isClickKey(InputRow.Key key) {
+        return key == InputRow.Key.LEFT_CLICK || key == InputRow.Key.RIGHT_CLICK;
     }
 
     @Override

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8PlaybackBridge.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8PlaybackBridge.java
@@ -115,7 +115,15 @@ public final class Forge8PlaybackBridge implements PlaybackBridge {
     public void setKey(InputRow.Key key, boolean pressed) {
         currentRow.setKeyActive(key, pressed);
         KeyBinding kb = bindFor(key);
-        if (kb != null) KeyBinding.setKeyBindState(kb.getKeyCode(), pressed);
+        if (kb == null) return;
+        KeyBinding.setKeyBindState(kb.getKeyCode(), pressed);
+        if (pressed && isClickKey(key)) {
+            KeyBinding.onTick(kb.getKeyCode());
+        }
+    }
+
+    private static boolean isClickKey(InputRow.Key key) {
+        return key == InputRow.Key.LEFT_CLICK || key == InputRow.Key.RIGHT_CLICK;
     }
 
     @Override

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8PlaybackBridge.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8PlaybackBridge.java
@@ -134,6 +134,14 @@ public final class Forge8PlaybackBridge implements PlaybackBridge {
     }
 
     @Override
+    public void setPitch(float absolutePitch) {
+        EntityPlayerSP p = Minecraft.getMinecraft().thePlayer;
+        if (p == null) return;
+        p.rotationPitch = absolutePitch;
+        p.prevRotationPitch = absolutePitch;
+    }
+
+    @Override
     public void releaseAllKeys() {
         for (InputRow.Key k : InputRow.Key.values()) {
             setKey(k, false);
@@ -219,6 +227,8 @@ public final class Forge8PlaybackBridge implements PlaybackBridge {
             case JUMP: return o.keyBindJump;
             case SNEAK: return o.keyBindSneak;
             case SPRINT: return o.keyBindSprint;
+            case LEFT_CLICK: return o.keyBindAttack;
+            case RIGHT_CLICK: return o.keyBindUseItem;
         }
         return null;
     }


### PR DESCRIPTION
The milestone's design centerpiece (#101 reworks the too-wide input pane; #100 was blocked on it).

- Configurable columns: every column except Tick and W is opt-in via a "Columns" popup (grouped Movement / Modifiers / Look / Mouse / Effects), persisted in `Settings`. New columns (Pitch / LMB / RMB) default hidden, so existing panes are unchanged until opt-in.
- Pitch (#101): nullable `Float pitch` on `InputRow` (null = inherit previous tick), clamped to plus/minus 90, applied during playback. Persisted as `SaveFile.Row.pitch` (absent = inherit).
- Mouse buttons (#100): `InputRow.Key` extended with `LEFT_CLICK`/`RIGHT_CLICK` appended last (ordinals preserved), flowing through `activeKeys`, drag-to-paint, save key-name list, `releaseAllKeys`, bridge `setKey`, and playback. Rendered as toggle columns.
- Back-compat: old saves (no pitch, no mouse keys) load unchanged, proven by tests.

Files: `ui/InputRow.java`, `save/SaveFile.java`, `save/SaveIO.java`, `ui/InputOverlay.java`, `ui/Settings.java`, `Application.java`, `PlaybackController.java`, `ports/PlaybackBridge.java` (`setPitch`); (loaders, not compiled) `Forge8/12PlaybackBridge`, `FabricPlaybackBridge` (`setPitch` + LMB->attack / RMB->use). `+InputRowSaveRoundTripTest` (4), `+ColumnVisibilitySettingsTest` (3).

Closes #100
Closes #101

GATE: DESIGN REVIEW + loader test. Confirm the column UX + defaults, the pitch model (inherit-null, no lock/flick), and the mouse-as-Key-enum choice. Loader test: pitch drives head pitch in playback; LMB/RMB press attack/use; buttons release on stop/pause.
Build: `:core:check` green (+7 tests); loader code NOT compiled here.
Merge: LAST (heaviest overlap). Resolve conflicts with #129 (`InputOverlay`), #105/#129 (`PlaybackController.tick`), #105/#117 (loader bridges + `PlaybackBridge`), #108/#112 (`SaveIO`/`SaveFile`). Known gap: the Pitch column has no Tab-to-next-row stepping yet (deliberate).
