### PR TITLE
feat(anglesolver): velocity angle calculator (#112)

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/AngleSolverEngine.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/AngleSolverEngine.java
@@ -253,6 +253,149 @@ public final class AngleSolverEngine {
         worker.start();
     }
 
+    private static final class VelocityJob {
+        final JumpSpec spec;
+        final double[] gameFacings;
+        final List<ConstraintAt> uiConstraints;
+        final int startTick;
+        final int landingTick;
+        final int numTicks;
+        final double targetSpeed;
+
+        VelocityJob(JumpSpec spec, double[] gameFacings, List<ConstraintAt> uiConstraints,
+                    int startTick, int landingTick, int numTicks, double targetSpeed) {
+            this.spec = spec;
+            this.gameFacings = gameFacings;
+            this.uiConstraints = uiConstraints;
+            this.startTick = startTick;
+            this.landingTick = landingTick;
+            this.numTicks = numTicks;
+            this.targetSpeed = targetSpeed;
+        }
+    }
+
+    private VelocityJob buildVelocityJob() {
+        int startTick = state.getStartTick();
+        int landingTick = state.getLandingTick();
+        int total = segmentConstraintCount(startTick, landingTick);
+
+        List<InputRow> rows = inputs.getRows();
+        int numTicks = landingTick - startTick;
+        if (numTicks <= 0 || startTick < 0 || startTick >= boxes.size()
+                || landingTick > rows.size() || startTick >= rows.size()) {
+            state.setResult(new SolveResult(false, 0, total, startTick + 1, landingTick + 1));
+            return null;
+        }
+
+        Phys ph = buildPhys(startTick, numTicks);
+        List<ConstraintAt> uiCons = collectUiConstraints(startTick, numTicks);
+
+        List<JumpConstraint> constraints = new ArrayList<>();
+        Objective objective = new Objective(axis(state.getAxis()), sense(state.getGoal()), numTicks);
+        for (ConstraintAt ca : uiCons) addMapped(constraints, ca.c, ca.absTick, ca.segTick, numTicks);
+
+        JumpSpec spec = new JumpSpec(ph.inputs, constraints, objective);
+        double[] gameFacings = fixedGameFacings(startTick, numTicks);
+        return new VelocityJob(spec, gameFacings, uiCons, startTick, landingTick, numTicks, state.getTargetSpeed());
+    }
+
+    private double[] fixedGameFacings(int startTick, int numTicks) {
+        double[] f = new double[numTicks];
+        for (int k = 0; k < numTicks; k++) {
+            TickState s = boxes.getState(startTick + k);
+            f[k] = s != null ? s.yaw : 0.0;
+        }
+        return f;
+    }
+
+    public void solveVelocityAngle() {
+        if (solving) return;
+        VelocityJob job = buildVelocityJob();
+        if (job == null) return;
+
+        long t0 = System.nanoTime();
+        state.clearResult();
+        lastPlan = null;
+        pending = null;
+        startNanos = t0;
+        AtomicBoolean token = new AtomicBoolean(false);
+        cancel = token;
+        solving = true;
+        Thread worker = new Thread(() -> {
+            try {
+                Outcome o = runVelocityJob(job, token);
+                if (o != null && !token.get()) pending = o;
+            } catch (Throwable t) {
+                if (!token.get()) {
+                    SolveResult fail = new SolveResult(
+                            false, 0, job.uiConstraints.size(),
+                            job.startTick + 1, job.landingTick + 1
+                    );
+                    pending = new Outcome(fail, null);
+                }
+            }
+        }, "angle-velocity-solver");
+        worker.setDaemon(true);
+        worker.start();
+    }
+
+    private Outcome runVelocityJob(VelocityJob job, AtomicBoolean cancel) {
+        long solveStart = System.nanoTime();
+        VelocityAngleSolver solver = new VelocityAngleSolver(model, job.spec, job.gameFacings, job.targetSpeed);
+        VelocityAngleSolver.Result vr = solver.solve(FEAS_TOL, cancel);
+        if (cancel.get() || vr == null) return null;
+        long solveNanos = System.nanoTime() - solveStart;
+
+        SolveResult result = buildVelocityResult(job, vr);
+        result.setDurationNanos(solveNanos);
+        result.setDurationMs(solveNanos / 1_000_000L);
+        result.setFinishedAt(formatClock());
+        result.setSolver("velocity-angle sweep + golden-section refine");
+        result.setObjective(vr.path.getPos(job.spec.objective.tick, job.spec.objective.axis));
+        result.getOutcomes().add(0, objectiveOutcome(result, job.spec.objective, job.startTick));
+        double realizedSpeed = Math.hypot(vr.initialVelocity.x, vr.initialVelocity.z);
+        result.getOutcomes().add(0, new SolveResult.Outcome(
+                "velocity angle", "T" + (job.startTick + 1),
+                "= " + ConstraintText.fixedStat(vr.angle360Deg) + "°",
+                ConstraintText.fixedStat(realizedSpeed) + " b/t", ""
+        ));
+        addBaseDetails(result, solveNanos);
+        result.addDetail("Target speed", ConstraintText.fixedStat(job.targetSpeed) + " b/t");
+        result.addDetail(
+                "Velocity angle", ConstraintText.fixedStat(vr.angle360Deg) + "° ("
+                + ConstraintText.fixedStat(vr.angleDeg) + "°)"
+        );
+        result.addDetail("Launch vX", ConstraintText.fixedStat(vr.initialVelocity.x));
+        result.addDetail("Launch vZ", ConstraintText.fixedStat(vr.initialVelocity.z));
+        result.addDetail("Coarse step", ConstraintText.fixedStat(0.2) + "°");
+        return new Outcome(result, null);
+    }
+
+    private SolveResult buildVelocityResult(VelocityJob job, VelocityAngleSolver.Result vr) {
+        int total = 0;
+        int met = 0;
+        List<SolveResult.Outcome> outs = new ArrayList<>();
+        List<ConstraintAt> ordered = new ArrayList<>(job.uiConstraints);
+        ordered.sort((a, b) -> Integer.compare(a.absTick, b.absTick));
+        for (ConstraintAt ca : ordered) {
+            Double found = findValue(ca.c, ca.segTick, job.numTicks, job.gameFacings, vr.path);
+            if (found == null) continue;
+            total++;
+            if (satisfied(ca.c, found)) met++;
+            outs.add(outcome(ca.c, ca.absTick, found));
+        }
+        SolveResult r = new SolveResult(met == total, met, total, job.startTick + 1, job.landingTick + 1);
+        r.getOutcomes().addAll(outs);
+        return r;
+    }
+
+    public VelocityAngleSolver.Result debugSolveVelocityAngle() {
+        VelocityJob job = buildVelocityJob();
+        if (job == null) return null;
+        return new VelocityAngleSolver(model, job.spec, job.gameFacings, job.targetSpeed)
+                .solve(FEAS_TOL, new AtomicBoolean(false));
+    }
+
     /** Per-tick physics snapshot shared by solve() and the block solver. */
     private static final class Phys {
         final JumpPhysicsInputs inputs;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/AngleSolverState.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/AngleSolverState.java
@@ -67,6 +67,9 @@ public final class AngleSolverState {
     private Goal goal = Goal.MAX;
     private Effort effort = Effort.FAST;
 
+    public static final double DEFAULT_TARGET_SPEED = 0.2873;
+    private double targetSpeed = DEFAULT_TARGET_SPEED;
+
     private InputMode defaultInputs = InputMode.FORCE_45;
     private SprintMode defaultSprint = SprintMode.ALWAYS;
     private Slipperiness defaultSlipperiness = Slipperiness.AIR;
@@ -125,6 +128,14 @@ public final class AngleSolverState {
 
     public void setEffort(Effort effort) {
         this.effort = effort;
+    }
+
+    public double getTargetSpeed() {
+        return targetSpeed;
+    }
+
+    public void setTargetSpeed(double targetSpeed) {
+        this.targetSpeed = Math.max(0.0, targetSpeed);
     }
 
     public boolean isStart(int tick) {
@@ -460,6 +471,7 @@ public final class AngleSolverState {
         axis = Axis.X;
         goal = Goal.MAX;
         effort = Effort.FAST;
+        targetSpeed = DEFAULT_TARGET_SPEED;
         defaultInputs = InputMode.FORCE_45;
         defaultSprint = SprintMode.ALWAYS;
         defaultSlipperiness = Slipperiness.AIR;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/VelocityAngleSolver.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/VelocityAngleSolver.java
@@ -1,0 +1,147 @@
+package de.legoshi.parkourcalc.core.anglesolver;
+
+import de.legoshi.parkourcalc.core.anglesolver.solver.Angles;
+import de.legoshi.parkourcalc.core.anglesolver.solver.ForwardModel;
+import de.legoshi.parkourcalc.core.anglesolver.solver.ForwardPath;
+import de.legoshi.parkourcalc.core.anglesolver.solver.JumpConstraintCompiler;
+import de.legoshi.parkourcalc.core.anglesolver.solver.JumpPhysicsInputs;
+import de.legoshi.parkourcalc.core.anglesolver.solver.JumpSpec;
+import de.legoshi.parkourcalc.core.anglesolver.solver.McSineTable;
+import de.legoshi.parkourcalc.core.anglesolver.solver.Objective;
+import de.legoshi.parkourcalc.core.sim.Vec3dCore;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public final class VelocityAngleSolver {
+
+    private static final double COARSE_STEP_DEG = 0.2;
+
+    private static final double REFINE_BRACKET_DEG = COARSE_STEP_DEG;
+
+    private static final double REFINE_TOL_DEG = 1.0e-4;
+
+    private static final double INV_GOLDEN = (Math.sqrt(5.0) - 1.0) / 2.0;
+
+    public static final class Result {
+        public final double angleDeg;
+        public final double angle360Deg;
+        public final Vec3dCore initialVelocity;
+        public final ForwardPath path;
+        public final double maxViolation;
+
+        Result(double angleDeg, Vec3dCore initialVelocity, ForwardPath path, double maxViolation) {
+            this.angleDeg = angleDeg;
+            this.angle360Deg = angleDeg < 0 ? angleDeg + 360.0 : angleDeg;
+            this.initialVelocity = initialVelocity;
+            this.path = path;
+            this.maxViolation = maxViolation;
+        }
+    }
+
+    private final ForwardModel model;
+    private final JumpPhysicsInputs scenario;
+    private final double[] gameFacings;
+    private final JumpConstraintCompiler.Compiled constraints;
+    private final Objective objective;
+    private final double speed;
+    private final double vy0;
+
+    public VelocityAngleSolver(ForwardModel model, JumpSpec spec, double[] gameFacings, double speed) {
+        this.model = model;
+        this.scenario = spec.asScenario();
+        this.gameFacings = gameFacings.clone();
+        this.constraints = JumpConstraintCompiler.compile(spec);
+        this.objective = spec.objective;
+        this.speed = Math.max(0.0, speed);
+        this.vy0 = scenario.initialVelocity.y;
+    }
+
+    public static Vec3dCore velocityFor(double thetaDeg, double speed, double vy) {
+        float rad = (float) thetaDeg * (float) (Math.PI / 180.0);
+        double vx = -McSineTable.sinStep(rad) * speed;
+        double vz = McSineTable.cosStep(rad) * speed;
+        return new Vec3dCore(vx, vy, vz);
+    }
+
+    public Result solve(double feasTol, AtomicBoolean cancel) {
+        double tol = Math.max(0.0, feasTol);
+        double bestTheta = 0.0;
+        double bestScore = Double.POSITIVE_INFINITY;
+        int steps = (int) Math.round(360.0 / COARSE_STEP_DEG);
+        for (int i = 0; i < steps; i++) {
+            if (cancel != null && cancel.get()) return null;
+            double theta = i * COARSE_STEP_DEG;
+            double score = score(theta, tol);
+            if (score < bestScore) {
+                bestScore = score;
+                bestTheta = theta;
+            }
+        }
+
+        double refined = refine(bestTheta - REFINE_BRACKET_DEG, bestTheta + REFINE_BRACKET_DEG, tol, cancel);
+        if (cancel != null && cancel.get()) return null;
+
+        double wrapped = Angles.wrap(refined);
+        ForwardPath path = evaluate(wrapped);
+        double viol = constraints.maxViolation(gameFacings, path);
+        return new Result(wrapped, velocityFor(wrapped, speed, vy0), path, viol);
+    }
+
+    private double refine(double lo, double hi, double feasTol, AtomicBoolean cancel) {
+        double a = lo;
+        double b = hi;
+        double c = b - INV_GOLDEN * (b - a);
+        double d = a + INV_GOLDEN * (b - a);
+        double fc = score(c, feasTol);
+        double fd = score(d, feasTol);
+        for (int it = 0; it < 60 && (b - a) > REFINE_TOL_DEG; it++) {
+            if (cancel != null && cancel.get()) break;
+            if (fc < fd) {
+                b = d;
+                d = c;
+                fd = fc;
+                c = b - INV_GOLDEN * (b - a);
+                fc = score(c, feasTol);
+            } else {
+                a = c;
+                c = d;
+                fc = fd;
+                d = a + INV_GOLDEN * (b - a);
+                fd = score(d, feasTol);
+            }
+        }
+        return 0.5 * (a + b);
+    }
+
+    private double score(double theta, double feasTol) {
+        ForwardPath path = evaluate(theta);
+        double viol = Math.max(0.0, constraints.maxViolation(gameFacings, path) - feasTol);
+        double objTerm = objective.sense == Objective.Sense.MAX
+                ? -path.getPos(objective.tick, objective.axis)
+                : path.getPos(objective.tick, objective.axis);
+        return viol + 1.0e-6 * objTerm;
+    }
+
+    private ForwardPath evaluate(double theta) {
+        JumpPhysicsInputs sc = withInitialVelocity(velocityFor(theta, speed, vy0));
+        return model.forward(sc, gameFacings);
+    }
+
+    private JumpPhysicsInputs withInitialVelocity(Vec3dCore v) {
+        JumpPhysicsInputs sc = new JumpPhysicsInputs(scenario.numTicks);
+        sc.startPos = scenario.startPos;
+        sc.startYaw = scenario.startYaw;
+        sc.initialVelocity = v;
+        sc.jumpTick = scenario.jumpTick;
+        sc.jumpPerTick = scenario.jumpPerTick;
+        sc.strafeSign = scenario.strafeSign;
+        sc.strafePerTick = scenario.strafePerTick;
+        sc.speedAmplifier = scenario.speedAmplifier;
+        sc.slipPerTick = scenario.slipPerTick;
+        sc.yawLockedPerTick = scenario.yawLockedPerTick;
+        sc.sprintPerTick = scenario.sprintPerTick;
+        sc.forwardInputPerTick = scenario.forwardInputPerTick;
+        sc.strafeInputPerTick = scenario.strafeInputPerTick;
+        return sc;
+    }
+}

--- a/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveFile.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveFile.java
@@ -44,6 +44,7 @@ public final class SaveFile {
         public String axis;
         public String goal;
         public String effort;                            // absent in old files -> FAST
+        public Double targetSpeed;
         public String defaultInputs;
         public String defaultSprint;                     // absent in old files -> ALWAYS
         public String defaultSlipperiness;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveIO.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveIO.java
@@ -98,6 +98,7 @@ public final class SaveIO {
         state.setAxis(parseEnum(AngleSolverState.Axis.class, a.axis, AngleSolverState.Axis.X));
         state.setGoal(parseEnum(AngleSolverState.Goal.class, a.goal, AngleSolverState.Goal.MAX));
         state.setEffort(parseEnum(AngleSolverState.Effort.class, a.effort, AngleSolverState.Effort.FAST));
+        if (a.targetSpeed != null) state.setTargetSpeed(a.targetSpeed);
         state.setDefaultInputs(parseEnum(AngleSolverState.InputMode.class, a.defaultInputs, AngleSolverState.InputMode.FORCE_45));
         state.setDefaultSprint(parseEnum(AngleSolverState.SprintMode.class, a.defaultSprint, AngleSolverState.SprintMode.ALWAYS));
         state.setDefaultSlipperiness(parseEnum(Slipperiness.class, a.defaultSlipperiness, Slipperiness.AIR));
@@ -289,6 +290,7 @@ public final class SaveIO {
         a.axis = s.getAxis().name();
         a.goal = s.getGoal().name();
         a.effort = s.getEffort().name();
+        a.targetSpeed = s.getTargetSpeed();
         a.defaultInputs = s.getDefaultInputs().name();
         a.defaultSprint = s.getDefaultSprint().name();
         a.defaultSlipperiness = s.getDefaultSlipperiness().name();

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverWindow.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverWindow.java
@@ -22,6 +22,7 @@ import imgui.flag.ImGuiCol;
 import imgui.flag.ImGuiCond;
 import imgui.flag.ImGuiStyleVar;
 import imgui.flag.ImGuiWindowFlags;
+import imgui.type.ImFloat;
 import imgui.type.ImInt;
 
 import java.util.ArrayList;
@@ -54,7 +55,16 @@ public final class AngleSolverWindow implements RenderInterface {
     private static final String[] EFFORTS = {"Fast", "Thorough"};
 
     private static final String[] FORM_LABELS =
-            {"Start tick", "Goal tick", "Axis", "Goal", "Inputs", "Sprint", "Slipperiness", "Potion"};
+            {"Start tick", "Goal tick", "Axis", "Goal", "Inputs", "Sprint", "Slipperiness", "Potion", "Speed"};
+
+    private static final String VELOCITY_ANGLE_TIP =
+            "Stratfinding helper (issue #112): instead of solving the per-tick facings for a fixed launch"
+            + " velocity, this fixes the launch SPEED to the value above and searches the DIRECTION of the"
+            + " initial horizontal velocity over a full circle for the angle that best meets the constraints"
+            + " below.\n\nThe angle is a Minecraft yaw: 0 = +Z, 90 = -X. It is the direction your speed"
+            + " vector points at launch.\n\nv1 keeps the current start position and only optimizes the"
+            + " velocity direction; it does not author per-tick yaws, so its result cannot be Applied (it"
+            + " would change the launch velocity, not the rows). Use it to read off the target angle.";
 
     /** Unscaled; lines the details table up under the toggle title and sets it off from the solved values. */
     private static final float DETAIL_INDENT = 13f;
@@ -80,6 +90,7 @@ public final class AngleSolverWindow implements RenderInterface {
     private final ImInt slipBuf = new ImInt();
     private final ImInt doseCombo = new ImInt();
     private final ImInt levelBuf = new ImInt();
+    private final ImFloat speedBuf = new ImFloat();
     private final String[] slipItems;
 
     private boolean yawsExpanded;
@@ -89,6 +100,7 @@ public final class AngleSolverWindow implements RenderInterface {
     private boolean problemExpanded = true;
     private boolean solveForExpanded = true;
     private boolean defaultStateExpanded = true;
+    private boolean velocityAngleExpanded;
     private boolean advancedExpanded;
     private int doseToRemove;
 
@@ -177,6 +189,9 @@ public final class AngleSolverWindow implements RenderInterface {
             potionRow(labelW);
         }
         state.pruneRedundantOverrides();
+
+        ThemeManager.sectionSpacing();
+        renderVelocityAngle(labelW, scale);
 
         ThemeManager.sectionSpacing();
         renderAdvanced(labelW, scale);
@@ -377,6 +392,39 @@ public final class AngleSolverWindow implements RenderInterface {
         }
         ImGui.sameLine();
         if (SolverWidgets.deleteX("rm" + index)) doseToRemove = index;
+    }
+
+    private void renderVelocityAngle(float labelW, float scale) {
+        velocityAngleExpanded = sectionToggle("Velocity angle", "velangle", velocityAngleExpanded, scale);
+        if (!velocityAngleExpanded) return;
+
+        speedRow(labelW);
+
+        ThemeManager.pushTextColor(ThemeManager.textMutedColor());
+        ImGui.text("Searches the launch direction for this speed.");
+        ThemeManager.popTextColor();
+        TooltipUtil.onHover(VELOCITY_ANGLE_TIP);
+
+        if (engine.isSolving()) {
+            Controls.disabledButton("Solve velocity angle");
+        } else if (Controls.secondaryButton("Solve velocity angle")) {
+            yawsExpanded = false;
+            detailsExpanded = false;
+            solverExpanded = false;
+            outcomesExpanded = true;
+            engine.solveVelocityAngle();
+        }
+    }
+
+    private void speedRow(float labelW) {
+        Controls.pushInputFrameHeight();
+        SolverWidgets.rowLabel("Speed", labelW);
+        speedBuf.set((float) state.getTargetSpeed());
+        ImGui.setNextItemWidth(ImGui.getContentRegionAvail().x);
+        if (ImGui.inputFloat("##targetSpeed", speedBuf, 0f, 0f, "%.4f")) {
+            state.setTargetSpeed(speedBuf.get());
+        }
+        Controls.popInputFrameHeight();
     }
 
     private void renderAdvanced(float labelW, float scale) {

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/VelocityAngleSolverTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/VelocityAngleSolverTest.java
@@ -1,0 +1,190 @@
+package de.legoshi.parkourcalc.anglesolver;
+
+import de.legoshi.parkourcalc.core.anglesolver.AngleSolverEngine;
+import de.legoshi.parkourcalc.core.anglesolver.AngleSolverState;
+import de.legoshi.parkourcalc.core.anglesolver.Constraint;
+import de.legoshi.parkourcalc.core.anglesolver.SolveResult;
+import de.legoshi.parkourcalc.core.anglesolver.VelocityAngleSolver;
+import de.legoshi.parkourcalc.core.anglesolver.solver.Angles;
+import de.legoshi.parkourcalc.core.anglesolver.solver.ExactJumpModel;
+import de.legoshi.parkourcalc.core.anglesolver.solver.JumpConstraint;
+import de.legoshi.parkourcalc.core.anglesolver.solver.JumpPhysicsInputs;
+import de.legoshi.parkourcalc.core.anglesolver.solver.JumpSpec;
+import de.legoshi.parkourcalc.core.anglesolver.solver.Objective;
+import de.legoshi.parkourcalc.core.sim.TickState;
+import de.legoshi.parkourcalc.core.sim.Vec3dCore;
+import de.legoshi.parkourcalc.core.ui.BoxController;
+import de.legoshi.parkourcalc.core.ui.InputData;
+import de.legoshi.parkourcalc.core.ui.InputRow;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class VelocityAngleSolverTest {
+
+    private static final ExactJumpModel MODEL = ExactJumpModel.forMcVersion("1.21.10");
+    private static final double SPEED = 0.3;
+    private static final Vec3dCore START = new Vec3dCore(0.5, 100.0, 0.5);
+
+    private static JumpPhysicsInputs coastAir(int n) {
+        JumpPhysicsInputs sc = new JumpPhysicsInputs(n);
+        sc.startPos = START;
+        sc.startYaw = 0f;
+        sc.initialVelocity = Vec3dCore.ZERO;
+        sc.jumpTick = -1;
+        sc.jumpPerTick = new boolean[n];
+        sc.strafePerTick = new boolean[n];
+        sc.speedAmplifier = new int[n];
+        sc.slipPerTick = new double[n];
+        sc.yawLockedPerTick = new boolean[n];
+        sc.forwardInputPerTick = new float[n];
+        sc.strafeInputPerTick = new float[n];
+        sc.sprintPerTick = new boolean[n];
+        for (int t = 0; t < n; t++) {
+            sc.slipPerTick[t] = Double.NaN;
+            sc.yawLockedPerTick[t] = true;
+        }
+        return sc;
+    }
+
+    private static double[] facings(int n) {
+        return new double[n];
+    }
+
+    private static VelocityAngleSolver.Result solveObjectiveOnly(int n, JumpPhysicsInputs.Axis axis, Objective.Sense sense) {
+        JumpSpec spec = new JumpSpec(coastAir(n), new ArrayList<JumpConstraint>(), new Objective(axis, sense, n));
+        return new VelocityAngleSolver(MODEL, spec, facings(n), SPEED).solve(0.0, new AtomicBoolean(false));
+    }
+
+    @Test
+    public void maximizingZPointsLaunchStraightNorth() {
+        VelocityAngleSolver.Result r = solveObjectiveOnly(4, JumpPhysicsInputs.Axis.Z, Objective.Sense.MAX);
+        assertNotNull(r);
+        double err = Math.abs(Angles.wrapDelta(r.angle360Deg - 0.0));
+        assertTrue("maximize Z -> launch +Z (theta~0, got " + r.angle360Deg + ")", err < 0.5);
+        assertTrue("no constraints: trivially feasible", r.maxViolation <= 0.0);
+    }
+
+    @Test
+    public void minimizingXPointsLaunchWest() {
+        VelocityAngleSolver.Result r = solveObjectiveOnly(3, JumpPhysicsInputs.Axis.X, Objective.Sense.MIN);
+        assertNotNull(r);
+        double err = Math.abs(Angles.wrapDelta(r.angle360Deg - 90.0));
+        assertTrue("minimize X -> launch -X (theta~90, got " + r.angle360Deg + ")", err < 0.5);
+    }
+
+    @Test
+    public void maximizingXPointsLaunchEast() {
+        VelocityAngleSolver.Result r = solveObjectiveOnly(3, JumpPhysicsInputs.Axis.X, Objective.Sense.MAX);
+        assertNotNull(r);
+        double err = Math.abs(Angles.wrapDelta(r.angle360Deg - 270.0));
+        assertTrue("maximize X -> launch +X (theta~270, got " + r.angle360Deg + ")", err < 0.5);
+    }
+
+    @Test
+    public void findsFeasibleLaunchDirectionForLandingBox() {
+        int n = 4;
+        double target = 210.0;
+        double band = 1.0e-2;
+        JumpPhysicsInputs probe = coastAir(n);
+        probe.initialVelocity = VelocityAngleSolver.velocityFor(target, SPEED, 0.0);
+        double landX = MODEL.forward(probe, facings(n)).posX[n];
+        double landZ = MODEL.forward(probe, facings(n)).posZ[n];
+        List<JumpConstraint> cons = new ArrayList<>();
+        cons.add(new JumpConstraint(JumpConstraint.Mode.X, n, null, JumpConstraint.Op.PLUS, JumpConstraint.Cmp.GE, landX - band, "XLo"));
+        cons.add(new JumpConstraint(JumpConstraint.Mode.X, n, null, JumpConstraint.Op.PLUS, JumpConstraint.Cmp.LE, landX + band, "XHi"));
+        cons.add(new JumpConstraint(JumpConstraint.Mode.Z, n, null, JumpConstraint.Op.PLUS, JumpConstraint.Cmp.GE, landZ - band, "ZLo"));
+        cons.add(new JumpConstraint(JumpConstraint.Mode.Z, n, null, JumpConstraint.Op.PLUS, JumpConstraint.Cmp.LE, landZ + band, "ZHi"));
+        Objective obj = new Objective(JumpPhysicsInputs.Axis.X, Objective.Sense.MIN, n);
+        JumpSpec spec = new JumpSpec(coastAir(n), cons, obj);
+
+        VelocityAngleSolver.Result r = new VelocityAngleSolver(MODEL, spec, facings(n), SPEED)
+                .solve(0.0, new AtomicBoolean(false));
+        assertNotNull(r);
+        assertTrue("feasible inside the landing box (viol=" + r.maxViolation + ")", r.maxViolation <= 0.0);
+        double mag = Math.hypot(r.initialVelocity.x, r.initialVelocity.z);
+        assertEquals("launch speed ~ the target magnitude", SPEED, mag, 1.0e-3);
+        double err = Math.abs(Angles.wrapDelta(r.angle360Deg - target));
+        assertTrue(
+                "within the feasible arc of theta=" + target + " (got " + r.angle360Deg + ", err " + err + ")",
+                err < 1.0
+        );
+    }
+
+    @Test
+    public void velocityForMatchesMinecraftYawBasis() {
+        Vec3dCore north = VelocityAngleSolver.velocityFor(0.0, SPEED, 0.0);
+        assertEquals(0.0, north.x, 0.0);
+        assertEquals(SPEED, north.z, 0.0);
+        Vec3dCore west = VelocityAngleSolver.velocityFor(90.0, SPEED, 0.0);
+        assertEquals(-SPEED, west.x, 1.0e-3);
+        assertEquals(0.0, west.z, 1.0e-3);
+    }
+
+    @Test
+    public void engineReportsMetConstraintsForReachableLanding() {
+        int n = 2;
+        double band = 1.0e-2;
+        JumpPhysicsInputs probe = coastAir(n);
+        probe.initialVelocity = VelocityAngleSolver.velocityFor(120.0, SPEED, 0.0);
+        double landX = MODEL.forward(probe, facings(n)).posX[n];
+        double landZ = MODEL.forward(probe, facings(n)).posZ[n];
+
+        InputData inputs = new InputData();
+        BoxController boxes = new BoxController();
+        for (int t = 0; t <= n; t++) {
+            inputs.getRows().add(new InputRow());
+            Vec3dCore pos = t == 0 ? START : Vec3dCore.ZERO;
+            boxes.add(new TickState(
+                    pos, false, false, false, 0f,
+                    Collections.<Vec3dCore>emptyList(), Vec3dCore.ZERO, false, Double.NaN
+            ));
+        }
+        AngleSolverState state = new AngleSolverState();
+        state.setDefaultInputs(AngleSolverState.InputMode.KEEP);
+        state.setStartTick(0);
+        state.setLandingTick(n);
+        state.setTargetSpeed(SPEED);
+        state.tickConstraints(n).getConstraints().add(
+                Constraint.range(Constraint.Field.X, landX - band, landX + band, true, true)
+        );
+        state.tickConstraints(n).getConstraints().add(
+                Constraint.range(Constraint.Field.Z, landZ - band, landZ + band, true, true)
+        );
+
+        AngleSolverEngine engine = new AngleSolverEngine(state, boxes, inputs, t -> { }, MODEL);
+
+        VelocityAngleSolver.Result r = engine.debugSolveVelocityAngle();
+        assertNotNull("engine built a velocity-angle problem", r);
+        double err = Math.abs(Angles.wrapDelta(r.angle360Deg - 120.0));
+        assertTrue("engine search lands near theta=120 (got " + r.angle360Deg + ")", err < 2.0);
+
+        engine.solveVelocityAngle();
+        long deadline = System.currentTimeMillis() + 10_000L;
+        while (engine.isSolving() && System.currentTimeMillis() < deadline) {
+            engine.poll();
+            sleep();
+        }
+        engine.poll();
+        SolveResult res = state.getResult();
+        assertNotNull("a result was published", res);
+        assertTrue("both pinned constraints met (" + res.getMet() + "/" + res.getTotal() + ")", res.isSuccess());
+        assertEquals(2, res.getTotal());
+        assertEquals(2, res.getMet());
+    }
+
+    private static void sleep() {
+        try {
+            Thread.sleep(2);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}


### PR DESCRIPTION
A tool to find the optimal launch-velocity direction for a jump given a target speed and the existing landing constraints. New `VelocityAngleSolver` is the dual of the facing solver: it fixes the per-tick facings (= recorded `TickState.yaw`) and searches the 1-D launch-velocity direction over `[0,360)` via a 0.2 deg global sweep + golden-section refine, reusing the engine's `ForwardModel` + `JumpConstraintCompiler`. `AngleSolverEngine.solveVelocityAngle` runs it on a worker thread (same snapshot/poll pattern as `solve()`), and the result flows into the existing result panel. New collapsible "Velocity angle" UI section (speed input, default `0.2873`); `targetSpeed` persisted in `SaveFile`.

Files: `anglesolver/VelocityAngleSolver.java` (new), `anglesolver/AngleSolverEngine.java`, `ui/anglesolver/AngleSolverWindow.java`, `anglesolver/AngleSolverState.java`, `save/SaveFile.java`, `save/SaveIO.java`. `+VelocityAngleSolverTest` (6 tests).

Closes #112

GATE: FEATURE REVIEW (v1). Deferred (TODO #112 in code): position inference from facing (v1 keeps the configured start position); Apply (the result reads off the target angle, it does not rewrite rows). Model note: because the launch vector uses MC's quantized sine table, the landing is a staircase in theta, so real constraints should be small boxes/ranges, not EQ points; the objective parks feasible results at the edge of the feasible arc.
Build: `:core:check` green (+6 tests). Scope: core-only.
Merge: angle-solver cluster. `AngleSolverWindow`/`AngleSolverState`/`SaveFile` shared with #115 and #100/#101 (additive, different sections).
