### PR TITLE
feat(ui): configurable Tick Info window (#143)

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/Settings.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/Settings.java
@@ -119,6 +119,8 @@ public final class Settings {
     public int tickInfoPrecision = DEFAULT_TICK_INFO_PRECISION;
     public int solverStatsPrecision = DEFAULT_SOLVER_STATS_PRECISION;
 
+    public TickInfoConfig tickInfoStats = TickInfoConfig.defaultConfig(DEFAULT_TICK_INFO_PRECISION);
+
     public int scaleIndex = AUTO_SCALE_INDEX; // resolved from display on first run; concrete once chosen
 
     public String[] recentFiles = new String[0];
@@ -138,6 +140,10 @@ public final class Settings {
 
     // Keep the tick-box path overlay drawn in-world during playback.
     public boolean keepBoxesDuringPlayback = DEFAULT_KEEP_BOXES_DURING_PLAYBACK;
+
+    public static int defaultTickInfoPrecision() {
+        return DEFAULT_TICK_INFO_PRECISION;
+    }
 
     // First-run default: bigger displays start at a larger preset so 4K isn't a sliver.
     public static int resolveAutoScaleIndex(int displayHeightPx) {
@@ -186,6 +192,7 @@ public final class Settings {
         scrollbarGrabMinSize = DEFAULT_SCROLLBAR_GRAB_MIN_SIZE;
         tickInfoPrecision = DEFAULT_TICK_INFO_PRECISION;
         solverStatsPrecision = DEFAULT_SOLVER_STATS_PRECISION;
+        tickInfoStats = TickInfoConfig.defaultConfig(DEFAULT_TICK_INFO_PRECISION);
         scaleIndex = DEFAULT_SCALE_INDEX;
         recentFiles = new String[0];
         viewTickInfo = DEFAULT_VIEW_TICK_INFO;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/SettingsIO.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/SettingsIO.java
@@ -51,6 +51,7 @@ public final class SettingsIO {
         }
 
         clampScaleIndex(settings);
+        normalizeTickInfoStats(settings);
     }
 
     public static void save(Path file, Settings settings) {
@@ -93,5 +94,16 @@ public final class SettingsIO {
         if (settings.scaleIndex < 0 || settings.scaleIndex >= Settings.PRESET_SCALES.length) {
             settings.scaleIndex = Settings.DEFAULT_SCALE_INDEX;
         }
+    }
+
+    private static void normalizeTickInfoStats(Settings settings) {
+        if (settings.tickInfoStats == null) {
+            settings.tickInfoStats = TickInfoConfig.defaultConfig(Settings.defaultTickInfoPrecision());
+            return;
+        }
+        settings.tickInfoStats.normalize(
+                Settings.defaultTickInfoPrecision(),
+                Settings.MIN_STAT_PRECISION,
+                Settings.MAX_STAT_PRECISION);
     }
 }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/SettingsModal.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/SettingsModal.java
@@ -52,7 +52,7 @@ public final class SettingsModal {
     private static final String TT_KEEP_BOXES_PLAYBACK = "Keeps the tick-box path overlay drawn in-world while playback is running, instead of hiding it.";
     private static final String TT_AUTO_APPLY = "Applies a feasible Angle Solver solution to the input rows the moment the solve finishes, skipping the Apply confirmation.";
     private static final String TT_AUTO_SAVE = "Saves the open TAS automatically while it has unsaved changes, at most every 30 seconds. Needs a named save (use Save As once); Ctrl+S still saves instantly.";
-    private static final String TT_TICK_INFO_PRECISION = "Decimal places shown for numeric values in the Tick Info panel.";
+    private static final String TT_TICK_INFO_PRECISION = "Default decimal places for Tick Info stats. Each stat's precision can be overridden by right-clicking the Tick Info window; new and reset stats start from this value.";
     private static final String TT_SOLVER_PRECISION = "Decimal places for Angle Solver stats: solved yaws, objective values, constraint chips, and the constraint value editor.";
 
     private final Settings settings;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/SettingsModal.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/SettingsModal.java
@@ -20,7 +20,8 @@ public final class SettingsModal {
     private static final String RESET_BTN = "Reset All";
     private static final float CONTROL_COL_EMS = 12f;
     private static final float LABEL_COL_EMS = 18f; // fixed so the control column lines up across every subsection table
-    private static final float MODAL_MAX_WIDTH_EMS = 36f;
+    private static final float MODAL_MIN_WIDTH_EMS = 38f;
+    private static final float MODAL_MAX_WIDTH_EMS = 44f;
 
     private static final String TT_UI_SCALE = "Multiplier applied to all ImGui widgets and fonts. 1.5x is the default for 1080p.";
     private static final String TT_SCROLLBAR_SIZE = "Thickness of scrollbars: the width of vertical bars and the height of horizontal ones. Scales with UI Scale.";
@@ -52,18 +53,17 @@ public final class SettingsModal {
     private static final String TT_KEEP_BOXES_PLAYBACK = "Keeps the tick-box path overlay drawn in-world while playback is running, instead of hiding it.";
     private static final String TT_AUTO_APPLY = "Applies a feasible Angle Solver solution to the input rows the moment the solve finishes, skipping the Apply confirmation.";
     private static final String TT_AUTO_SAVE = "Saves the open TAS automatically while it has unsaved changes, at most every 30 seconds. Needs a named save (use Save As once); Ctrl+S still saves instantly.";
-    private static final String TT_TICK_INFO_PRECISION = "Default decimal places for Tick Info stats. Each stat's precision can be overridden by right-clicking the Tick Info window; new and reset stats start from this value.";
     private static final String TT_SOLVER_PRECISION = "Decimal places for Angle Solver stats: solved yaws, objective values, constraint chips, and the constraint value editor.";
 
     private final Settings settings;
     private final Runnable onChanged;
+    private final TickInfoStatsEditor tickInfoStatsEditor;
 
     private final ImInt scaleIndexBuf = new ImInt();
     private final float[] yawTurnCapBuf = new float[1];
     private final int[] pathRenderDistanceBuf = new int[1];
     private final float[] scrollbarSizeBuf = new float[1];
     private final float[] scrollbarGrabBuf = new float[1];
-    private final int[] tickInfoPrecisionBuf = new int[1];
     private final int[] solverPrecisionBuf = new int[1];
     private final String[] scaleLabels;
 
@@ -72,6 +72,7 @@ public final class SettingsModal {
     public SettingsModal(Settings settings, Runnable onChanged) {
         this.settings = settings;
         this.onChanged = onChanged;
+        this.tickInfoStatsEditor = new TickInfoStatsEditor(settings, onChanged);
         this.scaleLabels = buildScaleLabels();
     }
 
@@ -93,7 +94,8 @@ public final class SettingsModal {
         }
         // Cap width so the auto-resize popup can't balloon; it still hugs content below the cap.
         if (ImGui.isPopupOpen(POPUP_ID)) {
-            ImGui.setNextWindowSizeConstraints(0f, 0f, ImGui.getFontSize() * MODAL_MAX_WIDTH_EMS, Float.MAX_VALUE);
+            float em = ImGui.getFontSize();
+            ImGui.setNextWindowSizeConstraints(em * MODAL_MIN_WIDTH_EMS, 0f, em * MODAL_MAX_WIDTH_EMS, Float.MAX_VALUE);
         }
         if (!Modal.begin("Preferences", POPUP_ID)) {
             return;
@@ -115,6 +117,10 @@ public final class SettingsModal {
             }
             if (Controls.beginTab("Input Table")) {
                 renderInputTable();
+                Controls.endTab();
+            }
+            if (Controls.beginTab("Tick Info")) {
+                renderTickInfo();
                 Controls.endTab();
             }
             if (Controls.beginTab("Playback")) {
@@ -192,22 +198,6 @@ public final class SettingsModal {
         }
 
         ThemeManager.sectionSpacing();
-        sectionHeader("Tick Info");
-        if (beginLayoutTable("##settings_tick_info")) {
-            row("Decimal places", () -> {
-                tickInfoPrecisionBuf[0] = settings.tickInfoPrecision;
-                ImGui.setNextItemWidth(-1);
-                if (Controls.sliderInt("##tick_info_precision", tickInfoPrecisionBuf,
-                        Settings.MIN_STAT_PRECISION, Settings.MAX_STAT_PRECISION, "%d decimals")) {
-                    settings.tickInfoPrecision = tickInfoPrecisionBuf[0];
-                }
-                if (ImGui.isItemDeactivatedAfterEdit()) onChanged.run();
-                tooltipForLastItem(TT_TICK_INFO_PRECISION);
-            });
-            ThemeManager.endStandardFormTable();
-        }
-
-        ThemeManager.sectionSpacing();
         sectionHeader("Angle Solver");
         if (beginLayoutTable("##settings_angle_solver")) {
             checkboxRow("Auto-apply solutions", "##auto_apply_solve", settings.autoApplySolve, TT_AUTO_APPLY, v -> settings.autoApplySolve = v);
@@ -280,6 +270,14 @@ public final class SettingsModal {
             checkboxRow("Highlight on-ground ticks", "##highlight_on_ground", settings.highlightOnGroundRows, TT_GROUND_HIGHLIGHT, v -> settings.highlightOnGroundRows = v);
             ThemeManager.endStandardFormTable();
         }
+    }
+
+    private void renderTickInfo() {
+        ThemeManager.sectionSpacing();
+        sectionHeader("Stats");
+        ImGui.textDisabled("Toggle, set decimals, and drag to reorder.");
+        ThemeManager.sectionSpacing();
+        tickInfoStatsEditor.render();
     }
 
     private void renderPlayback() {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/TickInfoConfig.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/TickInfoConfig.java
@@ -1,0 +1,79 @@
+package de.legoshi.parkourcalc.core.ui;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class TickInfoConfig {
+
+    public List<TickInfoStatSetting> stats;
+
+    public TickInfoConfig() {
+        this.stats = new ArrayList<>();
+    }
+
+    public static TickInfoConfig defaultConfig(int defaultDecimals) {
+        TickInfoConfig config = new TickInfoConfig();
+        for (TickInfoStat stat : TickInfoStat.values()) {
+            config.stats.add(new TickInfoStatSetting(stat.id(), true, defaultDecimals));
+        }
+        return config;
+    }
+
+    public void normalize(int defaultDecimals, int minDecimals, int maxDecimals) {
+        List<TickInfoStatSetting> cleaned = new ArrayList<>();
+        java.util.Set<TickInfoStat> seen = java.util.EnumSet.noneOf(TickInfoStat.class);
+
+        if (stats != null) {
+            for (TickInfoStatSetting setting : stats) {
+                if (setting == null) continue;
+                TickInfoStat stat = TickInfoStat.byId(setting.id);
+                if (stat == null || seen.contains(stat)) continue;
+                seen.add(stat);
+                setting.id = stat.id();
+                setting.decimals = clamp(setting.decimals, minDecimals, maxDecimals);
+                cleaned.add(setting);
+            }
+        }
+        for (TickInfoStat stat : TickInfoStat.values()) {
+            if (!seen.contains(stat)) {
+                cleaned.add(new TickInfoStatSetting(stat.id(), true, clamp(defaultDecimals, minDecimals, maxDecimals)));
+            }
+        }
+        stats = cleaned;
+    }
+
+    public TickInfoStatSetting find(TickInfoStat stat) {
+        if (stats == null || stat == null) return null;
+        for (TickInfoStatSetting setting : stats) {
+            if (setting != null && stat.id().equals(setting.id)) return setting;
+        }
+        return null;
+    }
+
+    public List<TickInfoStat> enabledInOrder() {
+        List<TickInfoStat> result = new ArrayList<>();
+        if (stats == null) return result;
+        for (TickInfoStatSetting setting : stats) {
+            if (setting == null || !setting.enabled) continue;
+            TickInfoStat stat = TickInfoStat.byId(setting.id);
+            if (stat != null) result.add(stat);
+        }
+        return result;
+    }
+
+    public void move(int from, int to) {
+        if (stats == null) return;
+        int size = stats.size();
+        if (from < 0 || from >= size || to < 0 || to > size) return;
+        if (to == from || to == from + 1) return;
+        TickInfoStatSetting moved = stats.remove(from);
+        int dest = to > from ? to - 1 : to;
+        stats.add(dest, moved);
+    }
+
+    private static int clamp(int value, int lo, int hi) {
+        if (value < lo) return lo;
+        if (value > hi) return hi;
+        return value;
+    }
+}

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/TickInfoConfigPopup.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/TickInfoConfigPopup.java
@@ -1,0 +1,202 @@
+package de.legoshi.parkourcalc.core.ui;
+
+import de.legoshi.parkourcalc.core.ui.theme.Controls;
+import de.legoshi.parkourcalc.core.ui.theme.ThemeManager;
+import de.legoshi.parkourcalc.core.ui.util.TooltipUtil;
+import imgui.ImDrawList;
+import imgui.ImGui;
+import imgui.ImVec2;
+import imgui.flag.ImGuiDragDropFlags;
+import imgui.flag.ImGuiMouseCursor;
+import imgui.flag.ImGuiSelectableFlags;
+import imgui.flag.ImGuiTableColumnFlags;
+
+import java.util.List;
+
+public final class TickInfoConfigPopup {
+
+    private static final String POPUP_ID = "###tick-info-config";
+    private static final String TABLE_ID = "tick-info-config-table";
+    private static final String TITLE = "Tick Info stats";
+    private static final String SUBTITLE = "Toggle, set decimals, and drag to reorder.";
+    private static final String RESET_BTN = "Reset to defaults";
+    private static final String GRIP = "::";
+    private static final String DRAG_DROP_TYPE = "TICK_INFO_STAT";
+
+    private static final String COL_STAT = "Stat";
+    private static final String COL_ON = "On";
+    private static final String COL_DECIMALS = "Decimals";
+
+    private static final float DECIMALS_SLIDER_EMS = 9f;
+    private static final String TT_TOGGLE = "Show or hide this stat in the Tick Info panel.";
+    private static final String TT_DECIMALS = "Decimal places used for this stat's numeric value(s).";
+    private static final String TT_GRIP = "Drag to reorder.";
+
+    private final Settings settings;
+    private final int[] decimalsBuf = new int[1];
+
+    private int draggingIndex = -1;
+    private int dropTarget = -1;
+    private float dropLineY = -1f;
+    private float rowMinX, rowMaxX;
+    private boolean openRequested;
+
+    public TickInfoConfigPopup(Settings settings) {
+        this.settings = settings;
+    }
+
+    public void handleOpenOnRightClick(int hoveredFlags) {
+        if (ImGui.isMouseReleased(1) && ImGui.isWindowHovered(hoveredFlags)) {
+            openRequested = true;
+        }
+    }
+
+    public void render() {
+        if (openRequested) {
+            ImGui.openPopup(POPUP_ID);
+            openRequested = false;
+        }
+        if (!ImGui.beginPopup(POPUP_ID)) {
+            draggingIndex = -1;
+            return;
+        }
+
+        ImGui.textDisabled(SUBTITLE);
+        ThemeManager.paddedSeparator();
+
+        renderStatTable();
+
+        ThemeManager.paddedSeparator();
+        if (Controls.secondaryButton(RESET_BTN)) {
+            settings.tickInfoStats = TickInfoConfig.defaultConfig(Settings.defaultTickInfoPrecision());
+            draggingIndex = -1;
+        }
+
+        ImGui.endPopup();
+    }
+
+    private void renderStatTable() {
+        List<TickInfoStatSetting> stats = settings.tickInfoStats != null ? settings.tickInfoStats.stats : null;
+        if (stats == null || stats.isEmpty()) {
+            ImGui.text(TITLE + ": none");
+            return;
+        }
+
+        if (!ThemeManager.beginStandardKeyValueTable(TABLE_ID, 3, 0, 0f, 0f)) {
+            return;
+        }
+        int fixed = ImGuiTableColumnFlags.WidthFixed;
+        float cellPad = ImGui.getStyle().getCellPadding().x;
+        float labelW = ImGui.calcTextSize(GRIP + "  Collision angle (deg)").x + 2f * cellPad;
+        float onW = ImGui.calcTextSize(COL_ON).x + 2f * cellPad + ImGui.getFrameHeight();
+        float decW = ImGui.getFontSize() * DECIMALS_SLIDER_EMS;
+        ImGui.tableSetupColumn(COL_STAT, fixed, ThemeManager.tableLeftmostColumnWidth(COL_STAT, labelW));
+        ImGui.tableSetupColumn(COL_ON, fixed, ThemeManager.tableColumnWidth(COL_ON, onW));
+        ImGui.tableSetupColumn(COL_DECIMALS, fixed,
+                ThemeManager.tableRightmostColumnWidth(COL_DECIMALS, decW, ThemeManager.tableFixedScrollbarSlack()));
+
+        dropLineY = -1f;
+        for (int i = 0; i < stats.size(); i++) {
+            renderStatRow(i, stats.get(i));
+        }
+
+        drawDropIndicator();
+        applyDragDrop(stats.size());
+
+        ThemeManager.endStandardTable();
+    }
+
+    private void renderStatRow(int index, TickInfoStatSetting setting) {
+        TickInfoStat stat = TickInfoStat.byId(setting.id);
+        String label = stat != null ? stat.label() : setting.id;
+        String tooltip = stat != null ? stat.tooltip() : "";
+
+        ImGui.tableNextRow();
+        ThemeManager.paintTableRowBg(index);
+        if (draggingIndex == index) {
+            ThemeManager.paintTableRowTint(ThemeManager.selectedTintColor(0.5f));
+        }
+
+        ImGui.tableNextColumn();
+        ThemeManager.tableLeftmostCellPad();
+        ThemeManager.pushTextColor(draggingIndex == index ? ThemeManager.textColor() : ThemeManager.textMutedColor());
+        ThemeManager.rightAlignedSelectable(
+                "stat" + index, GRIP + "  " + label, draggingIndex == index,
+                ImGuiSelectableFlags.SpanAllColumns | ImGuiSelectableFlags.AllowItemOverlap);
+        ThemeManager.popTextColor();
+        TooltipUtil.onHover(tooltip.isEmpty() ? TT_GRIP : tooltip);
+        if (ImGui.isItemHovered()) ImGui.setMouseCursor(ImGuiMouseCursor.Hand);
+        handleRowDragDrop(index);
+
+        ImGui.tableNextColumn();
+        if (Controls.checkbox("##on" + index, setting.enabled)) {
+            setting.enabled = !setting.enabled;
+        }
+        TooltipUtil.onHover(TT_TOGGLE);
+
+        ImGui.tableNextColumn();
+        boolean numeric = usesDecimals(stat);
+        if (!numeric) ImGui.beginDisabled(true);
+        decimalsBuf[0] = setting.decimals;
+        ImGui.setNextItemWidth(-1);
+        if (Controls.sliderInt("##dec" + index, decimalsBuf,
+                Settings.MIN_STAT_PRECISION, Settings.MAX_STAT_PRECISION, "%d") && numeric) {
+            setting.decimals = decimalsBuf[0];
+        }
+        if (!numeric) ImGui.endDisabled();
+        TooltipUtil.onHover(TT_DECIMALS);
+        ThemeManager.tableRightmostCellTrailingPad();
+    }
+
+    private void handleRowDragDrop(int index) {
+        if (ImGui.beginDragDropSource(ImGuiDragDropFlags.SourceNoPreviewTooltip)) {
+            draggingIndex = index;
+            // Payload is never read back (imgui-java weak-refs it); the move is resolved from draggingIndex.
+            ImGui.setDragDropPayload(DRAG_DROP_TYPE, Integer.valueOf(index));
+            ImGui.endDragDropSource();
+        }
+        if (draggingIndex == -1) return;
+
+        ImVec2 rowMin = ImGui.getItemRectMin();
+        ImVec2 rowMax = ImGui.getItemRectMax();
+        rowMinX = rowMin.x;
+        rowMaxX = ImGui.getWindowPos().x + ImGui.getWindowWidth();
+
+        ImVec2 mouse = ImGui.getMousePos();
+        float gap = ImGui.getStyle().getCellPadding().y;
+        if (mouse.y < rowMin.y - gap - 1f || mouse.y >= rowMax.y + gap + 1f) return;
+
+        boolean insertAbove = mouse.y < (rowMin.y + rowMax.y) / 2f;
+        dropLineY = insertAbove ? rowMin.y - gap : rowMax.y + gap;
+        dropTarget = insertAbove ? index : index + 1;
+    }
+
+    private void drawDropIndicator() {
+        if (draggingIndex == -1 || dropLineY <= 0f) return;
+        ImDrawList dl = ImGui.getWindowDrawList();
+        dl.addLine(rowMinX, dropLineY, rowMaxX, dropLineY, ThemeManager.warningColor(), 2.0f);
+    }
+
+    private void applyDragDrop(int size) {
+        if (draggingIndex == -1) return;
+        if (ImGui.isMouseReleased(0)) {
+            int from = draggingIndex;
+            int to = dropTarget;
+            draggingIndex = -1;
+            dropTarget = -1;
+            if (to >= 0 && to <= size && settings.tickInfoStats != null) {
+                settings.tickInfoStats.move(from, to);
+            }
+        } else if (!ImGui.isMouseDown(0)) {
+            draggingIndex = -1;
+            dropTarget = -1;
+        }
+    }
+
+    private static boolean usesDecimals(TickInfoStat stat) {
+        if (stat == null) return false;
+        return stat.kind() == TickInfoStat.Kind.NUM
+                || stat.kind() == TickInfoStat.Kind.TRIPLE
+                || stat.kind() == TickInfoStat.Kind.XZ;
+    }
+}

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/TickInfoPanel.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/TickInfoPanel.java
@@ -8,7 +8,7 @@ import de.legoshi.parkourcalc.core.ui.theme.ThemeManager;
 import de.legoshi.parkourcalc.core.ui.util.TooltipUtil;
 import imgui.ImGui;
 import imgui.ImGuiIO;
-import imgui.flag.ImGuiHoveredFlags;
+import imgui.flag.ImGuiCond;
 import imgui.flag.ImGuiTableColumnFlags;
 import imgui.flag.ImGuiWindowFlags;
 
@@ -35,7 +35,6 @@ public final class TickInfoPanel implements RenderInterface {
     private final SelectionManager selection;
     private final Settings settings;
     private final SimulationRunner runner;
-    private final TickInfoConfigPopup configPopup;
     private int rowCounter;
 
     private int sampleDecimals = -1;
@@ -47,7 +46,6 @@ public final class TickInfoPanel implements RenderInterface {
         this.selection = selection;
         this.settings = settings;
         this.runner = runner;
-        this.configPopup = new TickInfoConfigPopup(settings);
     }
 
     private float effectivePitch(int idx) {
@@ -96,16 +94,15 @@ public final class TickInfoPanel implements RenderInterface {
 
     @Override
     public void render(ImGuiIO io) {
-        if (!ThemeManager.beginPanel(WINDOW_ID, WINDOW_TITLE,
-                ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.AlwaysAutoResize)) {
+        float em = ImGui.getFontSize();
+        ImGui.setNextWindowSize(em * 17f, em * 26f, ImGuiCond.FirstUseEver);
+        ImGui.setNextWindowSizeConstraints(em * 11f, em * 6f, Float.MAX_VALUE, Float.MAX_VALUE);
+        if (!ThemeManager.beginPanel(WINDOW_ID, WINDOW_TITLE, ImGuiWindowFlags.NoCollapse)) {
             return;
         }
 
-        configPopup.handleOpenOnRightClick(ImGuiHoveredFlags.ChildWindows | ImGuiHoveredFlags.AllowWhenBlockedByPopup);
-
         if (selection.size() != 1) {
             ImGui.text(PLACEHOLDER_SELECT_ONE);
-            configPopup.render();
             ImGui.end();
             return;
         }
@@ -114,7 +111,6 @@ public final class TickInfoPanel implements RenderInterface {
         List<TickState> states = boxController.getStates();
         if (pathIndex < 0 || pathIndex >= states.size()) {
             ImGui.text(PLACEHOLDER_OUT_OF_RANGE);
-            configPopup.render();
             ImGui.end();
             return;
         }
@@ -128,7 +124,6 @@ public final class TickInfoPanel implements RenderInterface {
         float appliedPitch = isStart ? runner.getStartPitch() : effectivePitch(idx);
 
         renderTable(idx, cur, prev, prev2, appliedYaw, appliedPitch, isStart);
-        configPopup.render();
         ImGui.end();
     }
 

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/TickInfoPanel.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/TickInfoPanel.java
@@ -8,13 +8,13 @@ import de.legoshi.parkourcalc.core.ui.theme.ThemeManager;
 import de.legoshi.parkourcalc.core.ui.util.TooltipUtil;
 import imgui.ImGui;
 import imgui.ImGuiIO;
+import imgui.flag.ImGuiHoveredFlags;
 import imgui.flag.ImGuiTableColumnFlags;
 import imgui.flag.ImGuiWindowFlags;
 
 import java.util.List;
 import java.util.Locale;
 
-/** Read-only inspector for the single currently-selected tick. */
 public final class TickInfoPanel implements RenderInterface {
 
     private static final String WINDOW_ID = "###tick-info";
@@ -22,6 +22,7 @@ public final class TickInfoPanel implements RenderInterface {
     private static final String TABLE_ID = "tick-info-table";
     private static final String PLACEHOLDER_SELECT_ONE = "Select a single tick.";
     private static final String PLACEHOLDER_OUT_OF_RANGE = "No tick data (resimulating).";
+    private static final String PLACEHOLDER_NO_STATS = "No stats enabled. Right-click to configure.";
     private static final String NA = "n/a";
 
     private static final String COL_FIELD = "Field";
@@ -34,12 +35,11 @@ public final class TickInfoPanel implements RenderInterface {
     private final SelectionManager selection;
     private final Settings settings;
     private final SimulationRunner runner;
+    private final TickInfoConfigPopup configPopup;
     private int rowCounter;
 
-    private int fmtPrecision = -1;
-    private String fmtNum;
-    private String fmtNumSingle;
-    private String numSample;
+    private int sampleDecimals = -1;
+    private String numSample = "";
 
     public TickInfoPanel(BoxController boxController, InputData inputData, SelectionManager selection, Settings settings, SimulationRunner runner) {
         this.boxController = boxController;
@@ -47,6 +47,7 @@ public final class TickInfoPanel implements RenderInterface {
         this.selection = selection;
         this.settings = settings;
         this.runner = runner;
+        this.configPopup = new TickInfoConfigPopup(settings);
     }
 
     private float effectivePitch(int idx) {
@@ -58,15 +59,39 @@ public final class TickInfoPanel implements RenderInterface {
         return p;
     }
 
-    private void rebuildFormats() {
-        int p = Math.min(Math.max(settings.tickInfoPrecision, Settings.MIN_STAT_PRECISION), Settings.MAX_STAT_PRECISION);
-        if (p == fmtPrecision) return;
-        fmtPrecision = p;
-        fmtNum = "%" + (7 + p) + "." + p + "f";
-        fmtNumSingle = "%." + p + "f";
+    private static int clampPrecision(int p) {
+        return Math.min(Math.max(p, Settings.MIN_STAT_PRECISION), Settings.MAX_STAT_PRECISION);
+    }
+
+    private static String fmtNum(int decimals) {
+        int d = clampPrecision(decimals);
+        return "%" + (7 + d) + "." + d + "f";
+    }
+
+    private static String fmtNumSingle(int decimals) {
+        int d = clampPrecision(decimals);
+        return "%." + d + "f";
+    }
+
+    private void rebuildColumnSample(int widestDecimals) {
+        int d = clampPrecision(widestDecimals);
+        if (d == sampleDecimals) return;
+        sampleDecimals = d;
         StringBuilder sample = new StringBuilder("-99999.");
-        for (int i = 0; i < p; i++) sample.append('9');
+        for (int i = 0; i < d; i++) sample.append('9');
         numSample = sample.toString();
+    }
+
+    private int widestEnabledDecimals() {
+        int widest = Settings.MIN_STAT_PRECISION;
+        TickInfoConfig config = settings.tickInfoStats;
+        if (config == null || config.stats == null) return widest;
+        for (TickInfoStatSetting setting : config.stats) {
+            if (setting != null && setting.enabled && setting.decimals > widest) {
+                widest = setting.decimals;
+            }
+        }
+        return clampPrecision(widest);
     }
 
     @Override
@@ -76,8 +101,11 @@ public final class TickInfoPanel implements RenderInterface {
             return;
         }
 
+        configPopup.handleOpenOnRightClick(ImGuiHoveredFlags.ChildWindows | ImGuiHoveredFlags.AllowWhenBlockedByPopup);
+
         if (selection.size() != 1) {
             ImGui.text(PLACEHOLDER_SELECT_ONE);
+            configPopup.render();
             ImGui.end();
             return;
         }
@@ -86,6 +114,7 @@ public final class TickInfoPanel implements RenderInterface {
         List<TickState> states = boxController.getStates();
         if (pathIndex < 0 || pathIndex >= states.size()) {
             ImGui.text(PLACEHOLDER_OUT_OF_RANGE);
+            configPopup.render();
             ImGui.end();
             return;
         }
@@ -99,6 +128,7 @@ public final class TickInfoPanel implements RenderInterface {
         float appliedPitch = isStart ? runner.getStartPitch() : effectivePitch(idx);
 
         renderTable(idx, cur, prev, prev2, appliedYaw, appliedPitch, isStart);
+        configPopup.render();
         ImGui.end();
     }
 
@@ -108,7 +138,13 @@ public final class TickInfoPanel implements RenderInterface {
     }
 
     private void renderTable(int idx, TickState cur, TickState prev, TickState prev2, float appliedYaw, float appliedPitch, boolean isStart) {
-        rebuildFormats();
+        List<TickInfoStat> enabled = settings.tickInfoStats.enabledInOrder();
+        if (enabled.isEmpty()) {
+            ImGui.text(PLACEHOLDER_NO_STATS);
+            return;
+        }
+
+        rebuildColumnSample(widestEnabledDecimals());
         if (!ThemeManager.beginStandardKeyValueTable(TABLE_ID, 4, 0, 0f, 0f)) {
             return;
         }
@@ -122,81 +158,130 @@ public final class TickInfoPanel implements RenderInterface {
         ImGui.tableSetupColumn(COL_Z, fixed, ThemeManager.tableRightmostColumnWidth(COL_Z, numW, ThemeManager.tableFixedScrollbarSlack()));
 
         rowCounter = 0;
-
-        if (isStart) {
-            rowText("Tick", "Start", "The simulation's start state: the seed the run launches from.");
-        } else {
-            rowInt("Tick", idx + 1, "Tick number (1-based), matching the input table's Tick column.");
-        }
-        rowNum("Yaw", appliedYaw, "Facing applied during this tick (drives this tick's movement). MC convention: 0 = +Z, increases CW looking down.");
-        rowNum("Pitch", appliedPitch, "Camera pitch held during this tick (-90 up, 90 down). Defaults to 40; each row adds a relative turn unless locked to an absolute value. Display only; pitch does not affect movement.");
-
-        if (prev != null) {
-            double dx = cur.position.x - prev.position.x;
-            double dz = cur.position.z - prev.position.z;
-            rowNum("Speed (XZ)", Math.sqrt(dx * dx + dz * dz),"Horizontal magnitude of actual displacement this tick, sqrt(dx^2 + dz^2), blocks/tick.");
-        } else {
-            rowNa("Speed (XZ)", "Horizontal magnitude of actual displacement this tick, sqrt(dx^2 + dz^2), blocks/tick.");
-        }
-
-        double motionXZ = Math.sqrt(cur.velocity.x * cur.velocity.x + cur.velocity.z * cur.velocity.z);
-        double motionXYZ = Math.sqrt(cur.velocity.x * cur.velocity.x + cur.velocity.y * cur.velocity.y + cur.velocity.z * cur.velocity.z);
-        rowNum("Motion (XZ)", motionXZ, "Horizontal magnitude of post-tick velocity, sqrt(vx^2 + vz^2), blocks/tick. Differs from Speed on collision ticks.");
-        rowNum("Motion (XYZ)", motionXYZ, "Total magnitude of post-tick velocity, sqrt(vx^2 + vy^2 + vz^2), blocks/tick.");
-
-        rowTriple("Position", cur.position.x, cur.position.y, cur.position.z, "Entity position entering this tick, before this tick's input is applied (the start seed for the Start row). This tick's movement shows on the next tick. World coords; anchor corner of the rendered tick box.");
-        rowTriple("Motion", cur.velocity.x, cur.velocity.y, cur.velocity.z, "Post-tick motionX/Y/Z (after MC's per-axis collision clamp). May read 0 on an axis where a wall was hit.");
-
-        if (prev != null) {
-            double dx = cur.position.x - prev.position.x;
-            double dy = cur.position.y - prev.position.y;
-            double dz = cur.position.z - prev.position.z;
-            rowTriple("Speed", dx, dy, dz, "Position(i) - position(i-1), the actual displacement vector this tick.");
-            rowXZ("Post motion (XZ)", dx, dz, "Per-axis horizontal displacement this tick: (deltaX, deltaZ). Differs from Motion on collision-clamp ticks.");
-        } else {
-            rowNa("Speed", "Position(i) - position(i-1), the actual displacement vector this tick.");
-            rowNa("Post motion (XZ)", "Per-axis horizontal displacement this tick: (deltaX, deltaZ). Differs from Motion on collision-clamp ticks.");
-        }
-
-        if (prev != null && prev2 != null) {
-            double dx = cur.position.x - prev.position.x;
-            double dz = cur.position.z - prev.position.z;
-            double pdx = prev.position.x - prev2.position.x;
-            double pdz = prev.position.z - prev2.position.z;
-            rowXZ("Acceleration (XZ)", dx - pdx, dz - pdz, "Per-axis change in post motion: (deltaX(i) - deltaX(i-1), deltaZ(i) - deltaZ(i-1)).");
-        } else {
-            rowNa("Acceleration (XZ)", "Per-axis change in post motion: (deltaX(i) - deltaX(i-1), deltaZ(i) - deltaZ(i-1)).");
-        }
-
-        if (prev != null) {
-            double dx = cur.position.x - prev.position.x;
-            double dz = cur.position.z - prev.position.z;
-            if (dx * dx + dz * dz < 1.0e-18) {
-                rowNa("Speed (angle)", "Movement direction in XZ. MC yaw convention: 0 = +Z, increases CW looking down (atan2(-dx, dz)).");
-            } else {
-                rowNum("Speed (angle)", Math.toDegrees(Math.atan2(-dx, dz)), "Movement direction in XZ. MC yaw convention: 0 = +Z, increases CW looking down (atan2(-dx, dz)).");
-            }
-        } else {
-            rowNa("Speed (angle)", "Movement direction in XZ. MC yaw convention: 0 = +Z, increases CW looking down (atan2(-dx, dz)).");
-        }
-
-        rowBool("On ground", cur.onGround, "Entity onGround flag at end of tick.");
-        rowBool("Sneaking", cur.sneaking, "Sneak input active during this tick.");
-        rowBool("Collision", cur.wallCollision, "Horizontal collision occurred this tick (MC horizontalCollision).");
-
-        if (cur.wallCollision) {
-            rowBool("Soft collision", cur.softCollision, "1.21.10 only: grazing wall hit that does NOT break sprint (Entity.collidedSoftly). Always false on 1.8.9/1.12.2.");
-        } else {
-            rowNa("Soft collision", "1.21.10 only: grazing wall hit that does NOT break sprint. n/a when no horizontal collision is happening.");
-        }
-
-        if (Double.isNaN(cur.collisionAngleDegrees)) {
-            rowNa("Collision angle (deg)", "1.21.10 only: angle between intended motion (forwardSpeed/sidewaysSpeed rotated by yaw) and post-collision motion. n/a on 1.8.9/1.12.2 or off-collision ticks.");
-        } else {
-            rowNum("Collision angle (deg)", cur.collisionAngleDegrees, "1.21.10 only: angle between intended motion and post-collision motion. MC keeps sprint when this is below ~8 deg (0.13962634 rad).");
+        for (TickInfoStat stat : enabled) {
+            int decimals = decimalsFor(stat);
+            renderStatRow(stat, decimals, idx, cur, prev, prev2, appliedYaw, appliedPitch, isStart);
         }
 
         ThemeManager.endStandardTable();
+    }
+
+    private int decimalsFor(TickInfoStat stat) {
+        TickInfoStatSetting setting = settings.tickInfoStats.find(stat);
+        int d = setting != null ? setting.decimals : Settings.defaultTickInfoPrecision();
+        return clampPrecision(d);
+    }
+
+    private void renderStatRow(TickInfoStat stat, int decimals, int idx,
+                               TickState cur, TickState prev, TickState prev2, float appliedYaw, float appliedPitch, boolean isStart) {
+        String tip = stat.tooltip();
+        String naTip = stat.naTooltip();
+        switch (stat) {
+            case TICK:
+                if (isStart) {
+                    rowText(stat.label(), "Start", "The simulation's start state: the seed the run launches from.");
+                } else {
+                    rowInt(stat.label(), idx + 1, tip);
+                }
+                break;
+            case YAW:
+                rowNum(stat.label(), appliedYaw, decimals, tip);
+                break;
+            case PITCH:
+                rowNum(stat.label(), appliedPitch, decimals, tip);
+                break;
+            case SPEED_XZ:
+                if (prev != null) {
+                    double dx = cur.position.x - prev.position.x;
+                    double dz = cur.position.z - prev.position.z;
+                    rowNum(stat.label(), Math.sqrt(dx * dx + dz * dz), decimals, tip);
+                } else {
+                    rowNa(stat.label(), naTip);
+                }
+                break;
+            case MOTION_XZ:
+                rowNum(stat.label(),
+                        Math.sqrt(cur.velocity.x * cur.velocity.x + cur.velocity.z * cur.velocity.z), decimals, tip);
+                break;
+            case MOTION_XYZ:
+                rowNum(stat.label(),
+                        Math.sqrt(cur.velocity.x * cur.velocity.x + cur.velocity.y * cur.velocity.y + cur.velocity.z * cur.velocity.z),
+                        decimals, tip);
+                break;
+            case POSITION:
+                rowTriple(stat.label(), cur.position.x, cur.position.y, cur.position.z, decimals, tip);
+                break;
+            case MOTION:
+                rowTriple(stat.label(), cur.velocity.x, cur.velocity.y, cur.velocity.z, decimals, tip);
+                break;
+            case SPEED:
+                if (prev != null) {
+                    rowTriple(stat.label(),
+                            cur.position.x - prev.position.x,
+                            cur.position.y - prev.position.y,
+                            cur.position.z - prev.position.z, decimals, tip);
+                } else {
+                    rowNa(stat.label(), naTip);
+                }
+                break;
+            case POST_MOTION_XZ:
+                if (prev != null) {
+                    rowXZ(stat.label(), cur.position.x - prev.position.x, cur.position.z - prev.position.z, decimals, tip);
+                } else {
+                    rowNa(stat.label(), naTip);
+                }
+                break;
+            case ACCELERATION_XZ:
+                if (prev != null && prev2 != null) {
+                    double dx = cur.position.x - prev.position.x;
+                    double dz = cur.position.z - prev.position.z;
+                    double pdx = prev.position.x - prev2.position.x;
+                    double pdz = prev.position.z - prev2.position.z;
+                    rowXZ(stat.label(), dx - pdx, dz - pdz, decimals, tip);
+                } else {
+                    rowNa(stat.label(), naTip);
+                }
+                break;
+            case SPEED_ANGLE:
+                if (prev != null) {
+                    double dx = cur.position.x - prev.position.x;
+                    double dz = cur.position.z - prev.position.z;
+                    if (dx * dx + dz * dz < 1.0e-18) {
+                        rowNa(stat.label(), naTip);
+                    } else {
+                        rowNum(stat.label(), Math.toDegrees(Math.atan2(-dx, dz)), decimals, tip);
+                    }
+                } else {
+                    rowNa(stat.label(), naTip);
+                }
+                break;
+            case ON_GROUND:
+                rowBool(stat.label(), cur.onGround, tip);
+                break;
+            case SNEAKING:
+                rowBool(stat.label(), cur.sneaking, tip);
+                break;
+            case COLLISION:
+                rowBool(stat.label(), cur.wallCollision, tip);
+                break;
+            case SOFT_COLLISION:
+                if (cur.wallCollision) {
+                    rowBool(stat.label(), cur.softCollision, tip);
+                } else {
+                    rowNa(stat.label(), naTip);
+                }
+                break;
+            case COLLISION_ANGLE:
+                if (Double.isNaN(cur.collisionAngleDegrees)) {
+                    rowNa(stat.label(), naTip);
+                } else {
+                    rowNum(stat.label(), cur.collisionAngleDegrees, decimals, tip);
+                }
+                break;
+            default:
+                rowNa(stat.label(), naTip);
+                break;
+        }
     }
 
     private void labelCell(String label, String tooltip) {
@@ -210,25 +295,25 @@ public final class TickInfoPanel implements RenderInterface {
         TooltipUtil.onHover(tooltip);
     }
 
-    private void rowTriple(String label, double x, double y, double z, String tooltip) {
+    private void rowTriple(String label, double x, double y, double z, int decimals, String tooltip) {
         labelCell(label, tooltip);
-        numCell(x);
-        numCell(y);
-        numCell(z);
+        numCell(x, decimals);
+        numCell(y, decimals);
+        numCell(z, decimals);
         ThemeManager.tableRightmostCellTrailingPad();
     }
 
-    private void rowXZ(String label, double x, double z, String tooltip) {
+    private void rowXZ(String label, double x, double z, int decimals, String tooltip) {
         labelCell(label, tooltip);
-        numCell(x);
+        numCell(x, decimals);
         emptyCell();
-        numCell(z);
+        numCell(z, decimals);
         ThemeManager.tableRightmostCellTrailingPad();
     }
 
-    private void rowNum(String label, double v, String tooltip) {
+    private void rowNum(String label, double v, int decimals, String tooltip) {
         labelCell(label, tooltip);
-        centerSingleValueInMiddleColumn(String.format(Locale.US, fmtNumSingle, v));
+        centerSingleValueInMiddleColumn(String.format(Locale.US, fmtNumSingle(decimals), v));
     }
 
     private void rowInt(String label, int v, String tooltip) {
@@ -251,9 +336,9 @@ public final class TickInfoPanel implements RenderInterface {
         ThemeManager.popTextColor();
     }
 
-    private void numCell(double v) {
+    private void numCell(double v, int decimals) {
         ImGui.tableNextColumn();
-        ThemeManager.textCenter(String.format(Locale.US, fmtNum, v));
+        ThemeManager.textCenter(String.format(Locale.US, fmtNum(decimals), v));
     }
 
     private static void emptyCell() {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/TickInfoStat.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/TickInfoStat.java
@@ -1,0 +1,95 @@
+package de.legoshi.parkourcalc.core.ui;
+
+public enum TickInfoStat {
+
+    TICK("tick", "Tick", Kind.INT,
+            "Tick number (1-based), matching the input table's Tick column."),
+    YAW("yaw", "Yaw", Kind.NUM,
+            "Facing applied during this tick (drives this tick's movement). MC convention: 0 = +Z, increases CW looking down."),
+    PITCH("pitch", "Pitch", Kind.NUM,
+            "Camera pitch held during this tick (-90 up, 90 down). Defaults to 40; each row adds a relative turn unless locked to an absolute value. Display only; pitch does not affect movement."),
+    SPEED_XZ("speedXZ", "Speed (XZ)", Kind.NUM,
+            "Horizontal magnitude of actual displacement this tick, sqrt(dx^2 + dz^2), blocks/tick."),
+    MOTION_XZ("motionXZ", "Motion (XZ)", Kind.NUM,
+            "Horizontal magnitude of post-tick velocity, sqrt(vx^2 + vz^2), blocks/tick. Differs from Speed on collision ticks."),
+    MOTION_XYZ("motionXYZ", "Motion (XYZ)", Kind.NUM,
+            "Total magnitude of post-tick velocity, sqrt(vx^2 + vy^2 + vz^2), blocks/tick."),
+    POSITION("position", "Position", Kind.TRIPLE,
+            "Entity position entering this tick, before this tick's input is applied (the start seed for the Start row). This tick's movement shows on the next tick. World coords; anchor corner of the rendered tick box."),
+    MOTION("motion", "Motion", Kind.TRIPLE,
+            "Post-tick motionX/Y/Z (after MC's per-axis collision clamp). May read 0 on an axis where a wall was hit."),
+    SPEED("speed", "Speed", Kind.TRIPLE,
+            "Position(i) - position(i-1), the actual displacement vector this tick."),
+    POST_MOTION_XZ("postMotionXZ", "Post motion (XZ)", Kind.XZ,
+            "Per-axis horizontal displacement this tick: (deltaX, deltaZ). Differs from Motion on collision-clamp ticks."),
+    ACCELERATION_XZ("accelerationXZ", "Acceleration (XZ)", Kind.XZ,
+            "Per-axis change in post motion: (deltaX(i) - deltaX(i-1), deltaZ(i) - deltaZ(i-1))."),
+    SPEED_ANGLE("speedAngle", "Speed (angle)", Kind.NUM,
+            "Movement direction in XZ. MC yaw convention: 0 = +Z, increases CW looking down (atan2(-dx, dz))."),
+    ON_GROUND("onGround", "On ground", Kind.BOOL,
+            "Entity onGround flag at end of tick."),
+    SNEAKING("sneaking", "Sneaking", Kind.BOOL,
+            "Sneak input active during this tick."),
+    COLLISION("collision", "Collision", Kind.BOOL,
+            "Horizontal collision occurred this tick (MC horizontalCollision)."),
+    SOFT_COLLISION("softCollision", "Soft collision", Kind.BOOL,
+            "1.21.10 only: grazing wall hit that does NOT break sprint (Entity.collidedSoftly). Always false on 1.8.9/1.12.2.",
+            "1.21.10 only: grazing wall hit that does NOT break sprint. n/a when no horizontal collision is happening."),
+    COLLISION_ANGLE("collisionAngle", "Collision angle (deg)", Kind.NUM,
+            "1.21.10 only: angle between intended motion and post-collision motion. MC keeps sprint when this is below ~8 deg (0.13962634 rad).",
+            "1.21.10 only: angle between intended motion (forwardSpeed/sidewaysSpeed rotated by yaw) and post-collision motion. n/a on 1.8.9/1.12.2 or off-collision ticks.");
+
+    public enum Kind {
+        NUM,
+        INT,
+        BOOL,
+        TRIPLE,
+        XZ
+    }
+
+    private final String id;
+    private final String label;
+    private final Kind kind;
+    private final String tooltip;
+    private final String naTooltip;
+
+    TickInfoStat(String id, String label, Kind kind, String tooltip) {
+        this(id, label, kind, tooltip, null);
+    }
+
+    TickInfoStat(String id, String label, Kind kind, String tooltip, String naTooltip) {
+        this.id = id;
+        this.label = label;
+        this.kind = kind;
+        this.tooltip = tooltip;
+        this.naTooltip = naTooltip;
+    }
+
+    public String id() {
+        return id;
+    }
+
+    public String label() {
+        return label;
+    }
+
+    public Kind kind() {
+        return kind;
+    }
+
+    public String tooltip() {
+        return tooltip;
+    }
+
+    public String naTooltip() {
+        return naTooltip != null ? naTooltip : tooltip;
+    }
+
+    public static TickInfoStat byId(String id) {
+        if (id == null) return null;
+        for (TickInfoStat stat : values()) {
+            if (stat.id.equals(id)) return stat;
+        }
+        return null;
+    }
+}

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/TickInfoStatSetting.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/TickInfoStatSetting.java
@@ -1,0 +1,21 @@
+package de.legoshi.parkourcalc.core.ui;
+
+public final class TickInfoStatSetting {
+
+    public String id;
+    public boolean enabled;
+    public int decimals;
+
+    public TickInfoStatSetting() {
+    }
+
+    public TickInfoStatSetting(String id, boolean enabled, int decimals) {
+        this.id = id;
+        this.enabled = enabled;
+        this.decimals = decimals;
+    }
+
+    public TickInfoStatSetting copy() {
+        return new TickInfoStatSetting(id, enabled, decimals);
+    }
+}

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/TickInfoStatsEditor.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/TickInfoStatsEditor.java
@@ -10,17 +10,15 @@ import imgui.flag.ImGuiDragDropFlags;
 import imgui.flag.ImGuiMouseCursor;
 import imgui.flag.ImGuiSelectableFlags;
 import imgui.flag.ImGuiTableColumnFlags;
+import imgui.flag.ImGuiTableFlags;
 
 import java.util.List;
 
-public final class TickInfoConfigPopup {
+public final class TickInfoStatsEditor {
 
-    private static final String POPUP_ID = "###tick-info-config";
     private static final String TABLE_ID = "tick-info-config-table";
     private static final String TITLE = "Tick Info stats";
-    private static final String SUBTITLE = "Toggle, set decimals, and drag to reorder.";
     private static final String RESET_BTN = "Reset to defaults";
-    private static final String GRIP = "::";
     private static final String DRAG_DROP_TYPE = "TICK_INFO_STAT";
 
     private static final String COL_STAT = "Stat";
@@ -33,46 +31,28 @@ public final class TickInfoConfigPopup {
     private static final String TT_GRIP = "Drag to reorder.";
 
     private final Settings settings;
+    private final Runnable onChanged;
     private final int[] decimalsBuf = new int[1];
 
     private int draggingIndex = -1;
     private int dropTarget = -1;
     private float dropLineY = -1f;
     private float rowMinX, rowMaxX;
-    private boolean openRequested;
 
-    public TickInfoConfigPopup(Settings settings) {
+    public TickInfoStatsEditor(Settings settings, Runnable onChanged) {
         this.settings = settings;
-    }
-
-    public void handleOpenOnRightClick(int hoveredFlags) {
-        if (ImGui.isMouseReleased(1) && ImGui.isWindowHovered(hoveredFlags)) {
-            openRequested = true;
-        }
+        this.onChanged = onChanged;
     }
 
     public void render() {
-        if (openRequested) {
-            ImGui.openPopup(POPUP_ID);
-            openRequested = false;
-        }
-        if (!ImGui.beginPopup(POPUP_ID)) {
-            draggingIndex = -1;
-            return;
-        }
-
-        ImGui.textDisabled(SUBTITLE);
-        ThemeManager.paddedSeparator();
-
         renderStatTable();
 
-        ThemeManager.paddedSeparator();
+        ThemeManager.sectionSpacing();
         if (Controls.secondaryButton(RESET_BTN)) {
             settings.tickInfoStats = TickInfoConfig.defaultConfig(Settings.defaultTickInfoPrecision());
             draggingIndex = -1;
+            onChanged.run();
         }
-
-        ImGui.endPopup();
     }
 
     private void renderStatTable() {
@@ -82,15 +62,15 @@ public final class TickInfoConfigPopup {
             return;
         }
 
-        if (!ThemeManager.beginStandardKeyValueTable(TABLE_ID, 3, 0, 0f, 0f)) {
+        int flags = ThemeManager.standardTableFlagsNoScroll() & ~ImGuiTableFlags.BordersInnerV;
+        if (!ThemeManager.beginStandardTableWithFlags(TABLE_ID, 3, flags, 0f, 0f)) {
             return;
         }
         int fixed = ImGuiTableColumnFlags.WidthFixed;
         float cellPad = ImGui.getStyle().getCellPadding().x;
-        float labelW = ImGui.calcTextSize(GRIP + "  Collision angle (deg)").x + 2f * cellPad;
         float onW = ImGui.calcTextSize(COL_ON).x + 2f * cellPad + ImGui.getFrameHeight();
         float decW = ImGui.getFontSize() * DECIMALS_SLIDER_EMS;
-        ImGui.tableSetupColumn(COL_STAT, fixed, ThemeManager.tableLeftmostColumnWidth(COL_STAT, labelW));
+        ImGui.tableSetupColumn(COL_STAT, ImGuiTableColumnFlags.WidthStretch);
         ImGui.tableSetupColumn(COL_ON, fixed, ThemeManager.tableColumnWidth(COL_ON, onW));
         ImGui.tableSetupColumn(COL_DECIMALS, fixed,
                 ThemeManager.tableRightmostColumnWidth(COL_DECIMALS, decW, ThemeManager.tableFixedScrollbarSlack()));
@@ -111,44 +91,50 @@ public final class TickInfoConfigPopup {
         String label = stat != null ? stat.label() : setting.id;
         String tooltip = stat != null ? stat.tooltip() : "";
 
-        ImGui.tableNextRow();
+        Controls.pushInputFrameHeight();
+        float rowH = ThemeManager.tableRowHeight();
+        ImGui.tableNextRow(0, rowH);
         ThemeManager.paintTableRowBg(index);
         if (draggingIndex == index) {
             ThemeManager.paintTableRowTint(ThemeManager.selectedTintColor(0.5f));
         }
 
         ImGui.tableNextColumn();
+        float rowTopScreen = ImGui.getCursorScreenPos().y - ImGui.getStyle().getCellPadding().y;
         ThemeManager.tableLeftmostCellPad();
         ThemeManager.pushTextColor(draggingIndex == index ? ThemeManager.textColor() : ThemeManager.textMutedColor());
-        ThemeManager.rightAlignedSelectable(
-                "stat" + index, GRIP + "  " + label, draggingIndex == index,
-                ImGuiSelectableFlags.SpanAllColumns | ImGuiSelectableFlags.AllowItemOverlap);
+        int selFlags = ImGuiSelectableFlags.SpanAllColumns | ImGuiSelectableFlags.AllowItemOverlap
+                | ImGuiSelectableFlags.DontClosePopups;
+        ThemeManager.leftAlignedSelectable("stat" + index, label, draggingIndex == index, selFlags);
         ThemeManager.popTextColor();
         TooltipUtil.onHover(tooltip.isEmpty() ? TT_GRIP : tooltip);
         if (ImGui.isItemHovered()) ImGui.setMouseCursor(ImGuiMouseCursor.Hand);
-        handleRowDragDrop(index);
+
+        handleRowDragDrop(index, rowTopScreen, rowH);
 
         ImGui.tableNextColumn();
         if (Controls.checkbox("##on" + index, setting.enabled)) {
             setting.enabled = !setting.enabled;
+            onChanged.run();
         }
         TooltipUtil.onHover(TT_TOGGLE);
 
         ImGui.tableNextColumn();
-        boolean numeric = usesDecimals(stat);
-        if (!numeric) ImGui.beginDisabled(true);
-        decimalsBuf[0] = setting.decimals;
-        ImGui.setNextItemWidth(-1);
-        if (Controls.sliderInt("##dec" + index, decimalsBuf,
-                Settings.MIN_STAT_PRECISION, Settings.MAX_STAT_PRECISION, "%d") && numeric) {
-            setting.decimals = decimalsBuf[0];
+        if (usesDecimals(stat)) {
+            decimalsBuf[0] = setting.decimals;
+            ImGui.setNextItemWidth(-(2f * ThemeManager.tableEdgeCellInset()));
+            if (Controls.sliderInt("##dec" + index, decimalsBuf,
+                    Settings.MIN_STAT_PRECISION, Settings.MAX_STAT_PRECISION, "%d")) {
+                setting.decimals = decimalsBuf[0];
+            }
+            if (ImGui.isItemDeactivatedAfterEdit()) onChanged.run();
+            TooltipUtil.onHover(TT_DECIMALS);
         }
-        if (!numeric) ImGui.endDisabled();
-        TooltipUtil.onHover(TT_DECIMALS);
         ThemeManager.tableRightmostCellTrailingPad();
+        Controls.popInputFrameHeight();
     }
 
-    private void handleRowDragDrop(int index) {
+    private void handleRowDragDrop(int index, float rowTopScreen, float rowH) {
         if (ImGui.beginDragDropSource(ImGuiDragDropFlags.SourceNoPreviewTooltip)) {
             draggingIndex = index;
             // Payload is never read back (imgui-java weak-refs it); the move is resolved from draggingIndex.
@@ -157,17 +143,15 @@ public final class TickInfoConfigPopup {
         }
         if (draggingIndex == -1) return;
 
-        ImVec2 rowMin = ImGui.getItemRectMin();
-        ImVec2 rowMax = ImGui.getItemRectMax();
-        rowMinX = rowMin.x;
-        rowMaxX = ImGui.getWindowPos().x + ImGui.getWindowWidth();
+        rowMinX = ImGui.getWindowPos().x + ImGui.getWindowContentRegionMinX();
+        rowMaxX = ImGui.getWindowPos().x + ImGui.getWindowContentRegionMaxX();
 
+        float rowBottomScreen = rowTopScreen + rowH;
         ImVec2 mouse = ImGui.getMousePos();
-        float gap = ImGui.getStyle().getCellPadding().y;
-        if (mouse.y < rowMin.y - gap - 1f || mouse.y >= rowMax.y + gap + 1f) return;
+        if (mouse.y < rowTopScreen || mouse.y >= rowBottomScreen) return;
 
-        boolean insertAbove = mouse.y < (rowMin.y + rowMax.y) / 2f;
-        dropLineY = insertAbove ? rowMin.y - gap : rowMax.y + gap;
+        boolean insertAbove = mouse.y < (rowTopScreen + rowBottomScreen) / 2f;
+        dropLineY = insertAbove ? rowTopScreen : rowBottomScreen;
         dropTarget = insertAbove ? index : index + 1;
     }
 
@@ -184,8 +168,9 @@ public final class TickInfoConfigPopup {
             int to = dropTarget;
             draggingIndex = -1;
             dropTarget = -1;
-            if (to >= 0 && to <= size && settings.tickInfoStats != null) {
+            if (to >= 0 && to <= size && settings.tickInfoStats != null && to != from && to != from + 1) {
                 settings.tickInfoStats.move(from, to);
+                onChanged.run();
             }
         } else if (!ImGui.isMouseDown(0)) {
             draggingIndex = -1;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/theme/ThemeManager.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/theme/ThemeManager.java
@@ -451,6 +451,18 @@ public final class ThemeManager {
         centeredSelectable(idSuffix, label, selected, 0);
     }
 
+    public static boolean leftAlignedSelectable(String idSuffix, String label, boolean selected, int flags) {
+        ImVec2 cellOrigin = ImGui.getCursorScreenPos();
+        ImGui.alignTextToFramePadding();
+        boolean clicked = ImGui.selectable("##" + idSuffix, selected, flags);
+        if (label != null && !label.isEmpty()) {
+            float tx = cellOrigin.x + tableEdgeCellInset();
+            float ty = cellOrigin.y + ImGui.getStyle().getFramePadding().y;
+            ImGui.getWindowDrawList().addText(tx, ty, ImGui.getColorU32(ImGuiCol.Text), label);
+        }
+        return clicked;
+    }
+
     public static boolean rightAlignedSelectable(String idSuffix, String label, boolean selected, int flags) {
         return rightAlignedSelectable(idSuffix, label, selected, flags, 0f, 0f);
     }

--- a/core/src/test/java/de/legoshi/parkourcalc/core/TickInfoConfigTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/TickInfoConfigTest.java
@@ -1,0 +1,173 @@
+package de.legoshi.parkourcalc.core;
+
+import de.legoshi.parkourcalc.core.ui.Settings;
+import de.legoshi.parkourcalc.core.ui.SettingsIO;
+import de.legoshi.parkourcalc.core.ui.TickInfoConfig;
+import de.legoshi.parkourcalc.core.ui.TickInfoStat;
+import de.legoshi.parkourcalc.core.ui.TickInfoStatSetting;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class TickInfoConfigTest {
+
+    @Test
+    public void defaultConfigMatchesLegacyStatSetOrderAndPrecision() {
+        TickInfoConfig config = TickInfoConfig.defaultConfig(Settings.defaultTickInfoPrecision());
+
+        TickInfoStat[] expected = TickInfoStat.values();
+        assertEquals("one setting per stat", expected.length, config.stats.size());
+        for (int i = 0; i < expected.length; i++) {
+            TickInfoStatSetting setting = config.stats.get(i);
+            assertEquals("order matches enum declaration order", expected[i].id(), setting.id);
+            assertTrue("every stat enabled by default", setting.enabled);
+            assertEquals("every stat at the legacy default precision",
+                    Settings.defaultTickInfoPrecision(), setting.decimals);
+        }
+        assertEquals(Arrays.asList(expected), config.enabledInOrder());
+    }
+
+    @Test
+    public void freshSettingsCarriesTheDefaultConfig() {
+        Settings settings = new Settings();
+        assertNotNull(settings.tickInfoStats);
+        assertEquals(TickInfoStat.values().length, settings.tickInfoStats.stats.size());
+        assertEquals(Arrays.asList(TickInfoStat.values()), settings.tickInfoStats.enabledInOrder());
+    }
+
+    @Test
+    public void moveReordersWithInsertBeforeSemantics() {
+        TickInfoConfig config = TickInfoConfig.defaultConfig(5);
+        String first = config.stats.get(0).id;
+        String second = config.stats.get(1).id;
+
+        config.move(0, 2);
+        assertEquals(second, config.stats.get(0).id);
+        assertEquals(first, config.stats.get(1).id);
+
+        List<String> before = ids(config);
+        config.move(1, 1);
+        config.move(1, 2);
+        assertEquals(before, ids(config));
+
+        config.move(-1, 0);
+        config.move(0, config.stats.size() + 5);
+        assertEquals(before, ids(config));
+    }
+
+    @Test
+    public void disablingHidesAStatButKeepsItInTheConfig() {
+        TickInfoConfig config = TickInfoConfig.defaultConfig(5);
+        int total = config.stats.size();
+
+        config.find(TickInfoStat.SNEAKING).enabled = false;
+        config.find(TickInfoStat.COLLISION).enabled = false;
+
+        List<TickInfoStat> visible = config.enabledInOrder();
+        assertEquals(total - 2, visible.size());
+        assertFalse(visible.contains(TickInfoStat.SNEAKING));
+        assertFalse(visible.contains(TickInfoStat.COLLISION));
+        assertTrue("disabled stats are retained for re-enabling", config.stats.size() == total);
+    }
+
+    @Test
+    public void roundTripPreservesEnabledDecimalsAndOrder() throws Exception {
+        Settings original = new Settings();
+        TickInfoConfig config = original.tickInfoStats;
+
+        config.find(TickInfoStat.YAW).enabled = false;
+        config.find(TickInfoStat.MOTION).enabled = false;
+        config.find(TickInfoStat.POSITION).decimals = 2;
+        config.find(TickInfoStat.SPEED).decimals = 9;
+        config.move(0, config.stats.size());
+        List<String> savedOrder = ids(config);
+
+        Path file = Files.createTempFile("pkc-tickinfo", ".json");
+        SettingsIO.save(file, original);
+
+        Settings loaded = new Settings();
+        SettingsIO.load(file, loaded);
+
+        TickInfoConfig out = loaded.tickInfoStats;
+        assertEquals("order preserved across save/load", savedOrder, ids(out));
+        assertFalse(out.find(TickInfoStat.YAW).enabled);
+        assertFalse(out.find(TickInfoStat.MOTION).enabled);
+        assertTrue(out.find(TickInfoStat.POSITION).enabled);
+        assertEquals(2, out.find(TickInfoStat.POSITION).decimals);
+        assertEquals(9, out.find(TickInfoStat.SPEED).decimals);
+        assertEquals(config.enabledInOrder(), out.enabledInOrder());
+    }
+
+    @Test
+    public void oldSettingsFileWithoutTickInfoStatsLoadsDefault() throws Exception {
+        Path file = Files.createTempFile("pkc-old-settings", ".json");
+        Files.write(file, "{\"tickInfoPrecision\":4,\"scaleIndex\":1}".getBytes(StandardCharsets.UTF_8));
+
+        Settings loaded = new Settings();
+        SettingsIO.load(file, loaded);
+
+        assertNotNull(loaded.tickInfoStats);
+        assertEquals("missing key falls back to the full default config",
+                Arrays.asList(TickInfoStat.values()), loaded.tickInfoStats.enabledInOrder());
+    }
+
+    @Test
+    public void normalizeDropsUnknownIdsAppendsMissingAndClampsDecimals() {
+        TickInfoConfig config = new TickInfoConfig();
+        config.stats = new ArrayList<>();
+        config.stats.add(new TickInfoStatSetting("a_removed_stat", true, 5));
+        config.stats.add(new TickInfoStatSetting(TickInfoStat.YAW.id(), false, 999));
+        config.stats.add(new TickInfoStatSetting(TickInfoStat.YAW.id(), true, 3));
+        config.stats.add(new TickInfoStatSetting(TickInfoStat.POSITION.id(), true, -7));
+
+        config.normalize(Settings.defaultTickInfoPrecision(), Settings.MIN_STAT_PRECISION, Settings.MAX_STAT_PRECISION);
+
+        assertEquals(null, TickInfoStat.byId("a_removed_stat"));
+        assertEquals(1, countId(config, TickInfoStat.YAW.id()));
+        assertFalse("first YAW occurrence (disabled) is the one kept", config.find(TickInfoStat.YAW).enabled);
+
+        assertEquals(Settings.MAX_STAT_PRECISION, config.find(TickInfoStat.YAW).decimals);
+        assertEquals(Settings.MIN_STAT_PRECISION, config.find(TickInfoStat.POSITION).decimals);
+
+        assertEquals(TickInfoStat.values().length, config.stats.size());
+        assertEquals(TickInfoStat.YAW.id(), config.stats.get(0).id);
+        assertEquals(TickInfoStat.POSITION.id(), config.stats.get(1).id);
+        for (TickInfoStat stat : TickInfoStat.values()) {
+            assertEquals("each stat present exactly once after normalize", 1, countId(config, stat.id()));
+        }
+        assertTrue(config.find(TickInfoStat.TICK).enabled);
+        assertEquals(Settings.defaultTickInfoPrecision(), config.find(TickInfoStat.TICK).decimals);
+    }
+
+    @Test
+    public void normalizeRebuildsFromNullOrEmpty() {
+        TickInfoConfig config = new TickInfoConfig();
+        config.stats = null;
+        config.normalize(Settings.defaultTickInfoPrecision(), Settings.MIN_STAT_PRECISION, Settings.MAX_STAT_PRECISION);
+        assertEquals(Arrays.asList(TickInfoStat.values()), config.enabledInOrder());
+    }
+
+    private static List<String> ids(TickInfoConfig config) {
+        List<String> result = new ArrayList<>();
+        for (TickInfoStatSetting setting : config.stats) result.add(setting.id);
+        return result;
+    }
+
+    private static int countId(TickInfoConfig config, String id) {
+        int n = 0;
+        for (TickInfoStatSetting setting : config.stats) {
+            if (id.equals(setting.id)) n++;
+        }
+        return n;
+    }
+}


### PR DESCRIPTION
Make the Tick Info panel user-configurable via a right-click context menu.

The panel now renders from a per-stat config in Settings: an ordered list of
{id, enabled, decimals} where list position is the display order. Right-clicking
the Tick Info window opens an overview listing every stat with an enable toggle,
a per-stat decimal slider, and drag-drop reordering (mirroring the input table's
row drag-drop in InputOverlay). Only enabled stats render, each with its own
decimal precision, in the chosen order.

A canonical TickInfoStat enum is the stat registry; declaration order is the
default order and id() is the persisted key. TickInfoConfig holds the list and
provides the legacy-equivalent default (every stat enabled, enum order, all at
the existing default precision) plus normalize() for back-compat: it drops
unknown ids, dedups, appends stats added since, and clamps decimals. SettingsIO
persists tickInfoStats through the same Gson reflection path as every other
setting and normalizes it on load, so old settings files load unchanged and an
untouched install looks identical to before. The Preferences "Tick Info decimal
places" slider now seeds the default precision for new/reset stats.

Adds TickInfoConfigTest: default matches the legacy stat set/order/precision,
round-trip persistence of enabled/decimals/order, reorder + disable semantics,
and back-compat normalization (missing key, unknown ids, clamping).

