### PR TITLE
feat(anglesolver): in-world visualization of landing constraints (#145)

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
@@ -13,6 +13,7 @@ import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.BoxController;
 import de.legoshi.parkourcalc.core.ui.BoxDragController;
 import de.legoshi.parkourcalc.core.ui.BoxSelectController;
+import de.legoshi.parkourcalc.core.ui.ConstraintSelection;
 import de.legoshi.parkourcalc.core.ui.FileMenu;
 import de.legoshi.parkourcalc.core.ui.InputData;
 import de.legoshi.parkourcalc.core.ui.InputOverlay;
@@ -21,6 +22,7 @@ import de.legoshi.parkourcalc.core.ui.MainWindowOverlay;
 import de.legoshi.parkourcalc.core.ui.OverlayManager;
 import de.legoshi.parkourcalc.core.ui.PerfOverlay;
 import de.legoshi.parkourcalc.core.ui.SelectionManager;
+import de.legoshi.parkourcalc.core.ui.WorldPick;
 import de.legoshi.parkourcalc.core.ui.Settings;
 import de.legoshi.parkourcalc.core.ui.SettingsIO;
 import de.legoshi.parkourcalc.core.ui.StartDragController;
@@ -50,6 +52,8 @@ public final class Application {
     private final BoxController boxController = new BoxController();
     private final Settings settings = new Settings();
     private final SelectionManager selection;
+    private final ConstraintSelection constraintSelection = new ConstraintSelection();
+    private de.legoshi.parkourcalc.core.render.ConstraintBoxSource constraintSource = de.legoshi.parkourcalc.core.render.ConstraintBoxSource.NONE;
     private final SimulationRunner runner;
     private final BoxDragController dragController;
     private final StartDragController startDragController;
@@ -75,7 +79,7 @@ public final class Application {
                 saveController::markDirty, this::runSimulation, SimulationRunner.DEFAULT_MOVE_TICK_TOLERANCE);
         // Start box is the "Start" anchor: draggable to reposition, and tap-selectable as path index 0.
         this.dragController = new BoxDragController(boxController, startDragController, this::commitStartTap);
-        this.selectController = new BoxSelectController(boxController, this::commitWorldTap);
+        this.selectController = new BoxSelectController(this::pickWorld, this::commitWorldTap);
         this.yawGizmo = new YawGizmoController(
                 boxController,
                 this::handleStartYawChange,
@@ -123,7 +127,7 @@ public final class Application {
         angleSolverState = new AngleSolverState();
         saveController.setAngleSolver(angleSolverState);
         saveController.setDebugSource(boxController, settings);
-        AngleSolverTable angleSolverTable = new AngleSolverTable(angleSolverState, settings, selection, inputData::size);
+        AngleSolverTable angleSolverTable = new AngleSolverTable(angleSolverState, settings, selection, constraintSelection, inputData::size);
         inputOverlay.setAngleSolver(angleSolverTable);
         StartStateTable startStateTable = new StartStateTable(runner, () -> onUserChange(-1));
         inputOverlay.setStartState(startStateTable);
@@ -133,9 +137,9 @@ public final class Application {
         AngleSolverWindow angleSolverWindow = new AngleSolverWindow(angleSolverState, settings, inputData::size, angleSolverEngine);
 
         // In-world constraint visualization (gh-145): plates appear while the solver view is open.
-        de.legoshi.parkourcalc.core.render.PathRenderPlan.setConstraintSource(
-                new de.legoshi.parkourcalc.core.ui.anglesolver.AngleSolverConstraintSource(
-                        angleSolverState, boxController, () -> settings.viewAngleSolver));
+        constraintSource = new de.legoshi.parkourcalc.core.ui.anglesolver.AngleSolverConstraintSource(
+                angleSolverState, boxController, () -> settings.viewAngleSolver, settings, selection, constraintSelection);
+        de.legoshi.parkourcalc.core.render.PathRenderPlan.setConstraintSource(constraintSource);
 
         TickInfoPanel tickInfoPanel = new TickInfoPanel(boxController, inputData, selection, settings, runner);
         PerfOverlay perfOverlay = new PerfOverlay();
@@ -221,11 +225,24 @@ public final class Application {
         onUserChange(-1);
     }
 
-    private void commitWorldTap(int boxIndex) {
-        if (boxIndex <= 0) return;
-        if (boxIndex >= boxController.size() - 1) return;
-        selection.handleClick(boxIndex + 1);
+    private WorldPick pickWorld(Vec3dCore rayOrigin, Vec3dCore rayDirection) {
+        return boxController.pickWorld(rayOrigin, rayDirection, constraintSource);
+    }
+
+    private void commitWorldTap(WorldPick pick) {
+        if (pick == null) return;
+        if (pick.kind == WorldPick.Kind.CONSTRAINT) {
+            if (pick.index >= boxController.size() - 1) return;
+            selection.handleClick(pick.index + 1);
+            selection.requestScrollIntoView();
+            constraintSelection.focus(pick.index, pick.constraintIndices);
+            return;
+        }
+        if (pick.index <= 0) return;
+        if (pick.index >= boxController.size() - 1) return;
+        selection.handleClick(pick.index + 1);
         selection.requestScrollIntoView();
+        constraintSelection.clear();
     }
 
     private void commitStartTap() {
@@ -341,7 +358,8 @@ public final class Application {
         if (isControlPanelOpen()) return false;
         if (dragController.isDragging()) return true;
         if (!mc.isReady()) return false;
-        return yawGizmo.isCursorOverAnyBox(mc.getEyePosition(), mc.getLookDirection());
+        return yawGizmo.isCursorOverAnyBox(mc.getEyePosition(), mc.getLookDirection())
+                || boxController.isCursorOverConstraint(mc.getEyePosition(), mc.getLookDirection(), constraintSource);
     }
 
     public boolean shouldSuppressRightClick() {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
@@ -132,6 +132,11 @@ public final class Application {
         saveController.setSolverEngine(angleSolverEngine);
         AngleSolverWindow angleSolverWindow = new AngleSolverWindow(angleSolverState, settings, inputData::size, angleSolverEngine);
 
+        // In-world constraint visualization (gh-145): plates appear while the solver view is open.
+        de.legoshi.parkourcalc.core.render.PathRenderPlan.setConstraintSource(
+                new de.legoshi.parkourcalc.core.ui.anglesolver.AngleSolverConstraintSource(
+                        angleSolverState, boxController, () -> settings.viewAngleSolver));
+
         TickInfoPanel tickInfoPanel = new TickInfoPanel(boxController, inputData, selection, settings, runner);
         PerfOverlay perfOverlay = new PerfOverlay();
         FileMenu fileMenu = new FileMenu(saveController, filePicker, settings, this::saveSettings);

--- a/core/src/main/java/de/legoshi/parkourcalc/core/render/ConstraintBoxSource.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/render/ConstraintBoxSource.java
@@ -1,25 +1,24 @@
 package de.legoshi.parkourcalc.core.render;
 
-import de.legoshi.parkourcalc.core.sim.AABB;
-
 import java.util.List;
 
 /**
  * Per-tick supply of constraint plates for the world overlay (gh-145). Decouples
  * {@link de.legoshi.parkourcalc.core.ui.BoxController} from the angle-solver model: the
  * implementation owns the {@link de.legoshi.parkourcalc.core.anglesolver.AngleSolverState} and
- * turns each tick's drawable constraints into world AABBs via {@link ConstraintShapes#boxFor}.
+ * turns each tick's drawable constraints into world {@link ConstraintPlate}s via {@link ConstraintShapes}.
  *
- * <p>{@code boxesAt(tickIndex)} is called with a {@link de.legoshi.parkourcalc.core.ui.BoxController}
- * tick index (same index space as the simulated path), so the constraint→tick mapping stays explicit:
- * the boxes returned are anchored at that tick's simulated position.
+ * <p>{@code platesAt(tickIndex)} is called with a {@link de.legoshi.parkourcalc.core.ui.BoxController}
+ * tick index (same index space as the simulated path), so the constraint->tick mapping stays explicit:
+ * the plates returned are anchored at that tick's simulated position and carry their own type
+ * (include/exclude) and satisfied status.
  */
 public interface ConstraintBoxSource {
 
     /** Empty source: no constraint geometry. */
     ConstraintBoxSource NONE = new ConstraintBoxSource() {
         @Override
-        public List<AABB> boxesAt(int tickIndex) {
+        public List<ConstraintPlate> platesAt(int tickIndex) {
             return java.util.Collections.emptyList();
         }
 
@@ -30,7 +29,7 @@ public interface ConstraintBoxSource {
     };
 
     /** Drawable constraint plates anchored at the given tick, or an empty list if none. Never null. */
-    List<AABB> boxesAt(int tickIndex);
+    List<ConstraintPlate> platesAt(int tickIndex);
 
     /**
      * Monotonic-ish content stamp: changes whenever the constraint geometry would change (edited

--- a/core/src/main/java/de/legoshi/parkourcalc/core/render/ConstraintBoxSource.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/render/ConstraintBoxSource.java
@@ -1,0 +1,41 @@
+package de.legoshi.parkourcalc.core.render;
+
+import de.legoshi.parkourcalc.core.sim.AABB;
+
+import java.util.List;
+
+/**
+ * Per-tick supply of constraint plates for the world overlay (gh-145). Decouples
+ * {@link de.legoshi.parkourcalc.core.ui.BoxController} from the angle-solver model: the
+ * implementation owns the {@link de.legoshi.parkourcalc.core.anglesolver.AngleSolverState} and
+ * turns each tick's drawable constraints into world AABBs via {@link ConstraintShapes#boxFor}.
+ *
+ * <p>{@code boxesAt(tickIndex)} is called with a {@link de.legoshi.parkourcalc.core.ui.BoxController}
+ * tick index (same index space as the simulated path), so the constraint→tick mapping stays explicit:
+ * the boxes returned are anchored at that tick's simulated position.
+ */
+public interface ConstraintBoxSource {
+
+    /** Empty source: no constraint geometry. */
+    ConstraintBoxSource NONE = new ConstraintBoxSource() {
+        @Override
+        public List<AABB> boxesAt(int tickIndex) {
+            return java.util.Collections.emptyList();
+        }
+
+        @Override
+        public long revision() {
+            return 0L;
+        }
+    };
+
+    /** Drawable constraint plates anchored at the given tick, or an empty list if none. Never null. */
+    List<AABB> boxesAt(int tickIndex);
+
+    /**
+     * Monotonic-ish content stamp: changes whenever the constraint geometry would change (edited
+     * constraints, axis/value edits, etc.). Folded into the cached-geometry structural hash so the
+     * loaders rebuild their buffers when constraints change but the path positions do not.
+     */
+    long revision();
+}

--- a/core/src/main/java/de/legoshi/parkourcalc/core/render/ConstraintPalette.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/render/ConstraintPalette.java
@@ -1,0 +1,34 @@
+package de.legoshi.parkourcalc.core.render;
+
+public final class ConstraintPalette {
+
+    private final int satisfiedOutline;
+    private final int violatedOutline;
+    private final int frontFill;
+    private final int backFill;
+    private final int highlight;
+
+    public ConstraintPalette(int satisfiedOutline, int violatedOutline, int frontFill, int backFill, int highlight) {
+        this.satisfiedOutline = satisfiedOutline;
+        this.violatedOutline = violatedOutline;
+        this.frontFill = frontFill;
+        this.backFill = backFill;
+        this.highlight = highlight;
+    }
+
+    public int outlineArgb(boolean satisfied) {
+        return satisfied ? satisfiedOutline : violatedOutline;
+    }
+
+    public int highlightArgb() {
+        return highlight;
+    }
+
+    public int frontArgb() {
+        return frontFill;
+    }
+
+    public int backArgb() {
+        return backFill;
+    }
+}

--- a/core/src/main/java/de/legoshi/parkourcalc/core/render/ConstraintPlate.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/render/ConstraintPlate.java
@@ -1,0 +1,25 @@
+package de.legoshi.parkourcalc.core.render;
+
+import de.legoshi.parkourcalc.core.sim.AABB;
+
+import java.util.List;
+
+public final class ConstraintPlate {
+
+    public final ConstraintShapes.Sense sense;
+    public final boolean satisfied;
+    public final List<AABB> front;
+    public final List<AABB> back;
+    public final int tick;
+    public final int[] constraintIndices;
+    public boolean highlighted;
+
+    public ConstraintPlate(ConstraintShapes.Sense sense, boolean satisfied, List<AABB> front, List<AABB> back, int tick, int[] constraintIndices) {
+        this.sense = sense;
+        this.satisfied = satisfied;
+        this.front = front;
+        this.back = back;
+        this.tick = tick;
+        this.constraintIndices = constraintIndices;
+    }
+}

--- a/core/src/main/java/de/legoshi/parkourcalc/core/render/ConstraintShapes.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/render/ConstraintShapes.java
@@ -5,49 +5,24 @@ import de.legoshi.parkourcalc.core.anglesolver.Constraint;
 import de.legoshi.parkourcalc.core.sim.AABB;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 
-/**
- * Maps an angle-solver landing constraint to an in-world AABB anchored at the tick it
- * applies to (gh-145). Pure geometry: callers feed a constraint plus that tick's simulated
- * position and get back the box to outline (LINES) and fill (FACES); the renderer wiring lives
- * in {@link de.legoshi.parkourcalc.core.ui.BoxController}.
- *
- * <p>Only the <b>spatial</b> fields have a place in the world: {@link Constraint.Field#X} and
- * {@link Constraint.Field#Z} are world positions, so a bound on one is a plane the player must be
- * on/past. The facing/velocity fields (F, dX, dZ) are not positions and have no spatial extent at
- * the tick, so {@link #spatialAxis(Constraint)} returns null for them and they are not drawn.
- *
- * <p>The box is a thin horizontal plate sitting on the tick's foot position:
- * <ul>
- *   <li>On the constrained axis it spans the constrained interval.</li>
- *   <li>On the other horizontal axis it spans a fixed {@link #CROSS_HALF_WIDTH} either side of the
- *       tick, so the plate is centred on (and visibly tied to) the tick.</li>
- *   <li>In Y it is a fixed-height slab ({@link #SLAB_HEIGHT}) so it reads as a surface, not a line.</li>
- * </ul>
- *
- * <p>A bounded range {@code X ∈ [lo, hi]} maps to a band of exactly that width. An open-ended
- * comparison ({@code >}/{@code >=}/{@code <}/{@code <=}) can't be drawn in full (it is half-infinite),
- * so it renders a limited sub-area: the band starts at the bound and extends {@link #OPEN_EXTENT}
- * blocks in the open direction, which reads as "open this way" without being infinite. Equality
- * ({@code =}) renders a thin slab of width {@code 2 *} {@link #EQ_HALF_WIDTH} centred on the value.
- */
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 public final class ConstraintShapes {
 
-    /** Half-width (blocks) of the plate on the axis the constraint does NOT bound; keeps it tied to the tick. */
-    public static final double CROSS_HALF_WIDTH = 0.35;
+    public enum Sense {
+        INCLUDE,
+        EXCLUDE
+    }
 
-    /** How far (blocks) an open-ended ({@code >}/{@code <}) band extends past its bound before it is clamped. */
-    public static final double OPEN_EXTENT = 1.0;
+    public static final double H = AngleSolverState.HITBOX_HALF_WIDTH;
 
-    /** Half-width (blocks) of the thin slab drawn for an exact {@code =} constraint. */
-    public static final double EQ_HALF_WIDTH = 0.02;
-
-    /** Vertical thickness (blocks) of the plate, anchored at the tick's foot Y. */
-    public static final double SLAB_HEIGHT = 0.06;
+    private static final double EQ_SATISFY_EPS = 1.0e-4;
 
     private ConstraintShapes() {
     }
 
-    /** The world axis a constraint occupies, or null when the field is non-spatial (F/dX/dZ) and not drawable. */
     public static AngleSolverState.Axis spatialAxis(Constraint c) {
         switch (c.getField()) {
             case X:
@@ -59,60 +34,132 @@ public final class ConstraintShapes {
         }
     }
 
-    /** True when this constraint maps to a world box (i.e. it bounds X or Z). */
     public static boolean isDrawable(Constraint c) {
         return spatialAxis(c) != null;
     }
 
-    /**
-     * The AABB for {@code c} anchored at {@code tickFoot} (the tick's simulated center-bottom, MC
-     * convention). Returns null if the constraint is non-spatial. The interval on the constrained
-     * axis is clamped for open-ended ops; the other horizontal axis and Y are fixed plate extents.
-     */
-    public static AABB boxFor(Constraint c, Vec3dCore tickFoot) {
-        AngleSolverState.Axis axis = spatialAxis(c);
-        if (axis == null) return null;
-
-        double[] span = axisSpan(c);
-        double lo = span[0];
-        double hi = span[1];
-
-        double y0 = tickFoot.y;
-        double y1 = tickFoot.y + SLAB_HEIGHT;
-
-        if (axis == AngleSolverState.Axis.X) {
-            double zMin = tickFoot.z - CROSS_HALF_WIDTH;
-            double zMax = tickFoot.z + CROSS_HALF_WIDTH;
-            return new AABB(new Vec3dCore(lo, y0, zMin), new Vec3dCore(hi, y1, zMax));
+    public static Sense sense(Constraint.Op op) {
+        switch (op) {
+            case GT:
+            case GE:
+            case LT:
+            case LE:
+                return Sense.EXCLUDE;
+            default:
+                return Sense.INCLUDE;
         }
-        double xMin = tickFoot.x - CROSS_HALF_WIDTH;
-        double xMax = tickFoot.x + CROSS_HALF_WIDTH;
-        return new AABB(new Vec3dCore(xMin, y0, lo), new Vec3dCore(xMax, y1, hi));
     }
 
-    /**
-     * The [lo, hi] interval on the constrained axis, already clamped to a finite sub-area for
-     * open-ended ops. Package-visible for tests; callers should prefer {@link #boxFor}.
-     */
-    static double[] axisSpan(Constraint c) {
+    public static boolean satisfied(Constraint c, Vec3dCore foot) {
+        AngleSolverState.Axis axis = spatialAxis(c);
+        if (axis == null) return true;
+        double v = (axis == AngleSolverState.Axis.X) ? foot.x : foot.z;
         if (c.isRange()) {
             double lo = Math.min(c.getLo(), c.getHi());
             double hi = Math.max(c.getLo(), c.getHi());
-            return new double[]{lo, hi};
+            boolean lower = c.isLoInclusive() ? v >= lo : v > lo;
+            boolean upper = c.isHiInclusive() ? v <= hi : v < hi;
+            return lower && upper;
         }
-        double v = c.getValue();
+        double val = c.getValue();
         switch (c.getOp()) {
             case GT:
+                return v > val;
             case GE:
-                // open toward +axis: [v, v + OPEN_EXTENT]
-                return new double[]{v, v + OPEN_EXTENT};
+                return v >= val;
             case LT:
+                return v < val;
             case LE:
-                // open toward -axis: [v - OPEN_EXTENT, v]
-                return new double[]{v - OPEN_EXTENT, v};
+                return v <= val;
             case EQ:
+                return Math.abs(v - val) <= EQ_SATISFY_EPS;
             default:
-                return new double[]{v - EQ_HALF_WIDTH, v + EQ_HALF_WIDTH};
+                return true;
         }
+    }
+
+    public static ConstraintPlate pad(Constraint xRange, Constraint zRange, Vec3dCore foot, ConstraintStyle style, int tick, int[] indices) {
+        double expand = style.expandByHitbox ? H : 0.0;
+        double[] xs = sortedBounds(xRange);
+        double[] zs = sortedBounds(zRange);
+        double[] y = yBounds(style.frontHeight, foot);
+        AABB body = new AABB(
+                new Vec3dCore(xs[0] - expand, y[0], zs[0] - expand),
+                new Vec3dCore(xs[1] + expand, y[1], zs[1] + expand));
+        boolean sat = satisfied(xRange, foot) && satisfied(zRange, foot);
+        return new ConstraintPlate(sense(xRange.getOp()), sat, one(body), none(), tick, indices);
+    }
+
+    public static ConstraintPlate strip(Constraint range, Vec3dCore foot, ConstraintStyle style, int tick, int[] indices) {
+        AngleSolverState.Axis axis = spatialAxis(range);
+        double expand = style.expandByHitbox ? H : 0.0;
+        double[] s = sortedBounds(range);
+        return band(axis, s[0] - expand, s[1] + expand, satisfied(range, foot), sense(range.getOp()), foot, style, tick, indices);
+    }
+
+    public static ConstraintPlate plane(Constraint eq, Vec3dCore foot, ConstraintStyle style, int tick, int[] indices) {
+        AngleSolverState.Axis axis = spatialAxis(eq);
+        double v = eq.getValue();
+        double half = style.expandByHitbox ? H : style.frontLength * 0.5;
+        return band(axis, v - half, v + half, satisfied(eq, foot), sense(eq.getOp()), foot, style, tick, indices);
+    }
+
+    public static ConstraintPlate exclude(Constraint open, Vec3dCore foot, ConstraintStyle style, int tick, int[] indices) {
+        AngleSolverState.Axis axis = spatialAxis(open);
+        double v = open.getValue();
+        boolean allowedPositive = open.getOp() == Constraint.Op.GT || open.getOp() == Constraint.Op.GE;
+        double expand = style.expandByHitbox ? H : 0.0;
+        double cross = crossCoord(axis, foot);
+        int dir = allowedPositive ? 1 : -1;
+        double bound = v - dir * expand;
+
+        double frontFar = bound + dir * style.frontLength;
+        double fw = style.frontWidth * 0.5;
+        double[] yF = yBounds(style.frontHeight, foot);
+        AABB front = rect(axis, Math.min(bound, frontFar), Math.max(bound, frontFar), cross - fw, cross + fw, yF);
+
+        double backFar = frontFar + dir * style.backLength;
+        double bw = style.backWidth * 0.5;
+        double[] yB = yBounds(style.backHeight, foot);
+        AABB back = rect(axis, Math.min(frontFar, backFar), Math.max(frontFar, backFar), cross - bw, cross + bw, yB);
+
+        return new ConstraintPlate(sense(open.getOp()), satisfied(open, foot), one(front), one(back), tick, indices);
+    }
+
+    private static ConstraintPlate band(AngleSolverState.Axis axis, double cLo, double cHi, boolean sat, Sense sense, Vec3dCore foot, ConstraintStyle style, int tick, int[] indices) {
+        double cross = crossCoord(axis, foot);
+        double fw = style.frontWidth * 0.5;
+        AABB front = rect(axis, cLo, cHi, cross - fw, cross + fw, yBounds(style.frontHeight, foot));
+        AABB back = rect(axis, cLo, cHi, cross - style.backLength, cross + style.backLength, yBounds(style.backHeight, foot));
+        return new ConstraintPlate(sense, sat, one(front), one(back), tick, indices);
+    }
+
+    private static double[] yBounds(double height, Vec3dCore foot) {
+        return new double[]{foot.y, foot.y + height};
+    }
+
+    private static AABB rect(AngleSolverState.Axis axis, double aLo, double aHi, double crossLo, double crossHi, double[] y) {
+        if (axis == AngleSolverState.Axis.X) {
+            return new AABB(new Vec3dCore(aLo, y[0], crossLo), new Vec3dCore(aHi, y[1], crossHi));
+        }
+        return new AABB(new Vec3dCore(crossLo, y[0], aLo), new Vec3dCore(crossHi, y[1], aHi));
+    }
+
+    private static double crossCoord(AngleSolverState.Axis axis, Vec3dCore foot) {
+        return (axis == AngleSolverState.Axis.X) ? foot.z : foot.x;
+    }
+
+    private static double[] sortedBounds(Constraint range) {
+        return new double[]{Math.min(range.getLo(), range.getHi()), Math.max(range.getLo(), range.getHi())};
+    }
+
+    private static List<AABB> one(AABB box) {
+        List<AABB> list = new ArrayList<>(1);
+        list.add(box);
+        return list;
+    }
+
+    private static List<AABB> none() {
+        return Collections.emptyList();
     }
 }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/render/ConstraintShapes.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/render/ConstraintShapes.java
@@ -1,0 +1,118 @@
+package de.legoshi.parkourcalc.core.render;
+
+import de.legoshi.parkourcalc.core.anglesolver.AngleSolverState;
+import de.legoshi.parkourcalc.core.anglesolver.Constraint;
+import de.legoshi.parkourcalc.core.sim.AABB;
+import de.legoshi.parkourcalc.core.sim.Vec3dCore;
+
+/**
+ * Maps an angle-solver landing constraint to an in-world AABB anchored at the tick it
+ * applies to (gh-145). Pure geometry: callers feed a constraint plus that tick's simulated
+ * position and get back the box to outline (LINES) and fill (FACES); the renderer wiring lives
+ * in {@link de.legoshi.parkourcalc.core.ui.BoxController}.
+ *
+ * <p>Only the <b>spatial</b> fields have a place in the world: {@link Constraint.Field#X} and
+ * {@link Constraint.Field#Z} are world positions, so a bound on one is a plane the player must be
+ * on/past. The facing/velocity fields (F, dX, dZ) are not positions and have no spatial extent at
+ * the tick, so {@link #spatialAxis(Constraint)} returns null for them and they are not drawn.
+ *
+ * <p>The box is a thin horizontal plate sitting on the tick's foot position:
+ * <ul>
+ *   <li>On the constrained axis it spans the constrained interval.</li>
+ *   <li>On the other horizontal axis it spans a fixed {@link #CROSS_HALF_WIDTH} either side of the
+ *       tick, so the plate is centred on (and visibly tied to) the tick.</li>
+ *   <li>In Y it is a fixed-height slab ({@link #SLAB_HEIGHT}) so it reads as a surface, not a line.</li>
+ * </ul>
+ *
+ * <p>A bounded range {@code X ∈ [lo, hi]} maps to a band of exactly that width. An open-ended
+ * comparison ({@code >}/{@code >=}/{@code <}/{@code <=}) can't be drawn in full (it is half-infinite),
+ * so it renders a limited sub-area: the band starts at the bound and extends {@link #OPEN_EXTENT}
+ * blocks in the open direction, which reads as "open this way" without being infinite. Equality
+ * ({@code =}) renders a thin slab of width {@code 2 *} {@link #EQ_HALF_WIDTH} centred on the value.
+ */
+public final class ConstraintShapes {
+
+    /** Half-width (blocks) of the plate on the axis the constraint does NOT bound; keeps it tied to the tick. */
+    public static final double CROSS_HALF_WIDTH = 0.35;
+
+    /** How far (blocks) an open-ended ({@code >}/{@code <}) band extends past its bound before it is clamped. */
+    public static final double OPEN_EXTENT = 1.0;
+
+    /** Half-width (blocks) of the thin slab drawn for an exact {@code =} constraint. */
+    public static final double EQ_HALF_WIDTH = 0.02;
+
+    /** Vertical thickness (blocks) of the plate, anchored at the tick's foot Y. */
+    public static final double SLAB_HEIGHT = 0.06;
+
+    private ConstraintShapes() {
+    }
+
+    /** The world axis a constraint occupies, or null when the field is non-spatial (F/dX/dZ) and not drawable. */
+    public static AngleSolverState.Axis spatialAxis(Constraint c) {
+        switch (c.getField()) {
+            case X:
+                return AngleSolverState.Axis.X;
+            case Z:
+                return AngleSolverState.Axis.Z;
+            default:
+                return null;
+        }
+    }
+
+    /** True when this constraint maps to a world box (i.e. it bounds X or Z). */
+    public static boolean isDrawable(Constraint c) {
+        return spatialAxis(c) != null;
+    }
+
+    /**
+     * The AABB for {@code c} anchored at {@code tickFoot} (the tick's simulated center-bottom, MC
+     * convention). Returns null if the constraint is non-spatial. The interval on the constrained
+     * axis is clamped for open-ended ops; the other horizontal axis and Y are fixed plate extents.
+     */
+    public static AABB boxFor(Constraint c, Vec3dCore tickFoot) {
+        AngleSolverState.Axis axis = spatialAxis(c);
+        if (axis == null) return null;
+
+        double[] span = axisSpan(c);
+        double lo = span[0];
+        double hi = span[1];
+
+        double y0 = tickFoot.y;
+        double y1 = tickFoot.y + SLAB_HEIGHT;
+
+        if (axis == AngleSolverState.Axis.X) {
+            double zMin = tickFoot.z - CROSS_HALF_WIDTH;
+            double zMax = tickFoot.z + CROSS_HALF_WIDTH;
+            return new AABB(new Vec3dCore(lo, y0, zMin), new Vec3dCore(hi, y1, zMax));
+        }
+        double xMin = tickFoot.x - CROSS_HALF_WIDTH;
+        double xMax = tickFoot.x + CROSS_HALF_WIDTH;
+        return new AABB(new Vec3dCore(xMin, y0, lo), new Vec3dCore(xMax, y1, hi));
+    }
+
+    /**
+     * The [lo, hi] interval on the constrained axis, already clamped to a finite sub-area for
+     * open-ended ops. Package-visible for tests; callers should prefer {@link #boxFor}.
+     */
+    static double[] axisSpan(Constraint c) {
+        if (c.isRange()) {
+            double lo = Math.min(c.getLo(), c.getHi());
+            double hi = Math.max(c.getLo(), c.getHi());
+            return new double[]{lo, hi};
+        }
+        double v = c.getValue();
+        switch (c.getOp()) {
+            case GT:
+            case GE:
+                // open toward +axis: [v, v + OPEN_EXTENT]
+                return new double[]{v, v + OPEN_EXTENT};
+            case LT:
+            case LE:
+                // open toward -axis: [v - OPEN_EXTENT, v]
+                return new double[]{v - OPEN_EXTENT, v};
+            case EQ:
+            default:
+                return new double[]{v - EQ_HALF_WIDTH, v + EQ_HALF_WIDTH};
+        }
+    }
+}

--- a/core/src/main/java/de/legoshi/parkourcalc/core/render/ConstraintStyle.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/render/ConstraintStyle.java
@@ -1,0 +1,24 @@
+package de.legoshi.parkourcalc.core.render;
+
+public final class ConstraintStyle {
+
+    public final boolean expandByHitbox;
+    public final double frontWidth;
+    public final double frontHeight;
+    public final double frontLength;
+    public final double backWidth;
+    public final double backHeight;
+    public final double backLength;
+
+    public ConstraintStyle(boolean expandByHitbox,
+                           double frontWidth, double frontHeight, double frontLength,
+                           double backWidth, double backHeight, double backLength) {
+        this.expandByHitbox = expandByHitbox;
+        this.frontWidth = frontWidth;
+        this.frontHeight = frontHeight;
+        this.frontLength = frontLength;
+        this.backWidth = backWidth;
+        this.backHeight = backHeight;
+        this.backLength = backLength;
+    }
+}

--- a/core/src/main/java/de/legoshi/parkourcalc/core/render/CountingBoxRenderer.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/render/CountingBoxRenderer.java
@@ -1,0 +1,33 @@
+package de.legoshi.parkourcalc.core.render;
+
+import de.legoshi.parkourcalc.core.ports.BoxRenderer;
+import de.legoshi.parkourcalc.core.sim.AABB;
+
+public final class CountingBoxRenderer implements BoxRenderer {
+
+    private final Mode mode;
+    private long vertexCount;
+
+    public CountingBoxRenderer(Mode mode) {
+        this.mode = mode;
+    }
+
+    public long vertexCount() {
+        return vertexCount;
+    }
+
+    @Override
+    public void drawBox(AABB box, int argb) {
+        vertexCount += (mode == Mode.LINES) ? PathVertexLayout.LINE_VERTS_PER_BOX : PathVertexLayout.FACE_VERTS_PER_BOX;
+    }
+
+    @Override
+    public void drawLine(double x1, double y1, double z1, double x2, double y2, double z2, int argb) {
+        if (mode == Mode.LINES) vertexCount += PathVertexLayout.LINE_VERTS_PER_SEGMENT;
+    }
+
+    @Override
+    public void drawTriangle(double x1, double y1, double z1, double x2, double y2, double z2, double x3, double y3, double z3, int argb) {
+        if (mode == Mode.FACES) vertexCount += PathVertexLayout.FACE_VERTS_PER_TRIANGLE;
+    }
+}

--- a/core/src/main/java/de/legoshi/parkourcalc/core/render/PathRenderPlan.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/render/PathRenderPlan.java
@@ -17,20 +17,13 @@ import java.util.function.Consumer;
  * <p><b>Constraint plates (gh-145).</b> When {@code showConstraints} is on, the face/line emitters append
  * a constraint region after the existing geometry (faces: main|hitbox|arrows|<b>constraints</b>; lines:
  * main|subtick|<b>constraints</b>). The region bakes into the same buffers the loaders already build, with
- * no change to the per-box offsets selection patching depends on. To <b>draw</b> the region, each loader's
- * cached-geometry {@code drawFaces}/{@code drawLines} adds one slice (the geometry is camera-run-independent,
- * so it is drawn once, not per run):
- * <pre>
- *   int cFace = PathVertexLayout.constraintFaceRegionBase(boxCount, hitboxStarts[boxCount], showArrows);
- *   int cFaceCount = constraintBoxCount * PathVertexLayout.CONSTRAINT_FACE_VERTS_PER_BOX;
- *   // glDrawArrays(GL_TRIANGLES, cFace, cFaceCount);  // (Fabric: drawRange on faceSegments)
- *
- *   int cLine = PathVertexLayout.constraintLineRegionBase(boxCount, subtickStarts[boxCount]);
- *   int cLineCount = constraintBoxCount * PathVertexLayout.CONSTRAINT_LINE_VERTS_PER_BOX;
- *   // glDrawArrays(GL_LINES, cLine, cLineCount);
- * </pre>
- * where {@code constraintBoxCount = boxController.constraintBoxCount(source)}. Until a loader adds that
- * slice the plates bake but stay invisible; nothing else is affected (buffers stay correctly sized).
+ * no change to the per-box offsets selection patching depends on. Plates vary in vertex count (a pad is
+ * one box; other constraints add a front box and a back box), so
+ * {@link #constraintFaceVerts}/{@link #constraintLineVerts} are counted by replaying the exact constraint
+ * emit through a {@link CountingBoxRenderer} ({@code BoxController.constraintFaceVertexCount}/
+ * {@code constraintLineVertexCount}). Each loader draws the region as the trailing slice
+ * {@code [faceTotal - constraintFaceVerts, faceTotal)} (and the line equivalent); the region is
+ * camera-run-independent, so it is drawn once, not per run.
  */
 public final class PathRenderPlan {
 
@@ -47,6 +40,12 @@ public final class PathRenderPlan {
     public static void setConstraintSource(ConstraintBoxSource source) {
         constraintSource = source != null ? source : ConstraintBoxSource.NONE;
     }
+
+    private static ConstraintBoxSource countedSource;
+    private static long countedRevision = Long.MIN_VALUE;
+    private static long countedGeometryRev = Long.MIN_VALUE;
+    private static int countedFaceVerts;
+    private static int countedLineVerts;
 
     public final int structuralHash;
     public final Set<Integer> selection;
@@ -82,29 +81,47 @@ public final class PathRenderPlan {
         // into the same buffers without disturbing the per-box offsets selection patching depends on.
         ConstraintBoxSource source = constraintSource;
         boolean drawConstraints = settings.showConstraints && source != ConstraintBoxSource.NONE;
-        int constraintArgbFace = BoxStyle.constraintFaceArgb(settings);
-        int constraintArgbLine = BoxStyle.constraintLineArgb(settings);
+        ConstraintPalette palette = new ConstraintPalette(
+                BoxStyle.constraintSatisfiedArgb(settings),
+                BoxStyle.constraintViolatedArgb(),
+                BoxStyle.constraintFillArgb(settings),
+                BoxStyle.constraintBackArgb(settings),
+                BoxStyle.constraintHighlightArgb(settings));
 
         Consumer<BoxRenderer> faceEmitter = faces -> {
             boxController.render(faces, face, 0, 0, 0, ALL);
             if (floor) boxController.renderHitboxFloorOutline(faces, hitbox, settings.showSubtick, 0, 0, 0, ALL);
             if (full) boxController.renderHitboxFullWireframe(faces, hitbox, settings.showSubtick, 0, 0, 0, ALL);
             if (settings.showYawArrows) boxController.renderYawArrows(faces, BoxStyle.yawArrowArgb(settings), 0, 0, 0, ALL);
-            if (drawConstraints) boxController.renderConstraints(faces, source, constraintArgbFace, 0, 0, 0, ALL);
+            if (drawConstraints) boxController.renderConstraints(faces, source, palette, false, 0, 0, 0, ALL);
         };
 
         Consumer<BoxRenderer> lineEmitter = lines -> {
             boxController.render(lines, line, 0, 0, 0, ALL);
             if (settings.showSubtick) boxController.renderPath(lines, BoxStyle.subtickPathArgb(settings), 0, 0, 0, ALL);
-            if (drawConstraints) boxController.renderConstraints(lines, source, constraintArgbLine, 0, 0, 0, ALL);
+            if (drawConstraints) boxController.renderConstraints(lines, source, palette, true, 0, 0, 0, ALL);
         };
 
         SelectionPatchSpec patch = new SelectionPatchSpec(face, line, hitbox, drawHitbox, full, settings.showSubtick);
-        int constraintBoxes = drawConstraints ? boxController.constraintBoxCount(source) : 0;
-        return new PathRenderPlan(structuralHash(settings, drawConstraints ? source.revision() : 0L),
+
+        long constraintRevision = drawConstraints ? source.revision() : 0L;
+        int constraintFaceVerts = 0;
+        int constraintLineVerts = 0;
+        if (drawConstraints) {
+            long geometryRev = boxController.getGeometryRev();
+            if (source != countedSource || constraintRevision != countedRevision || geometryRev != countedGeometryRev) {
+                countedFaceVerts = boxController.constraintFaceVertexCount(source, palette);
+                countedLineVerts = boxController.constraintLineVertexCount(source, palette);
+                countedSource = source;
+                countedRevision = constraintRevision;
+                countedGeometryRev = geometryRev;
+            }
+            constraintFaceVerts = countedFaceVerts;
+            constraintLineVerts = countedLineVerts;
+        }
+        return new PathRenderPlan(structuralHash(settings, constraintRevision),
                 selectedBoxes, faceEmitter, lineEmitter, patch,
-                constraintBoxes * PathVertexLayout.CONSTRAINT_FACE_VERTS_PER_BOX,
-                constraintBoxes * PathVertexLayout.CONSTRAINT_LINE_VERTS_PER_BOX);
+                constraintFaceVerts, constraintLineVerts);
     }
 
     /** Colors and overlay toggles, but NOT selection (which is patched in place). The constraint
@@ -124,11 +141,20 @@ public final class PathRenderPlan {
         h = 31 * h + Arrays.hashCode(settings.subtickPath);
         h = 31 * h + Arrays.hashCode(settings.constraintOutline);
         h = 31 * h + Arrays.hashCode(settings.constraintFill);
+        h = 31 * h + Arrays.hashCode(settings.constraintBack);
+        h = 31 * h + Arrays.hashCode(settings.constraintHighlight);
         h = 31 * h + (settings.showHitbox ? 1 : 0);
         h = 31 * h + (settings.showFullHitbox ? 2 : 0);
         h = 31 * h + (settings.showYawArrows ? 4 : 0);
         h = 31 * h + (settings.showSubtick ? 8 : 0);
         h = 31 * h + (settings.showConstraints ? 16 : 0);
+        h = 31 * h + (settings.constraintExpandByHitbox ? 32 : 0);
+        h = 31 * h + Float.hashCode(settings.constraintFrontWidth);
+        h = 31 * h + Float.hashCode(settings.constraintFrontHeight);
+        h = 31 * h + Float.hashCode(settings.constraintFrontLength);
+        h = 31 * h + Float.hashCode(settings.constraintBackWidth);
+        h = 31 * h + Float.hashCode(settings.constraintBackHeight);
+        h = 31 * h + Float.hashCode(settings.constraintBackLength);
         h = 31 * h + Long.hashCode(constraintRevision);
         return h;
     }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/render/PathRenderPlan.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/render/PathRenderPlan.java
@@ -11,23 +11,59 @@ import java.util.Arrays;
 import java.util.Set;
 import java.util.function.Consumer;
 
-/** Loader-agnostic per-frame inputs for the cached geometry (hash, selection, bake emitters, patch spec). */
+/**
+ * Loader-agnostic per-frame inputs for the cached geometry (hash, selection, bake emitters, patch spec).
+ *
+ * <p><b>Constraint plates (gh-145).</b> When {@code showConstraints} is on, the face/line emitters append
+ * a constraint region after the existing geometry (faces: main|hitbox|arrows|<b>constraints</b>; lines:
+ * main|subtick|<b>constraints</b>). The region bakes into the same buffers the loaders already build, with
+ * no change to the per-box offsets selection patching depends on. To <b>draw</b> the region, each loader's
+ * cached-geometry {@code drawFaces}/{@code drawLines} adds one slice (the geometry is camera-run-independent,
+ * so it is drawn once, not per run):
+ * <pre>
+ *   int cFace = PathVertexLayout.constraintFaceRegionBase(boxCount, hitboxStarts[boxCount], showArrows);
+ *   int cFaceCount = constraintBoxCount * PathVertexLayout.CONSTRAINT_FACE_VERTS_PER_BOX;
+ *   // glDrawArrays(GL_TRIANGLES, cFace, cFaceCount);  // (Fabric: drawRange on faceSegments)
+ *
+ *   int cLine = PathVertexLayout.constraintLineRegionBase(boxCount, subtickStarts[boxCount]);
+ *   int cLineCount = constraintBoxCount * PathVertexLayout.CONSTRAINT_LINE_VERTS_PER_BOX;
+ *   // glDrawArrays(GL_LINES, cLine, cLineCount);
+ * </pre>
+ * where {@code constraintBoxCount = boxController.constraintBoxCount(source)}. Until a loader adds that
+ * slice the plates bake but stay invisible; nothing else is affected (buffers stay correctly sized).
+ */
 public final class PathRenderPlan {
 
     private static final double ALL = Double.POSITIVE_INFINITY;
+
+    /**
+     * Constraint plates to overlay (gh-145), statically wired so the loaders' existing
+     * {@code build(boxController, settings, selection)} call needs no new argument (mirrors
+     * {@link de.legoshi.parkourcalc.core.anglesolver.ConstraintText}'s static wiring). The owner
+     * (Application) sets this once; defaults to {@link ConstraintBoxSource#NONE} for headless/tests.
+     */
+    private static volatile ConstraintBoxSource constraintSource = ConstraintBoxSource.NONE;
+
+    public static void setConstraintSource(ConstraintBoxSource source) {
+        constraintSource = source != null ? source : ConstraintBoxSource.NONE;
+    }
 
     public final int structuralHash;
     public final Set<Integer> selection;
     public final Consumer<BoxRenderer> faceEmitter;
     public final Consumer<BoxRenderer> lineEmitter;
     public final SelectionPatchSpec patch;
+    public final int constraintFaceVerts;
+    public final int constraintLineVerts;
 
-    private PathRenderPlan(int structuralHash, Set<Integer> selection, Consumer<BoxRenderer> faceEmitter, Consumer<BoxRenderer> lineEmitter, SelectionPatchSpec patch) {
+    private PathRenderPlan(int structuralHash, Set<Integer> selection, Consumer<BoxRenderer> faceEmitter, Consumer<BoxRenderer> lineEmitter, SelectionPatchSpec patch, int constraintFaceVerts, int constraintLineVerts) {
         this.structuralHash = structuralHash;
         this.selection = selection;
         this.faceEmitter = faceEmitter;
         this.lineEmitter = lineEmitter;
         this.patch = patch;
+        this.constraintFaceVerts = constraintFaceVerts;
+        this.constraintLineVerts = constraintLineVerts;
     }
 
     public static PathRenderPlan build(BoxController boxController, Settings settings, SelectionManager selection) {
@@ -42,24 +78,39 @@ public final class PathRenderPlan {
         boolean full = drawHitbox && settings.showFullHitbox;
         boolean floor = drawHitbox && !settings.showFullHitbox;
 
+        // Constraint plates ride a region appended after the path/hitbox/arrow geometry, so they bake
+        // into the same buffers without disturbing the per-box offsets selection patching depends on.
+        ConstraintBoxSource source = constraintSource;
+        boolean drawConstraints = settings.showConstraints && source != ConstraintBoxSource.NONE;
+        int constraintArgbFace = BoxStyle.constraintFaceArgb(settings);
+        int constraintArgbLine = BoxStyle.constraintLineArgb(settings);
+
         Consumer<BoxRenderer> faceEmitter = faces -> {
             boxController.render(faces, face, 0, 0, 0, ALL);
             if (floor) boxController.renderHitboxFloorOutline(faces, hitbox, settings.showSubtick, 0, 0, 0, ALL);
             if (full) boxController.renderHitboxFullWireframe(faces, hitbox, settings.showSubtick, 0, 0, 0, ALL);
             if (settings.showYawArrows) boxController.renderYawArrows(faces, BoxStyle.yawArrowArgb(settings), 0, 0, 0, ALL);
+            if (drawConstraints) boxController.renderConstraints(faces, source, constraintArgbFace, 0, 0, 0, ALL);
         };
 
         Consumer<BoxRenderer> lineEmitter = lines -> {
             boxController.render(lines, line, 0, 0, 0, ALL);
             if (settings.showSubtick) boxController.renderPath(lines, BoxStyle.subtickPathArgb(settings), 0, 0, 0, ALL);
+            if (drawConstraints) boxController.renderConstraints(lines, source, constraintArgbLine, 0, 0, 0, ALL);
         };
 
         SelectionPatchSpec patch = new SelectionPatchSpec(face, line, hitbox, drawHitbox, full, settings.showSubtick);
-        return new PathRenderPlan(structuralHash(settings), selectedBoxes, faceEmitter, lineEmitter, patch);
+        int constraintBoxes = drawConstraints ? boxController.constraintBoxCount(source) : 0;
+        return new PathRenderPlan(structuralHash(settings, drawConstraints ? source.revision() : 0L),
+                selectedBoxes, faceEmitter, lineEmitter, patch,
+                constraintBoxes * PathVertexLayout.CONSTRAINT_FACE_VERTS_PER_BOX,
+                constraintBoxes * PathVertexLayout.CONSTRAINT_LINE_VERTS_PER_BOX);
     }
 
-    /** Colors and overlay toggles, but NOT selection (which is patched in place). */
-    private static int structuralHash(Settings settings) {
+    /** Colors and overlay toggles, but NOT selection (which is patched in place). The constraint
+     *  revision is mixed in so editing constraints (which leaves path positions untouched) still
+     *  invalidates the cached buffers. */
+    private static int structuralHash(Settings settings, long constraintRevision) {
         int h = 1;
         h = 31 * h + Arrays.hashCode(settings.tickDefault);
         h = 31 * h + Arrays.hashCode(settings.tickSelected);
@@ -71,10 +122,14 @@ public final class PathRenderPlan {
         h = 31 * h + Arrays.hashCode(settings.hitboxSelected);
         h = 31 * h + Arrays.hashCode(settings.yawArrow);
         h = 31 * h + Arrays.hashCode(settings.subtickPath);
+        h = 31 * h + Arrays.hashCode(settings.constraintOutline);
+        h = 31 * h + Arrays.hashCode(settings.constraintFill);
         h = 31 * h + (settings.showHitbox ? 1 : 0);
         h = 31 * h + (settings.showFullHitbox ? 2 : 0);
         h = 31 * h + (settings.showYawArrows ? 4 : 0);
         h = 31 * h + (settings.showSubtick ? 8 : 0);
+        h = 31 * h + (settings.showConstraints ? 16 : 0);
+        h = 31 * h + Long.hashCode(constraintRevision);
         return h;
     }
 }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/render/PathVertexLayout.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/render/PathVertexLayout.java
@@ -7,11 +7,10 @@ public final class PathVertexLayout {
 
     public static final int FACE_VERTS_PER_BOX = 36; // 12 triangles
     public static final int LINE_VERTS_PER_BOX = 24; // 12 edges
+    public static final int FACE_VERTS_PER_TRIANGLE = 3;
+    public static final int LINE_VERTS_PER_SEGMENT = 2;
     public static final int THICK_EDGE_VERTS = 36;   // each hitbox edge is a filled box
     public static final int ARROW_VERTS_PER_BOX = 60; // 20 triangles (shaft + head)
-    // Constraint plates (gh-145): one filled box per plate, same vertex shape as a tick box.
-    public static final int CONSTRAINT_FACE_VERTS_PER_BOX = 36; // 12 triangles
-    public static final int CONSTRAINT_LINE_VERTS_PER_BOX = 24; // 12 edges
 
     /** Cap per pass (~1 GiB at 16 B/vertex, under the int byte limit); the hitbox is dropped past it. */
     public static final long MAX_PASS_VERTICES = 64_000_000L;
@@ -57,24 +56,5 @@ public final class PathVertexLayout {
     public static int arrowRegionVertices(int boxCount, boolean showArrows) {
         if (!showArrows || boxCount < 2) return 0;
         return (boxCount - 1) * ARROW_VERTS_PER_BOX;
-    }
-
-    /**
-     * First vertex of the appended constraint-plate region in the FACES buffer (gh-145). The faces
-     * buffer is laid out main | hitbox | arrows | constraints, so this sums those three. A loader
-     * draws the region with one extra {@code glDrawArrays}/{@code drawIndexed} of
-     * {@code constraintBoxCount * }{@link #CONSTRAINT_FACE_VERTS_PER_BOX} verts at this offset.
-     */
-    public static int constraintFaceRegionBase(int boxCount, int hitboxRegionVertices, boolean showArrows) {
-        return hitboxRegionBase(boxCount) + hitboxRegionVertices + arrowRegionVertices(boxCount, showArrows);
-    }
-
-    /**
-     * First vertex of the appended constraint-plate region in the LINES buffer (gh-145). The lines
-     * buffer is laid out main | subtick | constraints, so this is the main region plus the subtick
-     * region length. Draw {@code constraintBoxCount * }{@link #CONSTRAINT_LINE_VERTS_PER_BOX} verts here.
-     */
-    public static int constraintLineRegionBase(int boxCount, int subtickRegionVertices) {
-        return boxCount * LINE_VERTS_PER_BOX + subtickRegionVertices;
     }
 }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/render/PathVertexLayout.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/render/PathVertexLayout.java
@@ -9,6 +9,9 @@ public final class PathVertexLayout {
     public static final int LINE_VERTS_PER_BOX = 24; // 12 edges
     public static final int THICK_EDGE_VERTS = 36;   // each hitbox edge is a filled box
     public static final int ARROW_VERTS_PER_BOX = 60; // 20 triangles (shaft + head)
+    // Constraint plates (gh-145): one filled box per plate, same vertex shape as a tick box.
+    public static final int CONSTRAINT_FACE_VERTS_PER_BOX = 36; // 12 triangles
+    public static final int CONSTRAINT_LINE_VERTS_PER_BOX = 24; // 12 edges
 
     /** Cap per pass (~1 GiB at 16 B/vertex, under the int byte limit); the hitbox is dropped past it. */
     public static final long MAX_PASS_VERTICES = 64_000_000L;
@@ -48,5 +51,30 @@ public final class PathVertexLayout {
         }
         starts[n] = acc;
         return starts;
+    }
+
+    /** Yaw-arrow region vertex count in the faces buffer (0 when arrows are hidden / fewer than 2 boxes). */
+    public static int arrowRegionVertices(int boxCount, boolean showArrows) {
+        if (!showArrows || boxCount < 2) return 0;
+        return (boxCount - 1) * ARROW_VERTS_PER_BOX;
+    }
+
+    /**
+     * First vertex of the appended constraint-plate region in the FACES buffer (gh-145). The faces
+     * buffer is laid out main | hitbox | arrows | constraints, so this sums those three. A loader
+     * draws the region with one extra {@code glDrawArrays}/{@code drawIndexed} of
+     * {@code constraintBoxCount * }{@link #CONSTRAINT_FACE_VERTS_PER_BOX} verts at this offset.
+     */
+    public static int constraintFaceRegionBase(int boxCount, int hitboxRegionVertices, boolean showArrows) {
+        return hitboxRegionBase(boxCount) + hitboxRegionVertices + arrowRegionVertices(boxCount, showArrows);
+    }
+
+    /**
+     * First vertex of the appended constraint-plate region in the LINES buffer (gh-145). The lines
+     * buffer is laid out main | subtick | constraints, so this is the main region plus the subtick
+     * region length. Draw {@code constraintBoxCount * }{@link #CONSTRAINT_LINE_VERTS_PER_BOX} verts here.
+     */
+    public static int constraintLineRegionBase(int boxCount, int subtickRegionVertices) {
+        return boxCount * LINE_VERTS_PER_BOX + subtickRegionVertices;
     }
 }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/BoxController.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/BoxController.java
@@ -1,6 +1,7 @@
 package de.legoshi.parkourcalc.core.ui;
 
 import de.legoshi.parkourcalc.core.ports.BoxRenderer;
+import de.legoshi.parkourcalc.core.render.ConstraintBoxSource;
 import de.legoshi.parkourcalc.core.render.PathVertexLayout;
 import de.legoshi.parkourcalc.core.sim.AABB;
 import de.legoshi.parkourcalc.core.sim.TickState;
@@ -157,6 +158,33 @@ public final class BoxController {
             if (!inRange(i, camX, camY, camZ, maxDistanceSq)) continue;
             renderer.drawBox(tickAabbs.get(i), picker.argbFor(i, states.get(i)));
         }
+    }
+
+    /**
+     * Emits one {@code drawBox} per constraint plate, anchored at the tick it applies to (gh-145).
+     * The {@code source} maps each tick index to that tick's drawable constraint AABBs (computed from
+     * {@code ConstraintShapes} against the tick's simulated position). Outline and fill ride the same
+     * call: the renderer's mode (LINES vs FACES) decides whether {@code drawBox} emits edges or faces,
+     * exactly like {@link #render}, so the caller passes {@code outlineArgb} on the LINES pass and
+     * {@code fillArgb} on the FACES pass.
+     */
+    public void renderConstraints(BoxRenderer renderer, ConstraintBoxSource source, int argb,
+                                  double camX, double camY, double camZ, double maxDistanceSq) {
+        for (int i = 0; i < positions.size(); i++) {
+            if (!inRange(i, camX, camY, camZ, maxDistanceSq)) continue;
+            for (AABB box : source.boxesAt(i)) {
+                renderer.drawBox(box, argb);
+            }
+        }
+    }
+
+    /** Total constraint plates across all ticks; one plate is one box ({@code drawBox}) per pass. */
+    public int constraintBoxCount(ConstraintBoxSource source) {
+        int n = 0;
+        for (int i = 0; i < positions.size(); i++) {
+            n += source.boxesAt(i).size();
+        }
+        return n;
     }
 
     /** Cached AABB at index i, in the simulator's world coords. Null if out of range. */

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/BoxController.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/BoxController.java
@@ -2,6 +2,9 @@ package de.legoshi.parkourcalc.core.ui;
 
 import de.legoshi.parkourcalc.core.ports.BoxRenderer;
 import de.legoshi.parkourcalc.core.render.ConstraintBoxSource;
+import de.legoshi.parkourcalc.core.render.ConstraintPalette;
+import de.legoshi.parkourcalc.core.render.ConstraintPlate;
+import de.legoshi.parkourcalc.core.render.CountingBoxRenderer;
 import de.legoshi.parkourcalc.core.render.PathVertexLayout;
 import de.legoshi.parkourcalc.core.sim.AABB;
 import de.legoshi.parkourcalc.core.sim.TickState;
@@ -142,6 +145,49 @@ public final class BoxController {
         return tmin;
     }
 
+    public boolean isCursorOverConstraint(Vec3dCore rayOrigin, Vec3dCore rayDirection, ConstraintBoxSource source) {
+        for (int i = 0; i < positions.size(); i++) {
+            for (ConstraintPlate plate : source.platesAt(i)) {
+                if (closestPlateFace(plate, rayOrigin, rayDirection) >= 0) return true;
+            }
+        }
+        return false;
+    }
+
+    public WorldPick pickWorld(Vec3dCore rayOrigin, Vec3dCore rayDirection, ConstraintBoxSource source) {
+        int box = pickBoxIndex(rayOrigin, rayDirection);
+        if (box > 0 && box < positions.size() - 1) return WorldPick.box(box);
+
+        double bestT = PICK_REACH;
+        int bestTick = -1;
+        int[] bestIndices = null;
+        for (int i = 0; i < positions.size(); i++) {
+            for (ConstraintPlate plate : source.platesAt(i)) {
+                double t = closestPlateFace(plate, rayOrigin, rayDirection);
+                if (t >= 0 && t < bestT) {
+                    bestT = t;
+                    bestTick = plate.tick;
+                    bestIndices = plate.constraintIndices;
+                }
+            }
+        }
+        if (bestTick >= 0) return WorldPick.constraint(bestTick, bestIndices);
+        return null;
+    }
+
+    private double closestPlateFace(ConstraintPlate plate, Vec3dCore rayOrigin, Vec3dCore rayDirection) {
+        double best = -1;
+        for (AABB face : plate.front) {
+            double t = rayHitT(rayOrigin, rayDirection, face, PICK_REACH);
+            if (t >= 0 && (best < 0 || t < best)) best = t;
+        }
+        for (AABB face : plate.back) {
+            double t = rayHitT(rayOrigin, rayDirection, face, PICK_REACH);
+            if (t >= 0 && (best < 0 || t < best)) best = t;
+        }
+        return best;
+    }
+
     private static double[] slab(double o, double d, double min, double max) {
         if (Math.abs(d) < 1.0e-12) {
             if (o < min || o > max) return null;
@@ -160,31 +206,41 @@ public final class BoxController {
         }
     }
 
-    /**
-     * Emits one {@code drawBox} per constraint plate, anchored at the tick it applies to (gh-145).
-     * The {@code source} maps each tick index to that tick's drawable constraint AABBs (computed from
-     * {@code ConstraintShapes} against the tick's simulated position). Outline and fill ride the same
-     * call: the renderer's mode (LINES vs FACES) decides whether {@code drawBox} emits edges or faces,
-     * exactly like {@link #render}, so the caller passes {@code outlineArgb} on the LINES pass and
-     * {@code fillArgb} on the FACES pass.
-     */
-    public void renderConstraints(BoxRenderer renderer, ConstraintBoxSource source, int argb,
-                                  double camX, double camY, double camZ, double maxDistanceSq) {
+    public void renderConstraints(BoxRenderer renderer, ConstraintBoxSource source, ConstraintPalette palette,
+                                  boolean outlinePass, double camX, double camY, double camZ, double maxDistanceSq) {
         for (int i = 0; i < positions.size(); i++) {
             if (!inRange(i, camX, camY, camZ, maxDistanceSq)) continue;
-            for (AABB box : source.boxesAt(i)) {
-                renderer.drawBox(box, argb);
+            for (ConstraintPlate plate : source.platesAt(i)) {
+                if (outlinePass) {
+                    int outline = plate.highlighted ? palette.highlightArgb() : palette.outlineArgb(plate.satisfied);
+                    for (AABB box : plate.front) {
+                        renderer.drawBox(box, outline);
+                    }
+                    for (AABB box : plate.back) {
+                        renderer.drawBox(box, outline);
+                    }
+                } else {
+                    for (AABB box : plate.front) {
+                        renderer.drawBox(box, palette.frontArgb());
+                    }
+                    for (AABB box : plate.back) {
+                        renderer.drawBox(box, palette.backArgb());
+                    }
+                }
             }
         }
     }
 
-    /** Total constraint plates across all ticks; one plate is one box ({@code drawBox}) per pass. */
-    public int constraintBoxCount(ConstraintBoxSource source) {
-        int n = 0;
-        for (int i = 0; i < positions.size(); i++) {
-            n += source.boxesAt(i).size();
-        }
-        return n;
+    public int constraintFaceVertexCount(ConstraintBoxSource source, ConstraintPalette palette) {
+        CountingBoxRenderer counter = new CountingBoxRenderer(BoxRenderer.Mode.FACES);
+        renderConstraints(counter, source, palette, false, 0, 0, 0, Double.POSITIVE_INFINITY);
+        return (int) counter.vertexCount();
+    }
+
+    public int constraintLineVertexCount(ConstraintBoxSource source, ConstraintPalette palette) {
+        CountingBoxRenderer counter = new CountingBoxRenderer(BoxRenderer.Mode.LINES);
+        renderConstraints(counter, source, palette, true, 0, 0, 0, Double.POSITIVE_INFINITY);
+        return (int) counter.vertexCount();
     }
 
     /** Cached AABB at index i, in the simulator's world coords. Null if out of range. */

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/BoxSelectController.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/BoxSelectController.java
@@ -2,23 +2,25 @@ package de.legoshi.parkourcalc.core.ui;
 
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 
-import java.util.function.IntConsumer;
+import java.util.function.Consumer;
 
 public final class BoxSelectController {
 
-    private static final int NOT_PRESSED = -2;
+    public interface Picker {
+        WorldPick pick(Vec3dCore rayOrigin, Vec3dCore rayDirection);
+    }
 
-    private final BoxController boxController;
-    private final IntConsumer onTapCommit;
+    private final Picker picker;
+    private final Consumer<WorldPick> onTapCommit;
 
     private boolean wasMousePressed = false;
-    private int pressBoxIndex = NOT_PRESSED;
+    private WorldPick pressPick;
     private double pressScreenX = 0.0;
     private double pressScreenY = 0.0;
     private boolean abandoned = false;
 
-    public BoxSelectController(BoxController boxController, IntConsumer onTapCommit) {
-        this.boxController = boxController;
+    public BoxSelectController(Picker picker, Consumer<WorldPick> onTapCommit) {
+        this.picker = picker;
         this.onTapCommit = onTapCommit;
     }
 
@@ -30,20 +32,20 @@ public final class BoxSelectController {
         }
 
         if (mousePressed && !wasMousePressed) {
-            pressBoxIndex = boxController.pickBoxIndex(rayOrigin, rayDirection);
+            pressPick = picker.pick(rayOrigin, rayDirection);
             pressScreenX = cursorScreenX;
             pressScreenY = cursorScreenY;
             abandoned = false;
         }
 
-        if (mousePressed && pressBoxIndex != NOT_PRESSED && !abandoned
+        if (mousePressed && pressPick != null && !abandoned
                 && TapThreshold.exceeded(pressScreenX, pressScreenY, cursorScreenX, cursorScreenY)) {
             abandoned = true;
         }
 
         if (!mousePressed && wasMousePressed) {
-            if (pressBoxIndex != NOT_PRESSED && !abandoned) {
-                onTapCommit.accept(pressBoxIndex);
+            if (pressPick != null && !abandoned) {
+                onTapCommit.accept(pressPick);
             }
             resetState();
         }
@@ -52,7 +54,7 @@ public final class BoxSelectController {
     }
 
     private void resetState() {
-        pressBoxIndex = NOT_PRESSED;
+        pressPick = null;
         abandoned = false;
     }
 }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/BoxStyle.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/BoxStyle.java
@@ -53,6 +53,18 @@ public final class BoxStyle {
         return toArgb(c[0], c[1], c[2], c[3]);
     }
 
+    /** Outline color for a constraint plate: full alpha so the wireframe always reads (gh-145). */
+    public static int constraintLineArgb(Settings settings) {
+        float[] c = settings.constraintOutline;
+        return toArgb(c[0], c[1], c[2], 1.0f);
+    }
+
+    /** Fill color for a constraint plate: user-controlled (very translucent) alpha so it reads as an open band. */
+    public static int constraintFaceArgb(Settings settings) {
+        float[] c = settings.constraintFill;
+        return toArgb(c[0], c[1], c[2], c[3]);
+    }
+
     public static double pathMaxDistanceSq(Settings settings) {
         if (settings.unlimitedPathRender) return Double.POSITIVE_INFINITY;
         double d = settings.pathRenderDistance;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/BoxStyle.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/BoxStyle.java
@@ -1,5 +1,6 @@
 package de.legoshi.parkourcalc.core.ui;
 
+import de.legoshi.parkourcalc.core.render.ConstraintStyle;
 import de.legoshi.parkourcalc.core.sim.AABB;
 import de.legoshi.parkourcalc.core.sim.TickState;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
@@ -53,16 +54,41 @@ public final class BoxStyle {
         return toArgb(c[0], c[1], c[2], c[3]);
     }
 
-    /** Outline color for a constraint plate: full alpha so the wireframe always reads (gh-145). */
-    public static int constraintLineArgb(Settings settings) {
+    private static final float[] CONSTRAINT_VIOLATED = {0.949f, 0.259f, 0.361f, 1.000f};
+
+    public static int constraintSatisfiedArgb(Settings settings) {
         float[] c = settings.constraintOutline;
         return toArgb(c[0], c[1], c[2], 1.0f);
     }
 
-    /** Fill color for a constraint plate: user-controlled (very translucent) alpha so it reads as an open band. */
-    public static int constraintFaceArgb(Settings settings) {
+    public static int constraintViolatedArgb() {
+        return toArgb(CONSTRAINT_VIOLATED);
+    }
+
+    public static int constraintFillArgb(Settings settings) {
         float[] c = settings.constraintFill;
         return toArgb(c[0], c[1], c[2], c[3]);
+    }
+
+    public static int constraintBackArgb(Settings settings) {
+        float[] c = settings.constraintBack;
+        return toArgb(c[0], c[1], c[2], c[3]);
+    }
+
+    public static int constraintHighlightArgb(Settings settings) {
+        float[] c = settings.constraintHighlight;
+        return toArgb(c[0], c[1], c[2], 1.0f);
+    }
+
+    public static ConstraintStyle constraintStyle(Settings settings) {
+        return new ConstraintStyle(
+                settings.constraintExpandByHitbox,
+                settings.constraintFrontWidth,
+                settings.constraintFrontHeight,
+                settings.constraintFrontLength,
+                settings.constraintBackWidth,
+                settings.constraintBackHeight,
+                settings.constraintBackLength);
     }
 
     public static double pathMaxDistanceSq(Settings settings) {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/ConstraintSelection.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/ConstraintSelection.java
@@ -1,0 +1,70 @@
+package de.legoshi.parkourcalc.core.ui;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.function.IntUnaryOperator;
+
+public final class ConstraintSelection {
+
+    private final Set<Long> focus = new LinkedHashSet<>();
+
+    public void clear() {
+        focus.clear();
+    }
+
+    public void remapTick(IntUnaryOperator mapper) {
+        Set<Long> next = new LinkedHashSet<>();
+        for (long k : focus) {
+            int tick = (int) (k >> 32);
+            int index = (int) k;
+            int mapped = mapper.applyAsInt(tick);
+            if (mapped >= 0) next.add(key(mapped, index));
+        }
+        focus.clear();
+        focus.addAll(next);
+    }
+
+    public void focusOne(int tick, int index) {
+        focus.clear();
+        focus.add(key(tick, index));
+    }
+
+    public void focus(int tick, int[] indices) {
+        focus.clear();
+        if (indices != null) {
+            for (int index : indices) focus.add(key(tick, index));
+        }
+    }
+
+    public boolean hasFocus() {
+        return !focus.isEmpty();
+    }
+
+    public boolean isFocused(int tick, int index) {
+        return focus.contains(key(tick, index));
+    }
+
+    public boolean highlights(int tick, int index, SelectionManager selection) {
+        if (hasEffectiveFocus(selection)) {
+            return isFocused(tick, index) && selection.isSelected(tick + 1);
+        }
+        return selection.isSelected(tick + 1);
+    }
+
+    private boolean hasEffectiveFocus(SelectionManager selection) {
+        for (long k : focus) {
+            if (selection.isSelected((int) (k >> 32) + 1)) return true;
+        }
+        return false;
+    }
+
+    public long revision() {
+        long h = 1L;
+        for (long k : focus) h = 31 * h + k;
+        return h;
+    }
+
+    private static long key(int tick, int index) {
+        return ((long) tick << 32) | (index & 0xFFFFFFFFL);
+    }
+}

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/Settings.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/Settings.java
@@ -19,8 +19,24 @@ public final class Settings {
     private static final float[] DEFAULT_HITBOX_DEFAULT = {0.804f, 0.839f, 0.957f, 0.80f};      // text       #cdd6f4
     private static final float[] DEFAULT_HITBOX_SELECTED = {0.651f, 0.890f, 0.631f, 0.80f};     // green      #a6e3a1
     private static final float[] DEFAULT_TICK_GROUND_HIGHLIGHT = {0.541f, 0.576f, 0.941f, 0.22f}; // periwinkle #8a93f0
-    private static final float[] DEFAULT_CONSTRAINT_OUTLINE = {0.200f, 0.839f, 0.651f, 1.00f};    // teal       #33d6a6
+    private static final float[] DEFAULT_CONSTRAINT_OUTLINE = {0.404f, 0.831f, 0.451f, 1.00f};    // green      #67d473
     private static final float[] DEFAULT_CONSTRAINT_FILL = {0.200f, 0.839f, 0.651f, 0.15f};       // teal @15%   #33d6a6
+    private static final float[] DEFAULT_CONSTRAINT_BACK = {0.200f, 0.839f, 0.651f, 0.10f};
+    private static final float[] DEFAULT_CONSTRAINT_HIGHLIGHT = {0.976f, 0.886f, 0.686f, 1.00f};
+
+    private static final boolean DEFAULT_CONSTRAINT_EXPAND_BY_HITBOX = true;
+    private static final float DEFAULT_CONSTRAINT_FRONT_WIDTH = 0.6f;
+    private static final float DEFAULT_CONSTRAINT_FRONT_HEIGHT = 0.15f;
+    private static final float DEFAULT_CONSTRAINT_FRONT_LENGTH = 0.1f;
+    private static final float DEFAULT_CONSTRAINT_BACK_WIDTH = 0.6f;
+    private static final float DEFAULT_CONSTRAINT_BACK_HEIGHT = 0.0f;
+    private static final float DEFAULT_CONSTRAINT_BACK_LENGTH = 4.0f;
+
+    public static final float CONSTRAINT_MIN_DIM = 0.0f;
+    public static final float CONSTRAINT_MAX_WIDTH = 3.0f;
+    public static final float CONSTRAINT_MAX_HEIGHT = 2.0f;
+    public static final float CONSTRAINT_MAX_FRONT_LENGTH = 1.0f;
+    public static final float CONSTRAINT_MAX_BACK_LENGTH = 16.0f;
 
     private static final boolean DEFAULT_SHOW_YAW_ARROWS = true;
     private static final boolean DEFAULT_SHOW_HITBOX = false;
@@ -91,6 +107,16 @@ public final class Settings {
     public final float[] tickGroundHighlight = DEFAULT_TICK_GROUND_HIGHLIGHT.clone();
     public final float[] constraintOutline = DEFAULT_CONSTRAINT_OUTLINE.clone();
     public final float[] constraintFill = DEFAULT_CONSTRAINT_FILL.clone();
+    public final float[] constraintBack = DEFAULT_CONSTRAINT_BACK.clone();
+    public final float[] constraintHighlight = DEFAULT_CONSTRAINT_HIGHLIGHT.clone();
+
+    public boolean constraintExpandByHitbox = DEFAULT_CONSTRAINT_EXPAND_BY_HITBOX;
+    public float constraintFrontWidth = DEFAULT_CONSTRAINT_FRONT_WIDTH;
+    public float constraintFrontHeight = DEFAULT_CONSTRAINT_FRONT_HEIGHT;
+    public float constraintFrontLength = DEFAULT_CONSTRAINT_FRONT_LENGTH;
+    public float constraintBackWidth = DEFAULT_CONSTRAINT_BACK_WIDTH;
+    public float constraintBackHeight = DEFAULT_CONSTRAINT_BACK_HEIGHT;
+    public float constraintBackLength = DEFAULT_CONSTRAINT_BACK_LENGTH;
 
     public boolean showYawArrows = DEFAULT_SHOW_YAW_ARROWS;
     public boolean showHitbox = DEFAULT_SHOW_HITBOX;
@@ -175,6 +201,15 @@ public final class Settings {
         System.arraycopy(DEFAULT_TICK_GROUND_HIGHLIGHT, 0, tickGroundHighlight, 0, 4);
         System.arraycopy(DEFAULT_CONSTRAINT_OUTLINE, 0, constraintOutline, 0, 4);
         System.arraycopy(DEFAULT_CONSTRAINT_FILL, 0, constraintFill, 0, 4);
+        System.arraycopy(DEFAULT_CONSTRAINT_BACK, 0, constraintBack, 0, 4);
+        System.arraycopy(DEFAULT_CONSTRAINT_HIGHLIGHT, 0, constraintHighlight, 0, 4);
+        constraintExpandByHitbox = DEFAULT_CONSTRAINT_EXPAND_BY_HITBOX;
+        constraintFrontWidth = DEFAULT_CONSTRAINT_FRONT_WIDTH;
+        constraintFrontHeight = DEFAULT_CONSTRAINT_FRONT_HEIGHT;
+        constraintFrontLength = DEFAULT_CONSTRAINT_FRONT_LENGTH;
+        constraintBackWidth = DEFAULT_CONSTRAINT_BACK_WIDTH;
+        constraintBackHeight = DEFAULT_CONSTRAINT_BACK_HEIGHT;
+        constraintBackLength = DEFAULT_CONSTRAINT_BACK_LENGTH;
         showYawArrows = DEFAULT_SHOW_YAW_ARROWS;
         showHitbox = DEFAULT_SHOW_HITBOX;
         showFullHitbox = DEFAULT_SHOW_FULL_HITBOX;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/Settings.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/Settings.java
@@ -19,6 +19,8 @@ public final class Settings {
     private static final float[] DEFAULT_HITBOX_DEFAULT = {0.804f, 0.839f, 0.957f, 0.80f};      // text       #cdd6f4
     private static final float[] DEFAULT_HITBOX_SELECTED = {0.651f, 0.890f, 0.631f, 0.80f};     // green      #a6e3a1
     private static final float[] DEFAULT_TICK_GROUND_HIGHLIGHT = {0.541f, 0.576f, 0.941f, 0.22f}; // periwinkle #8a93f0
+    private static final float[] DEFAULT_CONSTRAINT_OUTLINE = {0.200f, 0.839f, 0.651f, 1.00f};    // teal       #33d6a6
+    private static final float[] DEFAULT_CONSTRAINT_FILL = {0.200f, 0.839f, 0.651f, 0.15f};       // teal @15%   #33d6a6
 
     private static final boolean DEFAULT_SHOW_YAW_ARROWS = true;
     private static final boolean DEFAULT_SHOW_HITBOX = false;
@@ -26,6 +28,7 @@ public final class Settings {
     private static final boolean DEFAULT_SHOW_SUBTICK = false;
     private static final boolean DEFAULT_SHOW_COL_SPEED = false;
     private static final boolean DEFAULT_SHOW_COL_JUMP_BOOST = false;
+    private static final boolean DEFAULT_SHOW_CONSTRAINTS = true;
     private static final boolean DEFAULT_HIGHLIGHT_ON_GROUND_ROWS = true;
 
     private static final boolean DEFAULT_SHOW_COL_A = true;
@@ -86,6 +89,8 @@ public final class Settings {
     public final float[] hitboxDefault = DEFAULT_HITBOX_DEFAULT.clone();
     public final float[] hitboxSelected = DEFAULT_HITBOX_SELECTED.clone();
     public final float[] tickGroundHighlight = DEFAULT_TICK_GROUND_HIGHLIGHT.clone();
+    public final float[] constraintOutline = DEFAULT_CONSTRAINT_OUTLINE.clone();
+    public final float[] constraintFill = DEFAULT_CONSTRAINT_FILL.clone();
 
     public boolean showYawArrows = DEFAULT_SHOW_YAW_ARROWS;
     public boolean showHitbox = DEFAULT_SHOW_HITBOX;
@@ -93,6 +98,7 @@ public final class Settings {
     public boolean showSubtick = DEFAULT_SHOW_SUBTICK;
     public boolean showColSpeed = DEFAULT_SHOW_COL_SPEED;
     public boolean showColJumpBoost = DEFAULT_SHOW_COL_JUMP_BOOST;
+    public boolean showConstraints = DEFAULT_SHOW_CONSTRAINTS;
     public boolean highlightOnGroundRows = DEFAULT_HIGHLIGHT_ON_GROUND_ROWS;
 
     public boolean showColA = DEFAULT_SHOW_COL_A;
@@ -167,12 +173,15 @@ public final class Settings {
         System.arraycopy(DEFAULT_HITBOX_DEFAULT, 0, hitboxDefault, 0, 4);
         System.arraycopy(DEFAULT_HITBOX_SELECTED, 0, hitboxSelected, 0, 4);
         System.arraycopy(DEFAULT_TICK_GROUND_HIGHLIGHT, 0, tickGroundHighlight, 0, 4);
+        System.arraycopy(DEFAULT_CONSTRAINT_OUTLINE, 0, constraintOutline, 0, 4);
+        System.arraycopy(DEFAULT_CONSTRAINT_FILL, 0, constraintFill, 0, 4);
         showYawArrows = DEFAULT_SHOW_YAW_ARROWS;
         showHitbox = DEFAULT_SHOW_HITBOX;
         showFullHitbox = DEFAULT_SHOW_FULL_HITBOX;
         showSubtick = DEFAULT_SHOW_SUBTICK;
         showColSpeed = DEFAULT_SHOW_COL_SPEED;
         showColJumpBoost = DEFAULT_SHOW_COL_JUMP_BOOST;
+        showConstraints = DEFAULT_SHOW_CONSTRAINTS;
         highlightOnGroundRows = DEFAULT_HIGHLIGHT_ON_GROUND_ROWS;
         showColA = DEFAULT_SHOW_COL_A;
         showColS = DEFAULT_SHOW_COL_S;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/SettingsModal.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/SettingsModal.java
@@ -32,7 +32,9 @@ public final class SettingsModal {
     private static final String TT_SUBTICK = "Renders the interpolated path between adjacent ticks, exposing collision moments inside a tick.";
     private static final String TT_COL_SPEED_AMP = "Adds a per-tick Speed potion amplifier column to the input table.";
     private static final String TT_COL_JUMP_BOOST_AMP = "Adds a per-tick Jump Boost potion amplifier column to the input table.";
-    private static final String TT_CONSTRAINTS = "Draws Angle Solver position constraints (X/Z) as translucent plates at the tick they apply to. Open-ended (> / <) constraints show a clamped band that points the open way. Only visible while the Angle Solver is open.";
+    private static final String TT_CONSTRAINTS = "Draws Angle Solver position constraints (X/Z) as translucent plates at the tick they apply to. The front plate sits on the constraint; the back fades out toward the open/free direction. Only visible while the Angle Solver is open.";
+    private static final String TT_C_EXPAND = "Grow each plate outward by the player hitbox half-width (0.3) so the plate covers your hitbox: your hitbox fits inside the plate exactly when the tick is valid.";
+    private static final String TT_C_DIM = "Size in blocks. Width is across the constraint, height is vertical, length is along the plate (front depth from the boundary / back reach behind it).";
     private static final String TT_GROUND_HIGHLIGHT = "Tints input rows whose simulated tick ended on the ground. Color is editable in Render Colors.";
     private static final String TT_COL_W = "W (forward) is always shown and can't be hidden.";
     private static final String TT_COL_A = "Strafe-left (A) column.";
@@ -66,6 +68,7 @@ public final class SettingsModal {
     private final float[] scrollbarSizeBuf = new float[1];
     private final float[] scrollbarGrabBuf = new float[1];
     private final int[] solverPrecisionBuf = new int[1];
+    private final float[] constraintDimBuf = new float[1];
     private final String[] scaleLabels;
 
     private boolean openRequested;
@@ -114,6 +117,10 @@ public final class SettingsModal {
             }
             if (Controls.beginTab("Visualization")) {
                 renderVisualization();
+                Controls.endTab();
+            }
+            if (Controls.beginTab("Constraints")) {
+                renderConstraints();
                 Controls.endTab();
             }
             if (Controls.beginTab("Input Table")) {
@@ -225,7 +232,6 @@ public final class SettingsModal {
             checkboxRow("Show hitbox", "##show_hitbox", settings.showHitbox, TT_HITBOX, v -> settings.showHitbox = v);
             checkboxRow("Show full hitbox", "##show_full_hitbox", settings.showFullHitbox, TT_FULL_HITBOX, v -> settings.showFullHitbox = v);
             checkboxRow("Subtick visualization", "##show_subtick", settings.showSubtick, TT_SUBTICK, v -> settings.showSubtick = v);
-            checkboxRow("Show constraints", "##show_constraints", settings.showConstraints, TT_CONSTRAINTS, v -> settings.showConstraints = v);
             ThemeManager.endStandardFormTable();
         }
 
@@ -244,6 +250,52 @@ public final class SettingsModal {
             checkboxRow("Unlimited path render distance", "##unlimited_path", settings.unlimitedPathRender, TT_PATH_UNLIMITED, v -> settings.unlimitedPathRender = v);
             ThemeManager.endStandardFormTable();
         }
+    }
+
+    private void renderConstraints() {
+        int colorFlags = ImGuiColorEditFlags.NoInputs | ImGuiColorEditFlags.NoDragDrop;
+
+        ThemeManager.sectionSpacing();
+        sectionHeader("Shape");
+        if (beginLayoutTable("##settings_constraint_shape")) {
+            checkboxRow("Show constraints", "##show_constraints", settings.showConstraints, TT_CONSTRAINTS, v -> settings.showConstraints = v);
+            checkboxRow("Expand by player hitbox", "##c_expand", settings.constraintExpandByHitbox, TT_C_EXPAND, v -> settings.constraintExpandByHitbox = v);
+            ThemeManager.endStandardFormTable();
+        }
+
+        ThemeManager.sectionSpacing();
+        sectionHeader("Front (plate on the constraint)");
+        if (beginLayoutTable("##settings_constraint_front")) {
+            constraintDimRow("Width", "##c_fw", settings.constraintFrontWidth, Settings.CONSTRAINT_MAX_WIDTH, v -> settings.constraintFrontWidth = v);
+            constraintDimRow("Height", "##c_fh", settings.constraintFrontHeight, Settings.CONSTRAINT_MAX_HEIGHT, v -> settings.constraintFrontHeight = v);
+            constraintDimRow("Length", "##c_fl", settings.constraintFrontLength, Settings.CONSTRAINT_MAX_FRONT_LENGTH, v -> settings.constraintFrontLength = v);
+            ThemeManager.endStandardFormTable();
+        }
+        renderColor("front color", settings.constraintFill, colorFlags);
+        renderColor("satisfied outline", settings.constraintOutline, colorFlags);
+        renderColor("selected highlight", settings.constraintHighlight, colorFlags);
+
+        ThemeManager.sectionSpacing();
+        sectionHeader("Back (fade tail)");
+        if (beginLayoutTable("##settings_constraint_back")) {
+            constraintDimRow("Width", "##c_bw", settings.constraintBackWidth, Settings.CONSTRAINT_MAX_WIDTH, v -> settings.constraintBackWidth = v);
+            constraintDimRow("Height", "##c_bh", settings.constraintBackHeight, Settings.CONSTRAINT_MAX_HEIGHT, v -> settings.constraintBackHeight = v);
+            constraintDimRow("Length", "##c_bl", settings.constraintBackLength, Settings.CONSTRAINT_MAX_BACK_LENGTH, v -> settings.constraintBackLength = v);
+            ThemeManager.endStandardFormTable();
+        }
+        renderColor("back color", settings.constraintBack, colorFlags);
+    }
+
+    private void constraintDimRow(String label, String id, float value, float max, Consumer<Float> setter) {
+        row(label, () -> {
+            constraintDimBuf[0] = value;
+            ImGui.setNextItemWidth(-1);
+            if (Controls.sliderFloat(id, constraintDimBuf, Settings.CONSTRAINT_MIN_DIM, max, "%.2f")) {
+                setter.accept(constraintDimBuf[0]);
+            }
+            if (ImGui.isItemDeactivatedAfterEdit()) onChanged.run();
+            tooltipForLastItem(TT_C_DIM);
+        });
     }
 
     private void renderInputTable() {
@@ -324,8 +376,6 @@ public final class SettingsModal {
         renderColor("yaw arrows", settings.yawArrow, flags);
         renderColor("yaw gizmo circle", settings.yawGizmoCircle, flags);
         renderColor("yaw gizmo direction", settings.yawGizmoDirection, flags);
-        renderColor("constraint outline", settings.constraintOutline, flags);
-        renderColor("constraint fill", settings.constraintFill, flags);
 
         ThemeManager.sectionSpacing();
         sectionHeader("Hitbox");

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/SettingsModal.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/SettingsModal.java
@@ -32,6 +32,7 @@ public final class SettingsModal {
     private static final String TT_SUBTICK = "Renders the interpolated path between adjacent ticks, exposing collision moments inside a tick.";
     private static final String TT_COL_SPEED_AMP = "Adds a per-tick Speed potion amplifier column to the input table.";
     private static final String TT_COL_JUMP_BOOST_AMP = "Adds a per-tick Jump Boost potion amplifier column to the input table.";
+    private static final String TT_CONSTRAINTS = "Draws Angle Solver position constraints (X/Z) as translucent plates at the tick they apply to. Open-ended (> / <) constraints show a clamped band that points the open way. Only visible while the Angle Solver is open.";
     private static final String TT_GROUND_HIGHLIGHT = "Tints input rows whose simulated tick ended on the ground. Color is editable in Render Colors.";
     private static final String TT_COL_W = "W (forward) is always shown and can't be hidden.";
     private static final String TT_COL_A = "Strafe-left (A) column.";
@@ -224,6 +225,7 @@ public final class SettingsModal {
             checkboxRow("Show hitbox", "##show_hitbox", settings.showHitbox, TT_HITBOX, v -> settings.showHitbox = v);
             checkboxRow("Show full hitbox", "##show_full_hitbox", settings.showFullHitbox, TT_FULL_HITBOX, v -> settings.showFullHitbox = v);
             checkboxRow("Subtick visualization", "##show_subtick", settings.showSubtick, TT_SUBTICK, v -> settings.showSubtick = v);
+            checkboxRow("Show constraints", "##show_constraints", settings.showConstraints, TT_CONSTRAINTS, v -> settings.showConstraints = v);
             ThemeManager.endStandardFormTable();
         }
 
@@ -322,6 +324,8 @@ public final class SettingsModal {
         renderColor("yaw arrows", settings.yawArrow, flags);
         renderColor("yaw gizmo circle", settings.yawGizmoCircle, flags);
         renderColor("yaw gizmo direction", settings.yawGizmoDirection, flags);
+        renderColor("constraint outline", settings.constraintOutline, flags);
+        renderColor("constraint fill", settings.constraintFill, flags);
 
         ThemeManager.sectionSpacing();
         sectionHeader("Hitbox");

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/WorldPick.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/WorldPick.java
@@ -1,0 +1,27 @@
+package de.legoshi.parkourcalc.core.ui;
+
+public final class WorldPick {
+
+    public enum Kind {
+        BOX,
+        CONSTRAINT
+    }
+
+    public final Kind kind;
+    public final int index;
+    public final int[] constraintIndices;
+
+    private WorldPick(Kind kind, int index, int[] constraintIndices) {
+        this.kind = kind;
+        this.index = index;
+        this.constraintIndices = constraintIndices;
+    }
+
+    public static WorldPick box(int boxIndex) {
+        return new WorldPick(Kind.BOX, boxIndex, null);
+    }
+
+    public static WorldPick constraint(int tick, int[] constraintIndices) {
+        return new WorldPick(Kind.CONSTRAINT, tick, constraintIndices);
+    }
+}

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverConstraintSource.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverConstraintSource.java
@@ -4,10 +4,15 @@ import de.legoshi.parkourcalc.core.anglesolver.AngleSolverState;
 import de.legoshi.parkourcalc.core.anglesolver.Constraint;
 import de.legoshi.parkourcalc.core.anglesolver.TickConstraints;
 import de.legoshi.parkourcalc.core.render.ConstraintBoxSource;
+import de.legoshi.parkourcalc.core.render.ConstraintPlate;
 import de.legoshi.parkourcalc.core.render.ConstraintShapes;
-import de.legoshi.parkourcalc.core.sim.AABB;
+import de.legoshi.parkourcalc.core.render.ConstraintStyle;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.BoxController;
+import de.legoshi.parkourcalc.core.ui.BoxStyle;
+import de.legoshi.parkourcalc.core.ui.ConstraintSelection;
+import de.legoshi.parkourcalc.core.ui.SelectionManager;
+import de.legoshi.parkourcalc.core.ui.Settings;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,50 +21,105 @@ import java.util.List;
  * Turns the angle-solver's per-tick constraints into world plates for the overlay (gh-145), bridging
  * {@link AngleSolverState} to the loader-agnostic {@link ConstraintBoxSource} port. Each constraint is
  * anchored at its tick's simulated foot position (the {@link BoxController} index equals the absolute
- * tick index the constraint is keyed by), so the constraint→tick mapping is explicit.
+ * tick index the constraint is keyed by), so the constraint->tick mapping is explicit.
  *
  * <p>Only enabled, spatial (X/Z) constraints produce geometry; facing/velocity constraints have no
- * world extent and are skipped (see {@link ConstraintShapes}). Plates render only while the solver view
- * is active, so constraints don't clutter the world when the feature is closed.
+ * world extent and are skipped (see {@link ConstraintShapes}). A co-tick bounded X range and Z range
+ * merge into a single landing pad; lone bounded ranges, equalities, and open-ended comparisons each
+ * become their own plate. Each plate carries the indices (into the tick's constraint list) it came from
+ * and whether it is highlighted by the current selection. Plates render only while the solver view is
+ * active.
  */
 public final class AngleSolverConstraintSource implements ConstraintBoxSource {
 
     private final AngleSolverState state;
     private final BoxController boxController;
     private final ActiveGate active;
+    private final Settings settings;
+    private final SelectionManager selection;
+    private final ConstraintSelection constraintSelection;
 
-    /** Lets the overlay vanish when the Angle Solver view is closed, without coupling to Settings here. */
+    /** Lets the overlay vanish when the Angle Solver view is closed. */
     public interface ActiveGate {
         boolean isActive();
     }
 
-    public AngleSolverConstraintSource(AngleSolverState state, BoxController boxController, ActiveGate active) {
+    public AngleSolverConstraintSource(AngleSolverState state, BoxController boxController, ActiveGate active,
+                                       Settings settings, SelectionManager selection, ConstraintSelection constraintSelection) {
         this.state = state;
         this.boxController = boxController;
         this.active = active;
+        this.settings = settings;
+        this.selection = selection;
+        this.constraintSelection = constraintSelection;
     }
 
     @Override
-    public List<AABB> boxesAt(int tickIndex) {
+    public List<ConstraintPlate> platesAt(int tickIndex) {
         if (!active.isActive()) return java.util.Collections.emptyList();
         TickConstraints tc = state.tickConstraintsOrNull(tickIndex);
         if (tc == null || tc.getConstraints().isEmpty()) return java.util.Collections.emptyList();
         Vec3dCore foot = boxController.getPosition(tickIndex);
         if (foot == null) return java.util.Collections.emptyList();
 
-        List<AABB> out = new ArrayList<>();
-        for (Constraint c : tc.getConstraints()) {
-            if (!c.isEnabled() || !ConstraintShapes.isDrawable(c)) continue;
-            AABB box = ConstraintShapes.boxFor(c, foot);
-            if (box != null) out.add(box);
+        List<Constraint> all = tc.getConstraints();
+        List<Integer> drawable = new ArrayList<>();
+        for (int i = 0; i < all.size(); i++) {
+            Constraint c = all.get(i);
+            if (c.isEnabled() && ConstraintShapes.isDrawable(c)) drawable.add(i);
+        }
+        if (drawable.isEmpty()) return java.util.Collections.emptyList();
+
+        ConstraintStyle style = BoxStyle.constraintStyle(settings);
+        int xIdx = firstBoundedRangeIndex(all, drawable, Constraint.Field.X);
+        int zIdx = firstBoundedRangeIndex(all, drawable, Constraint.Field.Z);
+        boolean merged = xIdx >= 0 && zIdx >= 0;
+
+        List<ConstraintPlate> out = new ArrayList<>();
+        if (merged) {
+            out.add(tagged(ConstraintShapes.pad(all.get(xIdx), all.get(zIdx), foot, style, tickIndex, new int[]{xIdx, zIdx})));
+        }
+        for (int idx : drawable) {
+            if (merged && (idx == xIdx || idx == zIdx)) continue;
+            Constraint c = all.get(idx);
+            int[] one = {idx};
+            ConstraintPlate plate;
+            if (ConstraintShapes.sense(c.getOp()) == ConstraintShapes.Sense.EXCLUDE) {
+                plate = ConstraintShapes.exclude(c, foot, style, tickIndex, one);
+            } else if (c.isRange()) {
+                plate = ConstraintShapes.strip(c, foot, style, tickIndex, one);
+            } else {
+                plate = ConstraintShapes.plane(c, foot, style, tickIndex, one);
+            }
+            out.add(tagged(plate));
         }
         return out;
     }
 
+    private ConstraintPlate tagged(ConstraintPlate plate) {
+        for (int idx : plate.constraintIndices) {
+            if (constraintSelection.highlights(plate.tick, idx, selection)) {
+                plate.highlighted = true;
+                break;
+            }
+        }
+        return plate;
+    }
+
+    private static int firstBoundedRangeIndex(List<Constraint> all, List<Integer> drawable, Constraint.Field field) {
+        for (int idx : drawable) {
+            Constraint c = all.get(idx);
+            if (c.isRange() && c.getField() == field) return idx;
+        }
+        return -1;
+    }
+
     /**
-     * Content stamp over the drawable constraints and their anchor ticks. Folded into the cached
-     * geometry's structural hash so editing a constraint (value, op, field, enable) rebuilds the
-     * buffers even though the path positions are unchanged.
+     * Content stamp over the drawable constraints, their anchor-tick selection, and the focused
+     * constraint. Folded into the cached geometry's structural hash so editing a constraint, or
+     * selecting/focusing a constrained tick (which recolours the plate), rebuilds the buffers even
+     * though the path positions are unchanged. Selecting a tick with no constraints does not change it,
+     * so the cheaper in-place box-selection patch still applies there.
      */
     @Override
     public long revision() {
@@ -68,16 +128,22 @@ public final class AngleSolverConstraintSource implements ConstraintBoxSource {
         for (Integer tickKey : state.populatedTicks()) {
             TickConstraints tc = state.tickConstraintsOrNull(tickKey);
             if (tc == null) continue;
+            boolean anyDrawable = false;
             for (Constraint c : tc.getConstraints()) {
                 if (!c.isEnabled() || !ConstraintShapes.isDrawable(c)) continue;
+                anyDrawable = true;
                 h = 31 * h + tickKey;
                 h = 31 * h + c.getField().ordinal();
                 h = 31 * h + c.getOp().ordinal();
                 h = 31 * h + Double.hashCode(c.getValue());
                 h = 31 * h + Double.hashCode(c.getLo());
                 h = 31 * h + Double.hashCode(c.getHi());
+                h = 31 * h + (c.isLoInclusive() ? 1 : 0);
+                h = 31 * h + (c.isHiInclusive() ? 1 : 0);
             }
+            if (anyDrawable) h = 31 * h + (selection.isSelected(tickKey + 1) ? 1 : 0);
         }
+        h = 31 * h + Long.hashCode(constraintSelection.revision());
         return h;
     }
 }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverConstraintSource.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverConstraintSource.java
@@ -1,0 +1,83 @@
+package de.legoshi.parkourcalc.core.ui.anglesolver;
+
+import de.legoshi.parkourcalc.core.anglesolver.AngleSolverState;
+import de.legoshi.parkourcalc.core.anglesolver.Constraint;
+import de.legoshi.parkourcalc.core.anglesolver.TickConstraints;
+import de.legoshi.parkourcalc.core.render.ConstraintBoxSource;
+import de.legoshi.parkourcalc.core.render.ConstraintShapes;
+import de.legoshi.parkourcalc.core.sim.AABB;
+import de.legoshi.parkourcalc.core.sim.Vec3dCore;
+import de.legoshi.parkourcalc.core.ui.BoxController;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Turns the angle-solver's per-tick constraints into world plates for the overlay (gh-145), bridging
+ * {@link AngleSolverState} to the loader-agnostic {@link ConstraintBoxSource} port. Each constraint is
+ * anchored at its tick's simulated foot position (the {@link BoxController} index equals the absolute
+ * tick index the constraint is keyed by), so the constraint→tick mapping is explicit.
+ *
+ * <p>Only enabled, spatial (X/Z) constraints produce geometry; facing/velocity constraints have no
+ * world extent and are skipped (see {@link ConstraintShapes}). Plates render only while the solver view
+ * is active, so constraints don't clutter the world when the feature is closed.
+ */
+public final class AngleSolverConstraintSource implements ConstraintBoxSource {
+
+    private final AngleSolverState state;
+    private final BoxController boxController;
+    private final ActiveGate active;
+
+    /** Lets the overlay vanish when the Angle Solver view is closed, without coupling to Settings here. */
+    public interface ActiveGate {
+        boolean isActive();
+    }
+
+    public AngleSolverConstraintSource(AngleSolverState state, BoxController boxController, ActiveGate active) {
+        this.state = state;
+        this.boxController = boxController;
+        this.active = active;
+    }
+
+    @Override
+    public List<AABB> boxesAt(int tickIndex) {
+        if (!active.isActive()) return java.util.Collections.emptyList();
+        TickConstraints tc = state.tickConstraintsOrNull(tickIndex);
+        if (tc == null || tc.getConstraints().isEmpty()) return java.util.Collections.emptyList();
+        Vec3dCore foot = boxController.getPosition(tickIndex);
+        if (foot == null) return java.util.Collections.emptyList();
+
+        List<AABB> out = new ArrayList<>();
+        for (Constraint c : tc.getConstraints()) {
+            if (!c.isEnabled() || !ConstraintShapes.isDrawable(c)) continue;
+            AABB box = ConstraintShapes.boxFor(c, foot);
+            if (box != null) out.add(box);
+        }
+        return out;
+    }
+
+    /**
+     * Content stamp over the drawable constraints and their anchor ticks. Folded into the cached
+     * geometry's structural hash so editing a constraint (value, op, field, enable) rebuilds the
+     * buffers even though the path positions are unchanged.
+     */
+    @Override
+    public long revision() {
+        if (!active.isActive()) return 0L;
+        long h = 1L;
+        for (Integer tickKey : state.populatedTicks()) {
+            TickConstraints tc = state.tickConstraintsOrNull(tickKey);
+            if (tc == null) continue;
+            for (Constraint c : tc.getConstraints()) {
+                if (!c.isEnabled() || !ConstraintShapes.isDrawable(c)) continue;
+                h = 31 * h + tickKey;
+                h = 31 * h + c.getField().ordinal();
+                h = 31 * h + c.getOp().ordinal();
+                h = 31 * h + Double.hashCode(c.getValue());
+                h = 31 * h + Double.hashCode(c.getLo());
+                h = 31 * h + Double.hashCode(c.getHi());
+            }
+        }
+        return h;
+    }
+}

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverTable.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverTable.java
@@ -8,6 +8,7 @@ import de.legoshi.parkourcalc.core.anglesolver.PotionDose;
 import de.legoshi.parkourcalc.core.anglesolver.Slipperiness;
 import de.legoshi.parkourcalc.core.anglesolver.StateOverride;
 import de.legoshi.parkourcalc.core.anglesolver.TickConstraints;
+import de.legoshi.parkourcalc.core.ui.ConstraintSelection;
 import de.legoshi.parkourcalc.core.ui.SelectionManager;
 import de.legoshi.parkourcalc.core.ui.Settings;
 import de.legoshi.parkourcalc.core.ui.theme.Controls;
@@ -46,6 +47,7 @@ public final class AngleSolverTable {
     private final AngleSolverState state;
     private final Settings settings;
     private final SelectionManager selection;
+    private final ConstraintSelection constraintSelection;
     private final IntSupplier rowCount;
 
     private int expandedRow = -1;
@@ -53,10 +55,6 @@ public final class AngleSolverTable {
     // Drawer height: measured from the prior frame's content so bottom padding matches the top.
     private int measuredTick = -1;
     private float measuredContentH = -1f;
-
-    // Constraint picked by clicking its chip: opens that tick's drawer and highlights the editor row.
-    private int selectedConstraintTick = -1;
-    private int selectedConstraintIndex = -1;
 
     private int selectedStateTick = -1;
     private DragKind selectedStateKind;
@@ -112,10 +110,11 @@ public final class AngleSolverTable {
     }
 
     public AngleSolverTable(AngleSolverState state, Settings settings, SelectionManager selection,
-                            IntSupplier rowCount) {
+                            ConstraintSelection constraintSelection, IntSupplier rowCount) {
         this.state = state;
         this.settings = settings;
         this.selection = selection;
+        this.constraintSelection = constraintSelection;
         this.rowCount = rowCount;
     }
 
@@ -138,7 +137,7 @@ public final class AngleSolverTable {
         state.onRowMoved(from, to);
         expandedRow = AngleSolverState.mapRowMove(expandedRow, from, to);
         measuredTick = AngleSolverState.mapRowMove(measuredTick, from, to);
-        selectedConstraintTick = AngleSolverState.mapRowMove(selectedConstraintTick, from, to);
+        constraintSelection.remapTick(t -> AngleSolverState.mapRowMove(t, from, to));
         selectedStateTick = AngleSolverState.mapRowMove(selectedStateTick, from, to);
     }
 
@@ -220,8 +219,12 @@ public final class AngleSolverTable {
 
     private void applyDrop(int hover) {
         if (dragKind == DragKind.CONSTRAINT) {
-            if (dragAlt) state.copyConstraint(dragTick, dragIndex, hover);
-            else if (hover != dragTick) state.moveConstraint(dragTick, dragIndex, hover);
+            if (dragAlt) {
+                state.copyConstraint(dragTick, dragIndex, hover);
+            } else if (hover != dragTick) {
+                state.moveConstraint(dragTick, dragIndex, hover);
+                clearConstraintSelection();
+            }
             return;
         }
         if (hover == dragTick && !dragAlt) return;
@@ -301,6 +304,7 @@ public final class AngleSolverTable {
         int flags = ImGuiSelectableFlags.SpanAllColumns | ImGuiSelectableFlags.AllowItemOverlap;
         if (ThemeManager.rightAlignedSelectable("row" + rowIndex, "", sel, flags, 0f, gutterItemH)) {
             selection.handleClick(rowIndex + 1);
+            constraintSelection.clear();
         }
         ImVec2 selMin = ImGui.getItemRectMin();
         ImVec2 selMax = ImGui.getItemRectMax();
@@ -555,7 +559,7 @@ public final class AngleSolverTable {
         ImVec2 mn = ImGui.getItemRectMin();
         ImVec2 mx = ImGui.getItemRectMax();
         boolean hover = ImGui.isItemHovered();
-        boolean selected = selectedConstraintTick == tick && selectedConstraintIndex == index;
+        boolean selected = constraintSelection.highlights(tick, index, selection);
 
         boolean off = !c.isEnabled();
         chipDropShadow(dl, mn, mx, s);
@@ -598,8 +602,8 @@ public final class AngleSolverTable {
         // A plain click (pressed and released on the chip without dragging) opens the tick and selects it.
         if (!dragging && ImGui.isItemDeactivated()) {
             expandedRow = tick;
-            selectedConstraintTick = tick;
-            selectedConstraintIndex = index;
+            constraintSelection.focusOne(tick, index);
+            selection.handleClick(tick + 1);
             clearStateSelection();
         }
 
@@ -635,6 +639,7 @@ public final class AngleSolverTable {
         int movePick = tickGrid("move", tick);
         if (movePick >= 0) {
             state.moveConstraint(tick, index, movePick);
+            clearConstraintSelection();
             ImGui.closeCurrentPopup();
         }
         ThemeManager.paddedSeparator();
@@ -643,6 +648,7 @@ public final class AngleSolverTable {
         ThemeManager.popTextColor();
         if (del) {
             state.deleteConstraint(tick, index);
+            clearConstraintSelection();
             ImGui.closeCurrentPopup();
         }
     }
@@ -779,8 +785,7 @@ public final class AngleSolverTable {
     }
 
     private void clearConstraintSelection() {
-        selectedConstraintTick = -1;
-        selectedConstraintIndex = -1;
+        constraintSelection.clear();
     }
 
     // ---- editor drawer ----------------------------------------------------------
@@ -872,7 +877,7 @@ public final class AngleSolverTable {
                 ImGui.pushID(i);
                 ImGui.tableNextRow();
                 ImGui.tableNextColumn();
-                if (tick == selectedConstraintTick && i == selectedConstraintIndex) drawSelectedRowHighlight();
+                if (constraintSelection.highlights(tick, i, selection)) drawSelectedRowHighlight();
                 editorGrip(tick, i, c);
                 ImGui.tableNextColumn();
                 if (ImGui.checkbox("##on", c.isEnabled())) c.setEnabled(!c.isEnabled());
@@ -906,7 +911,10 @@ public final class AngleSolverTable {
             Controls.popInputFrameHeight();
             ThemeManager.endStandardFormTable();
         }
-        if (delete >= 0) state.deleteConstraint(tick, delete);
+        if (delete >= 0) {
+            state.deleteConstraint(tick, delete);
+            clearConstraintSelection();
+        }
 
         if (Controls.secondaryButton("+ add constraint")) state.addConstraint(tick);
     }

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/ConstraintVisualizationTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/ConstraintVisualizationTest.java
@@ -4,57 +4,72 @@ import de.legoshi.parkourcalc.core.anglesolver.AngleSolverState;
 import de.legoshi.parkourcalc.core.anglesolver.Constraint;
 import de.legoshi.parkourcalc.core.ports.BoxRenderer;
 import de.legoshi.parkourcalc.core.render.ConstraintBoxSource;
+import de.legoshi.parkourcalc.core.render.ConstraintPalette;
+import de.legoshi.parkourcalc.core.render.ConstraintPlate;
 import de.legoshi.parkourcalc.core.render.ConstraintShapes;
+import de.legoshi.parkourcalc.core.render.ConstraintStyle;
+import de.legoshi.parkourcalc.core.render.PathRenderPlan;
 import de.legoshi.parkourcalc.core.sim.AABB;
 import de.legoshi.parkourcalc.core.sim.TickState;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.BoxController;
+import de.legoshi.parkourcalc.core.ui.ConstraintSelection;
+import de.legoshi.parkourcalc.core.ui.SelectionManager;
+import de.legoshi.parkourcalc.core.ui.Settings;
+import de.legoshi.parkourcalc.core.ui.WorldPick;
 import de.legoshi.parkourcalc.core.ui.anglesolver.AngleSolverConstraintSource;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-/**
- * gh-145: in-world constraint visualization geometry. Pins the constraint -> AABB mapping
- * (anchored at the tick's simulated position), the open-ended clamping extent / side, and the
- * BoxController emission + AngleSolverConstraintSource bridge.
- */
 public class ConstraintVisualizationTest {
 
     private static final double EPS = 1.0e-9;
+    private static final double H = ConstraintShapes.H;
 
-    /** Captures every AABB submitted, so tests can assert geometry without a real renderer. */
-    private static final class CapturingRenderer implements BoxRenderer {
+    private static final double FRONT_W = 0.6;
+    private static final double FRONT_H = 0.15;
+    private static final double FRONT_L = 0.1;
+    private static final double BACK_W = 0.6;
+    private static final double BACK_H = 0.0;
+    private static final double BACK_L = 4.0;
+    private static final double CORE = FRONT_W * 0.5;
+
+    private static final ConstraintStyle STYLE = new ConstraintStyle(true, FRONT_W, FRONT_H, FRONT_L, BACK_W, BACK_H, BACK_L);
+    private static final ConstraintStyle NO_EXPAND = new ConstraintStyle(false, FRONT_W, FRONT_H, FRONT_L, BACK_W, BACK_H, BACK_L);
+
+    private static final int[] I0 = {0};
+    private static final ConstraintPalette PALETTE = new ConstraintPalette(0x1, 0x2, 0x3, 0x4, 0x5);
+
+    private static final class VertCounter implements BoxRenderer {
         final Mode mode;
-        final List<AABB> boxes = new ArrayList<>();
-        int lines;
-        int triangles;
+        long count;
 
-        CapturingRenderer(Mode mode) {
+        VertCounter(Mode mode) {
             this.mode = mode;
         }
 
         @Override
         public void drawBox(AABB box, int argb) {
-            boxes.add(box);
+            count += (mode == Mode.LINES) ? 24 : 36;
         }
 
         @Override
         public void drawLine(double x1, double y1, double z1, double x2, double y2, double z2, int argb) {
-            lines++;
+            if (mode == Mode.LINES) count += 2;
         }
 
         @Override
         public void drawTriangle(double x1, double y1, double z1, double x2, double y2, double z2, double x3, double y3, double z3, int argb) {
-            triangles++;
+            if (mode == Mode.FACES) count += 3;
         }
     }
 
@@ -62,166 +77,316 @@ public class ConstraintVisualizationTest {
         return new TickState(p, false, false, false, 0f, Collections.<Vec3dCore>emptyList(), Vec3dCore.ZERO, false, Double.NaN);
     }
 
-    // ---- ConstraintShapes: range bands ----------------------------------------
-
-    @Test
-    public void rangeXMapsToBandAtTickPosition() {
-        Vec3dCore foot = new Vec3dCore(10.0, 64.0, 20.0);
-        Constraint c = Constraint.range(Constraint.Field.X, 12.0, 15.0, true, true);
-        AABB box = ConstraintShapes.boxFor(c, foot);
-
-        // Constrained axis spans the range exactly.
-        assertEquals(12.0, box.min.x, EPS);
-        assertEquals(15.0, box.max.x, EPS);
-        // Cross axis (Z) is a fixed plate centred on the tick.
-        assertEquals(20.0 - ConstraintShapes.CROSS_HALF_WIDTH, box.min.z, EPS);
-        assertEquals(20.0 + ConstraintShapes.CROSS_HALF_WIDTH, box.max.z, EPS);
-        // Y is a thin slab on the tick foot.
-        assertEquals(64.0, box.min.y, EPS);
-        assertEquals(64.0 + ConstraintShapes.SLAB_HEIGHT, box.max.y, EPS);
-    }
-
-    @Test
-    public void rangeZMapsToBandOnZAxis() {
-        Vec3dCore foot = new Vec3dCore(10.0, 64.0, 20.0);
-        Constraint c = Constraint.range(Constraint.Field.Z, -3.0, 2.0, true, true);
-        AABB box = ConstraintShapes.boxFor(c, foot);
-
-        assertEquals(-3.0, box.min.z, EPS);
-        assertEquals(2.0, box.max.z, EPS);
-        assertEquals(10.0 - ConstraintShapes.CROSS_HALF_WIDTH, box.min.x, EPS);
-        assertEquals(10.0 + ConstraintShapes.CROSS_HALF_WIDTH, box.max.x, EPS);
-    }
-
-    @Test
-    public void reversedRangeBoundsAreNormalised() {
-        Constraint c = Constraint.range(Constraint.Field.X, 15.0, 12.0, true, true);
-        AABB box = ConstraintShapes.boxFor(c, new Vec3dCore(0, 0, 0));
-        assertEquals(12.0, box.min.x, EPS);
-        assertEquals(15.0, box.max.x, EPS);
-    }
-
-    // ---- ConstraintShapes: open-ended clamping --------------------------------
-
-    @Test
-    public void greaterThanClampsToPositiveSide() {
-        Vec3dCore foot = new Vec3dCore(0.0, 64.0, 0.0);
-        Constraint c = Constraint.scalar(Constraint.Field.X, Constraint.Op.GT, 5.0);
-        AABB box = ConstraintShapes.boxFor(c, foot);
-        // Band starts at the bound and extends +X by OPEN_EXTENT (open toward +X).
-        assertEquals(5.0, box.min.x, EPS);
-        assertEquals(5.0 + ConstraintShapes.OPEN_EXTENT, box.max.x, EPS);
-    }
-
-    @Test
-    public void lessThanClampsToNegativeSide() {
-        Vec3dCore foot = new Vec3dCore(0.0, 64.0, 0.0);
-        Constraint c = Constraint.scalar(Constraint.Field.X, Constraint.Op.LE, 5.0);
-        AABB box = ConstraintShapes.boxFor(c, foot);
-        // Band ends at the bound and extends -X by OPEN_EXTENT (open toward -X).
-        assertEquals(5.0 - ConstraintShapes.OPEN_EXTENT, box.min.x, EPS);
-        assertEquals(5.0, box.max.x, EPS);
-    }
-
-    @Test
-    public void greaterEqualOnZClampsToPositiveZ() {
-        Constraint c = Constraint.scalar(Constraint.Field.Z, Constraint.Op.GE, -2.0);
-        AABB box = ConstraintShapes.boxFor(c, new Vec3dCore(0, 0, 0));
-        assertEquals(-2.0, box.min.z, EPS);
-        assertEquals(-2.0 + ConstraintShapes.OPEN_EXTENT, box.max.z, EPS);
-    }
-
-    @Test
-    public void equalityRendersThinSlabCentredOnValue() {
-        Constraint c = Constraint.scalar(Constraint.Field.X, Constraint.Op.EQ, 7.0);
-        AABB box = ConstraintShapes.boxFor(c, new Vec3dCore(0, 0, 0));
-        assertEquals(7.0 - ConstraintShapes.EQ_HALF_WIDTH, box.min.x, EPS);
-        assertEquals(7.0 + ConstraintShapes.EQ_HALF_WIDTH, box.max.x, EPS);
-        assertTrue("equality slab is thin", box.max.x - box.min.x < 0.1);
-    }
-
-    // ---- ConstraintShapes: non-spatial fields are not drawn -------------------
-
-    @Test
-    public void facingAndVelocityFieldsAreNotDrawable() {
-        assertNull(ConstraintShapes.spatialAxis(Constraint.scalar(Constraint.Field.F, Constraint.Op.GT, 0.1)));
-        assertNull(ConstraintShapes.spatialAxis(Constraint.scalar(Constraint.Field.DX, Constraint.Op.GT, 0.1)));
-        assertNull(ConstraintShapes.spatialAxis(Constraint.scalar(Constraint.Field.DZ, Constraint.Op.LT, -0.1)));
-        assertFalse(ConstraintShapes.isDrawable(Constraint.scalar(Constraint.Field.F, Constraint.Op.GT, 0.1)));
-        assertNull("non-spatial -> no box", ConstraintShapes.boxFor(Constraint.scalar(Constraint.Field.DZ, Constraint.Op.LT, -0.1), new Vec3dCore(0, 0, 0)));
-        assertEquals(AngleSolverState.Axis.X, ConstraintShapes.spatialAxis(Constraint.scalar(Constraint.Field.X, Constraint.Op.GT, 1.0)));
-        assertEquals(AngleSolverState.Axis.Z, ConstraintShapes.spatialAxis(Constraint.range(Constraint.Field.Z, 0, 1, true, true)));
-    }
-
-    // ---- BoxController emission -----------------------------------------------
-
-    @Test
-    public void boxControllerEmitsOnePlatePerConstraintInBothPasses() {
-        BoxController boxes = new BoxController();
-        boxes.add(tickAt(new Vec3dCore(0.5, 64.0, 0.5)));    // tick 0
-        boxes.add(tickAt(new Vec3dCore(1.5, 64.0, 0.5)));    // tick 1: two plates
-        boxes.add(tickAt(new Vec3dCore(2.5, 64.0, 0.5)));    // tick 2
-
-        final AABB a = new AABB(new Vec3dCore(1, 1, 1), new Vec3dCore(2, 2, 2));
-        final AABB b = new AABB(new Vec3dCore(3, 3, 3), new Vec3dCore(4, 4, 4));
-        ConstraintBoxSource source = new ConstraintBoxSource() {
-            @Override
-            public List<AABB> boxesAt(int tickIndex) {
-                if (tickIndex == 1) {
-                    List<AABB> l = new ArrayList<>();
-                    l.add(a);
-                    l.add(b);
-                    return l;
-                }
-                return Collections.emptyList();
-            }
-
-            @Override
-            public long revision() {
-                return 1L;
-            }
-        };
-
-        assertEquals(2, boxes.constraintBoxCount(source));
-
-        CapturingRenderer faces = new CapturingRenderer(BoxRenderer.Mode.FACES);
-        boxes.renderConstraints(faces, source, 0xFFFFFFFF, 0, 0, 0, Double.POSITIVE_INFINITY);
-        assertEquals(2, faces.boxes.size());
-        assertEquals(a, faces.boxes.get(0));
-        assertEquals(b, faces.boxes.get(1));
-
-        CapturingRenderer lines = new CapturingRenderer(BoxRenderer.Mode.LINES);
-        boxes.renderConstraints(lines, source, 0xFF00FF00, 0, 0, 0, Double.POSITIVE_INFINITY);
-        assertEquals(2, lines.boxes.size());
-    }
-
-    // ---- AngleSolverConstraintSource bridge -----------------------------------
-
     private static BoxController boxesWith(Vec3dCore... feet) {
         BoxController boxes = new BoxController();
         for (Vec3dCore f : feet) boxes.add(tickAt(f));
         return boxes;
     }
 
+    private static AngleSolverConstraintSource source(AngleSolverState state, BoxController boxes) {
+        return new AngleSolverConstraintSource(state, boxes, () -> true, new Settings(), new SelectionManager(null), new ConstraintSelection());
+    }
+
     @Test
-    public void sourceAnchorsRangeConstraintAtItsTickPosition() {
+    public void senseClassifiesInclusionVsExclusion() {
+        assertEquals(ConstraintShapes.Sense.INCLUDE, ConstraintShapes.sense(Constraint.Op.IN));
+        assertEquals(ConstraintShapes.Sense.INCLUDE, ConstraintShapes.sense(Constraint.Op.EQ));
+        assertEquals(ConstraintShapes.Sense.EXCLUDE, ConstraintShapes.sense(Constraint.Op.GT));
+        assertEquals(ConstraintShapes.Sense.EXCLUDE, ConstraintShapes.sense(Constraint.Op.GE));
+        assertEquals(ConstraintShapes.Sense.EXCLUDE, ConstraintShapes.sense(Constraint.Op.LT));
+        assertEquals(ConstraintShapes.Sense.EXCLUDE, ConstraintShapes.sense(Constraint.Op.LE));
+    }
+
+    @Test
+    public void onlySpatialFieldsAreDrawable() {
+        assertEquals(AngleSolverState.Axis.X, ConstraintShapes.spatialAxis(Constraint.scalar(Constraint.Field.X, Constraint.Op.GT, 1.0)));
+        assertEquals(AngleSolverState.Axis.Z, ConstraintShapes.spatialAxis(Constraint.range(Constraint.Field.Z, 0, 1, true, true)));
+        assertNull(ConstraintShapes.spatialAxis(Constraint.scalar(Constraint.Field.F, Constraint.Op.GT, 0.1)));
+        assertNull(ConstraintShapes.spatialAxis(Constraint.scalar(Constraint.Field.DX, Constraint.Op.GT, 0.1)));
+        assertNull(ConstraintShapes.spatialAxis(Constraint.scalar(Constraint.Field.DZ, Constraint.Op.LT, -0.1)));
+        assertFalse(ConstraintShapes.isDrawable(Constraint.scalar(Constraint.Field.F, Constraint.Op.GT, 0.1)));
+        assertTrue(ConstraintShapes.isDrawable(Constraint.scalar(Constraint.Field.X, Constraint.Op.GT, 0.1)));
+    }
+
+    @Test
+    public void satisfiedHandlesRangesAndComparisons() {
+        Vec3dCore foot = new Vec3dCore(5.0, 64.0, -2.0);
+        assertTrue(ConstraintShapes.satisfied(Constraint.range(Constraint.Field.X, 4.0, 6.0, true, true), foot));
+        assertFalse(ConstraintShapes.satisfied(Constraint.range(Constraint.Field.X, 6.0, 7.0, true, true), foot));
+        assertTrue(ConstraintShapes.satisfied(Constraint.scalar(Constraint.Field.X, Constraint.Op.GT, 4.0), foot));
+        assertFalse(ConstraintShapes.satisfied(Constraint.scalar(Constraint.Field.X, Constraint.Op.GT, 5.0), foot));
+        assertTrue(ConstraintShapes.satisfied(Constraint.scalar(Constraint.Field.X, Constraint.Op.GE, 5.0), foot));
+        assertTrue(ConstraintShapes.satisfied(Constraint.scalar(Constraint.Field.Z, Constraint.Op.LT, 0.0), foot));
+        assertTrue(ConstraintShapes.satisfied(Constraint.scalar(Constraint.Field.X, Constraint.Op.EQ, 5.0), foot));
+        assertFalse(ConstraintShapes.satisfied(Constraint.scalar(Constraint.Field.X, Constraint.Op.EQ, 5.5), foot));
+        assertTrue(ConstraintShapes.satisfied(Constraint.scalar(Constraint.Field.F, Constraint.Op.GT, 9.0), foot));
+    }
+
+    @Test
+    public void satisfiedHonorsExclusiveBounds() {
+        Vec3dCore onUpperBound = new Vec3dCore(2.0, 64.0, 0.0);
+        assertTrue(ConstraintShapes.satisfied(Constraint.range(Constraint.Field.X, 1.0, 2.0, true, true), onUpperBound));
+        assertFalse(ConstraintShapes.satisfied(Constraint.range(Constraint.Field.X, 1.0, 2.0, true, false), onUpperBound));
+    }
+
+    @Test
+    public void padIsOneSolidFrontPlateDilatedByTheHitbox() {
+        Vec3dCore foot = new Vec3dCore(5.5, 64.0, 8.5);
+        Constraint xr = Constraint.range(Constraint.Field.X, 5.0 - H, 6.0 + H, true, true);
+        Constraint zr = Constraint.range(Constraint.Field.Z, 8.0 - H, 9.0 + H, true, true);
+        ConstraintPlate plate = ConstraintShapes.pad(xr, zr, foot, STYLE, 0, new int[]{0, 1});
+
+        assertEquals(ConstraintShapes.Sense.INCLUDE, plate.sense);
+        assertTrue(plate.satisfied);
+        assertEquals(1, plate.front.size());
+        assertTrue(plate.back.isEmpty());
+
+        AABB body = plate.front.get(0);
+        assertEquals((5.0 - H) - H, body.min.x, EPS);
+        assertEquals((6.0 + H) + H, body.max.x, EPS);
+        assertEquals((8.0 - H) - H, body.min.z, EPS);
+        assertEquals((9.0 + H) + H, body.max.z, EPS);
+        assertEquals(64.0, body.min.y, EPS);
+        assertEquals(64.0 + FRONT_H, body.max.y, EPS);
+    }
+
+    @Test
+    public void padWithoutExpandUsesRawFootCenterBounds() {
+        Vec3dCore foot = new Vec3dCore(5.5, 64.0, 8.5);
+        Constraint xr = Constraint.range(Constraint.Field.X, 5.0 - H, 6.0 + H, true, true);
+        Constraint zr = Constraint.range(Constraint.Field.Z, 8.0 - H, 9.0 + H, true, true);
+        AABB body = ConstraintShapes.pad(xr, zr, foot, NO_EXPAND, 0, new int[]{0, 1}).front.get(0);
+        assertEquals(5.0 - H, body.min.x, EPS);
+        assertEquals(6.0 + H, body.max.x, EPS);
+    }
+
+    @Test
+    public void plateCarriesTickAndConstraintIndices() {
+        Vec3dCore foot = new Vec3dCore(5.5, 64.0, 8.5);
+        Constraint xr = Constraint.range(Constraint.Field.X, 5.0 - H, 6.0 + H, true, true);
+        Constraint zr = Constraint.range(Constraint.Field.Z, 8.0 - H, 9.0 + H, true, true);
+        ConstraintPlate plate = ConstraintShapes.pad(xr, zr, foot, STYLE, 7, new int[]{2, 3});
+        assertEquals(7, plate.tick);
+        assertArrayEquals(new int[]{2, 3}, plate.constraintIndices);
+        assertFalse(plate.highlighted);
+    }
+
+    @Test
+    public void validFootHasItsHitboxCoveredByThePad() {
+        Constraint xr = Constraint.range(Constraint.Field.X, 5.0 - H, 6.0 + H, true, true);
+        Constraint zr = Constraint.range(Constraint.Field.Z, 8.0 - H, 9.0 + H, true, true);
+        Vec3dCore foot = new Vec3dCore(5.0 - H + 0.05, 64.0, 8.5);
+        ConstraintPlate plate = ConstraintShapes.pad(xr, zr, foot, STYLE, 0, new int[]{0, 1});
+        AABB body = plate.front.get(0);
+        assertTrue(plate.satisfied);
+        assertTrue("hitbox left edge inside plate", foot.x - H >= body.min.x - EPS);
+        assertTrue("hitbox right edge inside plate", foot.x + H <= body.max.x + EPS);
+    }
+
+    @Test
+    public void stripFrontBandWithFlatBackTrail() {
+        Vec3dCore foot = new Vec3dCore(2.0, 64.0, 20.0);
+        ConstraintPlate plate = ConstraintShapes.strip(Constraint.range(Constraint.Field.X, 1.0, 5.0, true, true), foot, STYLE, 0, I0);
+        assertEquals(1, plate.front.size());
+        assertEquals(1, plate.back.size());
+
+        AABB front = plate.front.get(0);
+        assertEquals(1.0 - H, front.min.x, EPS);
+        assertEquals(5.0 + H, front.max.x, EPS);
+        assertEquals(20.0 - CORE, front.min.z, EPS);
+        assertEquals(20.0 + CORE, front.max.z, EPS);
+        assertEquals(64.0 + FRONT_H, front.max.y, EPS);
+
+        AABB back = plate.back.get(0);
+        assertEquals(20.0 - BACK_L, back.min.z, EPS);
+        assertEquals(20.0 + BACK_L, back.max.z, EPS);
+        assertEquals(back.min.y, back.max.y, EPS);
+    }
+
+    @Test
+    public void customFrontWidthSetsTheCrossExtent() {
+        ConstraintStyle wide = new ConstraintStyle(true, 2.0, FRONT_H, FRONT_L, BACK_W, BACK_H, BACK_L);
+        Vec3dCore foot = new Vec3dCore(2.0, 64.0, 20.0);
+        AABB front = ConstraintShapes.strip(Constraint.range(Constraint.Field.X, 1.0, 5.0, true, true), foot, wide, 0, I0).front.get(0);
+        assertEquals(20.0 - 1.0, front.min.z, EPS);
+        assertEquals(20.0 + 1.0, front.max.z, EPS);
+    }
+
+    @Test
+    public void eqIsAHitboxWideFrontBand() {
+        Vec3dCore foot = new Vec3dCore(7.0, 64.0, 3.0);
+        ConstraintPlate plate = ConstraintShapes.plane(Constraint.scalar(Constraint.Field.X, Constraint.Op.EQ, 7.0), foot, STYLE, 0, I0);
+        assertEquals(ConstraintShapes.Sense.INCLUDE, plate.sense);
+        assertEquals(1, plate.front.size());
+        assertEquals(1, plate.back.size());
+        AABB front = plate.front.get(0);
+        assertEquals(7.0 - H, front.min.x, EPS);
+        assertEquals(7.0 + H, front.max.x, EPS);
+    }
+
+    @Test
+    public void eqWithoutExpandUsesFrontLengthThickness() {
+        Vec3dCore foot = new Vec3dCore(7.0, 64.0, 3.0);
+        AABB front = ConstraintShapes.plane(Constraint.scalar(Constraint.Field.X, Constraint.Op.EQ, 7.0), foot, NO_EXPAND, 0, I0).front.get(0);
+        assertEquals(7.0 - FRONT_L * 0.5, front.min.x, EPS);
+        assertEquals(7.0 + FRONT_L * 0.5, front.max.x, EPS);
+    }
+
+    @Test
+    public void greaterThanExcludeFrontAnchoredAtBoundaryBackBehindIt() {
+        Vec3dCore foot = new Vec3dCore(10.0, 64.0, 0.0);
+        ConstraintPlate plate = ConstraintShapes.exclude(Constraint.scalar(Constraint.Field.X, Constraint.Op.GT, 5.0), foot, STYLE, 0, I0);
+
+        assertEquals(ConstraintShapes.Sense.EXCLUDE, plate.sense);
+        assertTrue(plate.satisfied);
+        assertEquals(1, plate.front.size());
+        assertEquals(1, plate.back.size());
+
+        AABB front = plate.front.get(0);
+        assertEquals("front near edge anchored at the hitbox-shifted bound", 5.0 - H, front.min.x, EPS);
+        assertEquals((5.0 - H) + FRONT_L, front.max.x, EPS);
+
+        AABB back = plate.back.get(0);
+        assertEquals((5.0 - H) + FRONT_L, back.min.x, EPS);
+        assertEquals((5.0 - H) + FRONT_L + BACK_L, back.max.x, EPS);
+    }
+
+    @Test
+    public void lessThanExcludeExtendsTowardNegative() {
+        Vec3dCore foot = new Vec3dCore(0.0, 64.0, 0.0);
+        ConstraintPlate plate = ConstraintShapes.exclude(Constraint.scalar(Constraint.Field.X, Constraint.Op.LE, 5.0), foot, STYLE, 0, I0);
+        AABB front = plate.front.get(0);
+        assertEquals("front near edge anchored at the hitbox-shifted bound", 5.0 + H, front.max.x, EPS);
+        assertEquals((5.0 + H) - FRONT_L, front.min.x, EPS);
+        AABB back = plate.back.get(0);
+        assertEquals((5.0 + H) - FRONT_L - BACK_L, back.min.x, EPS);
+        assertTrue(plate.satisfied);
+    }
+
+    @Test
+    public void excludeStatusFlipsWithFoot() {
+        Vec3dCore violating = new Vec3dCore(2.0, 64.0, 0.0);
+        ConstraintPlate plate = ConstraintShapes.exclude(Constraint.scalar(Constraint.Field.X, Constraint.Op.GT, 5.0), violating, STYLE, 0, I0);
+        assertFalse(plate.satisfied);
+    }
+
+    // ---- selection + highlight rule -------------------------------------------
+
+    @Test
+    public void highlightRuleFocusVsTickSelection() {
+        ConstraintSelection cs = new ConstraintSelection();
+        SelectionManager sel = new SelectionManager(null);
+
+        assertFalse(cs.highlights(1, 0, sel));
+
+        sel.selectOnly(2); // path 2 == tick 1
+        assertTrue("no focus + tick selected highlights every constraint on the tick", cs.highlights(1, 0, sel));
+        assertTrue(cs.highlights(1, 5, sel));
+        assertFalse(cs.highlights(2, 0, sel));
+
+        cs.focusOne(1, 0);
+        assertTrue("focused constraint highlights", cs.highlights(1, 0, sel));
+        assertFalse("a sibling does not highlight when one is focused", cs.highlights(1, 5, sel));
+    }
+
+    @Test
+    public void focusRemapFollowsAMovedTick() {
+        ConstraintSelection cs = new ConstraintSelection();
+        cs.focusOne(3, 1);
+        cs.remapTick(t -> t == 3 ? 7 : t);
+        SelectionManager sel = new SelectionManager(null);
+        sel.selectOnly(8); // tick 7
+        assertTrue(cs.highlights(7, 1, sel));
+        assertFalse(cs.highlights(3, 1, sel));
+    }
+
+    @Test
+    public void staleFocusOnDeselectedTickFallsBackToTickHighlight() {
+        ConstraintSelection cs = new ConstraintSelection();
+        SelectionManager sel = new SelectionManager(null);
+        cs.focusOne(1, 0);
+        sel.selectOnly(2); // tick 1 focused + selected
+        assertTrue(cs.highlights(1, 0, sel));
+        assertFalse(cs.highlights(1, 5, sel));
+
+        sel.selectOnly(3); // select tick 2; tick 1's focus is now stale
+        assertFalse("stale focus on a deselected tick stops highlighting", cs.highlights(1, 0, sel));
+        assertTrue("the newly selected tick highlights all its constraints", cs.highlights(2, 0, sel));
+        assertTrue(cs.highlights(2, 9, sel));
+    }
+
+    @Test
+    public void sourceHighlightsConstraintsOfSelectedTick() {
         AngleSolverState state = new AngleSolverState();
-        BoxController boxes = boxesWith(
-                new Vec3dCore(0.5, 64.0, 0.5),
-                new Vec3dCore(1.25, 65.0, 3.5)); // tick 1 carries the constraint
-        state.tickConstraints(1).getConstraints().add(Constraint.range(Constraint.Field.X, 1.0, 2.0, true, true));
+        BoxController boxes = boxesWith(new Vec3dCore(0.5, 64.0, 0.5), new Vec3dCore(1.5, 64.0, 0.5));
+        state.tickConstraints(1).getConstraints().add(Constraint.scalar(Constraint.Field.X, Constraint.Op.GT, 5.0));
 
-        AngleSolverConstraintSource source = new AngleSolverConstraintSource(state, boxes, () -> true);
+        SelectionManager sel = new SelectionManager(null);
+        ConstraintSelection cs = new ConstraintSelection();
+        AngleSolverConstraintSource src = new AngleSolverConstraintSource(state, boxes, () -> true, new Settings(), sel, cs);
 
-        assertTrue(source.boxesAt(0).isEmpty());
-        List<AABB> at1 = source.boxesAt(1);
-        assertEquals(1, at1.size());
-        AABB box = at1.get(0);
-        assertEquals(1.0, box.min.x, EPS);
-        assertEquals(2.0, box.max.x, EPS);
-        // Anchored at tick 1's position (z = 3.5, y = 65.0), not tick 0's.
-        assertEquals(3.5 - ConstraintShapes.CROSS_HALF_WIDTH, box.min.z, EPS);
-        assertEquals(65.0, box.min.y, EPS);
+        assertFalse(src.platesAt(1).get(0).highlighted);
+        sel.selectOnly(2); // tick 1
+        assertTrue(src.platesAt(1).get(0).highlighted);
+    }
+
+    @Test
+    public void sourceHighlightsOnlyFocusedConstraint() {
+        AngleSolverState state = new AngleSolverState();
+        BoxController boxes = boxesWith(new Vec3dCore(0.5, 64.0, 0.5), new Vec3dCore(1.5, 64.0, 0.5));
+        state.tickConstraints(1).getConstraints().add(Constraint.scalar(Constraint.Field.X, Constraint.Op.GT, 5.0)); // index 0
+        state.tickConstraints(1).getConstraints().add(Constraint.scalar(Constraint.Field.Z, Constraint.Op.GT, 0.0)); // index 1
+
+        SelectionManager sel = new SelectionManager(null);
+        ConstraintSelection cs = new ConstraintSelection();
+        cs.focusOne(1, 0);
+        sel.selectOnly(2); // tick 1 selected, so the focus is effective
+        AngleSolverConstraintSource src = new AngleSolverConstraintSource(state, boxes, () -> true, new Settings(), sel, cs);
+
+        List<ConstraintPlate> plates = src.platesAt(1);
+        assertEquals(2, plates.size());
+        for (ConstraintPlate p : plates) {
+            boolean isFirst = p.constraintIndices[0] == 0;
+            assertEquals(isFirst, p.highlighted);
+        }
+    }
+
+    // ---- source classification + identity -------------------------------------
+
+    @Test
+    public void sourceMergesCoTickXandZRangesIntoOnePadWithBothIndices() {
+        AngleSolverState state = new AngleSolverState();
+        BoxController boxes = boxesWith(new Vec3dCore(5.5, 64.0, 8.5));
+        state.tickConstraints(0).getConstraints().add(Constraint.scalar(Constraint.Field.DX, Constraint.Op.GT, 0.1)); // index 0, non-spatial
+        state.addLandingConstraintsForBlock(5, 64, 8, 0, false, false, false, false); // X at index 1, Z at index 2
+
+        List<ConstraintPlate> plates = source(state, boxes).platesAt(0);
+        assertEquals(1, plates.size());
+        ConstraintPlate pad = plates.get(0);
+        assertEquals(0, pad.tick);
+        assertArrayEquals("pad carries the X and Z list indices, skipping the non-spatial one", new int[]{1, 2}, pad.constraintIndices);
+        AABB body = pad.front.get(0);
+        assertEquals(5.0 - 2 * H, body.min.x, EPS);
+        assertEquals(6.0 + 2 * H, body.max.x, EPS);
+    }
+
+    @Test
+    public void sourceKeepsLoneRangeAsStripAndExcludeSeparate() {
+        AngleSolverState state = new AngleSolverState();
+        BoxController boxes = boxesWith(new Vec3dCore(0.5, 64.0, 0.5), new Vec3dCore(1.5, 64.0, 0.5));
+        state.tickConstraints(0).getConstraints().add(Constraint.range(Constraint.Field.X, 1.0, 5.0, true, true));
+        state.tickConstraints(1).getConstraints().add(Constraint.scalar(Constraint.Field.Z, Constraint.Op.GT, 0.0));
+
+        AngleSolverConstraintSource src = source(state, boxes);
+        List<ConstraintPlate> lone = src.platesAt(0);
+        assertEquals(1, lone.size());
+        assertEquals(ConstraintShapes.Sense.INCLUDE, lone.get(0).sense);
+        assertArrayEquals(new int[]{0}, lone.get(0).constraintIndices);
+
+        List<ConstraintPlate> excl = src.platesAt(1);
+        assertEquals(1, excl.size());
+        assertEquals(ConstraintShapes.Sense.EXCLUDE, excl.get(0).sense);
+        assertEquals(1, excl.get(0).back.size());
     }
 
     @Test
@@ -231,11 +396,25 @@ public class ConstraintVisualizationTest {
         Constraint disabled = Constraint.range(Constraint.Field.X, 1.0, 2.0, true, true);
         disabled.setEnabled(false);
         state.tickConstraints(0).getConstraints().add(disabled);
-        state.tickConstraints(0).getConstraints().add(Constraint.scalar(Constraint.Field.DX, Constraint.Op.GT, 0.2)); // non-spatial
-        state.tickConstraints(0).getConstraints().add(Constraint.scalar(Constraint.Field.Z, Constraint.Op.GT, 0.0)); // the only drawable one
+        state.tickConstraints(0).getConstraints().add(Constraint.scalar(Constraint.Field.DX, Constraint.Op.GT, 0.2));
+        state.tickConstraints(0).getConstraints().add(Constraint.scalar(Constraint.Field.Z, Constraint.Op.GT, 0.0));
 
-        AngleSolverConstraintSource source = new AngleSolverConstraintSource(state, boxes, () -> true);
-        assertEquals(1, source.boxesAt(0).size());
+        List<ConstraintPlate> plates = source(state, boxes).platesAt(0);
+        assertEquals(1, plates.size());
+        assertEquals(ConstraintShapes.Sense.EXCLUDE, plates.get(0).sense);
+        assertArrayEquals("uses the original list index of the only drawable constraint", new int[]{2}, plates.get(0).constraintIndices);
+    }
+
+    @Test
+    public void sourceAnchorsAtItsTickPosition() {
+        AngleSolverState state = new AngleSolverState();
+        BoxController boxes = boxesWith(new Vec3dCore(0.5, 64.0, 0.5), new Vec3dCore(1.25, 65.0, 3.5));
+        state.tickConstraints(1).getConstraints().add(Constraint.range(Constraint.Field.X, 1.0, 2.0, true, true));
+
+        AABB front = source(state, boxes).platesAt(1).get(0).front.get(0);
+        double core = new Settings().constraintFrontWidth * 0.5;
+        assertEquals(3.5 - core, front.min.z, EPS);
+        assertEquals(65.0, front.min.y, EPS);
     }
 
     @Test
@@ -245,13 +424,13 @@ public class ConstraintVisualizationTest {
         state.tickConstraints(0).getConstraints().add(Constraint.range(Constraint.Field.X, 1.0, 2.0, true, true));
 
         final boolean[] active = {false};
-        AngleSolverConstraintSource source = new AngleSolverConstraintSource(state, boxes, () -> active[0]);
-        assertTrue(source.boxesAt(0).isEmpty());
-        assertEquals(0L, source.revision());
+        AngleSolverConstraintSource src = new AngleSolverConstraintSource(state, boxes, () -> active[0], new Settings(), new SelectionManager(null), new ConstraintSelection());
+        assertTrue(src.platesAt(0).isEmpty());
+        assertEquals(0L, src.revision());
 
         active[0] = true;
-        assertEquals(1, source.boxesAt(0).size());
-        assertNotEquals(0L, source.revision());
+        assertEquals(1, src.platesAt(0).size());
+        assertNotEquals(0L, src.revision());
     }
 
     @Test
@@ -261,9 +440,157 @@ public class ConstraintVisualizationTest {
         Constraint c = Constraint.scalar(Constraint.Field.X, Constraint.Op.GT, 5.0);
         state.tickConstraints(0).getConstraints().add(c);
 
-        AngleSolverConstraintSource source = new AngleSolverConstraintSource(state, boxes, () -> true);
-        long before = source.revision();
+        AngleSolverConstraintSource src = source(state, boxes);
+        long before = src.revision();
         c.setValue(6.0);
-        assertNotEquals("editing a constraint value must bump the revision", before, source.revision());
+        assertNotEquals(before, src.revision());
+    }
+
+    @Test
+    public void revisionChangesWhenRangeInclusivityToggles() {
+        AngleSolverState state = new AngleSolverState();
+        BoxController boxes = boxesWith(new Vec3dCore(0.5, 64.0, 0.5));
+        Constraint c = Constraint.range(Constraint.Field.X, 1.0, 2.0, true, true);
+        state.tickConstraints(0).getConstraints().add(c);
+
+        AngleSolverConstraintSource src = source(state, boxes);
+        long before = src.revision();
+        c.setInclusive(false, true);
+        assertNotEquals(before, src.revision());
+    }
+
+    @Test
+    public void revisionTracksSelectionAndFocusOfConstrainedTicks() {
+        AngleSolverState state = new AngleSolverState();
+        BoxController boxes = boxesWith(new Vec3dCore(0.5, 64.0, 0.5), new Vec3dCore(1.5, 64.0, 0.5));
+        state.tickConstraints(1).getConstraints().add(Constraint.scalar(Constraint.Field.X, Constraint.Op.GT, 5.0));
+
+        SelectionManager sel = new SelectionManager(null);
+        ConstraintSelection cs = new ConstraintSelection();
+        AngleSolverConstraintSource src = new AngleSolverConstraintSource(state, boxes, () -> true, new Settings(), sel, cs);
+
+        long before = src.revision();
+        sel.selectOnly(2); // selecting the constrained tick recolours -> revision must change
+        assertNotEquals(before, src.revision());
+
+        long afterSelect = src.revision();
+        cs.focusOne(1, 0);
+        assertNotEquals(afterSelect, src.revision());
+    }
+
+    @Test
+    public void revisionIgnoresSelectionOfUnconstrainedTicks() {
+        AngleSolverState state = new AngleSolverState();
+        BoxController boxes = boxesWith(new Vec3dCore(0.5, 64.0, 0.5), new Vec3dCore(1.5, 64.0, 0.5), new Vec3dCore(2.5, 64.0, 0.5));
+        state.tickConstraints(1).getConstraints().add(Constraint.scalar(Constraint.Field.X, Constraint.Op.GT, 5.0));
+
+        SelectionManager sel = new SelectionManager(null);
+        AngleSolverConstraintSource src = new AngleSolverConstraintSource(state, boxes, () -> true, new Settings(), sel, new ConstraintSelection());
+
+        long before = src.revision();
+        sel.selectOnly(3); // tick 2 has no constraints; box-selection patch should still apply
+        assertEquals(before, src.revision());
+    }
+
+    // ---- pick (reuses the box ray-AABB machinery) -----------------------------
+
+    @Test
+    public void pickWorldPrefersBoxThenFallsBackToConstraint() {
+        AngleSolverState state = new AngleSolverState();
+        BoxController boxes = boxesWith(new Vec3dCore(0.5, 64.0, 0.5), new Vec3dCore(1.5, 64.0, 0.5), new Vec3dCore(2.5, 64.0, 0.5));
+        state.addLandingConstraintsForBlock(5, 64, 8, 1, false, false, false, false);
+        AngleSolverConstraintSource src = source(state, boxes);
+
+        Vec3dCore down = new Vec3dCore(0.0, -1.0, 0.0);
+
+        WorldPick boxPick = boxes.pickWorld(new Vec3dCore(1.5, 100.0, 0.5), down, src);
+        assertEquals(WorldPick.Kind.BOX, boxPick.kind);
+        assertEquals(1, boxPick.index);
+
+        WorldPick conPick = boxes.pickWorld(new Vec3dCore(5.0, 100.0, 8.5), down, src);
+        assertEquals(WorldPick.Kind.CONSTRAINT, conPick.kind);
+        assertEquals(1, conPick.index);
+        assertEquals(2, conPick.constraintIndices.length);
+
+        assertNull(boxes.pickWorld(new Vec3dCore(40.0, 100.0, 40.0), down, src));
+
+        assertTrue(boxes.isCursorOverConstraint(new Vec3dCore(5.0, 100.0, 8.5), down, src));
+        assertFalse(boxes.isCursorOverConstraint(new Vec3dCore(40.0, 100.0, 40.0), down, src));
+    }
+
+    @Test
+    public void backTrailIsAlsoClickable() {
+        AngleSolverState state = new AngleSolverState();
+        BoxController boxes = boxesWith(new Vec3dCore(0.5, 64.0, 0.5), new Vec3dCore(1.5, 64.0, 0.5));
+        state.tickConstraints(1).getConstraints().add(Constraint.scalar(Constraint.Field.X, Constraint.Op.GT, 5.0));
+        AngleSolverConstraintSource src = source(state, boxes);
+        Vec3dCore down = new Vec3dCore(0.0, -1.0, 0.0);
+
+        // x=6 lands on the back trail (the front box is only ~[4.7, 4.8]); z=0.5 is the tick foot.
+        WorldPick pick = boxes.pickWorld(new Vec3dCore(6.0, 100.0, 0.5), down, src);
+        assertEquals(WorldPick.Kind.CONSTRAINT, pick.kind);
+        assertEquals(1, pick.index);
+        assertTrue(boxes.isCursorOverConstraint(new Vec3dCore(6.0, 100.0, 0.5), down, src));
+    }
+
+    // ---- emitted-vertex count invariant ---------------------------------------
+
+    @Test
+    public void countMethodsEqualIndependentlyCountedEmission() {
+        AngleSolverState state = new AngleSolverState();
+        BoxController boxes = boxesWith(new Vec3dCore(5.5, 64.0, 8.5), new Vec3dCore(10.0, 64.0, 0.0));
+        state.addLandingConstraintsForBlock(5, 64, 8, 0, false, false, false, false);
+        state.tickConstraints(1).getConstraints().add(Constraint.scalar(Constraint.Field.X, Constraint.Op.GT, 5.0));
+
+        AngleSolverConstraintSource src = source(state, boxes);
+
+        VertCounter faces = new VertCounter(BoxRenderer.Mode.FACES);
+        boxes.renderConstraints(faces, src, PALETTE, false, 0, 0, 0, Double.POSITIVE_INFINITY);
+        VertCounter lines = new VertCounter(BoxRenderer.Mode.LINES);
+        boxes.renderConstraints(lines, src, PALETTE, true, 0, 0, 0, Double.POSITIVE_INFINITY);
+
+        // pad: 1 front box. exclude: 1 front + 1 back box. Front and back are both filled and outlined.
+        int expectedFaces = 36 + 36 * 2;
+        int expectedLines = 24 + 24 * 2;
+        assertEquals(expectedFaces, faces.count);
+        assertEquals(expectedLines, lines.count);
+
+        assertEquals(faces.count, boxes.constraintFaceVertexCount(src, PALETTE));
+        assertEquals(lines.count, boxes.constraintLineVertexCount(src, PALETTE));
+    }
+
+    @Test
+    public void planConstraintCountsEqualWhatTheFullEmitterBakes() {
+        BoxController boxes = boxesWith(new Vec3dCore(5.5, 64.0, 8.5), new Vec3dCore(10.0, 64.0, 0.0));
+        AngleSolverState state = new AngleSolverState();
+        state.addLandingConstraintsForBlock(5, 64, 8, 0, false, false, false, false);
+        state.tickConstraints(1).getConstraints().add(Constraint.scalar(Constraint.Field.X, Constraint.Op.GT, 5.0));
+        Settings settings = new Settings();
+        AngleSolverConstraintSource src = new AngleSolverConstraintSource(state, boxes, () -> true, settings, new SelectionManager(null), new ConstraintSelection());
+
+        SelectionManager selection = new SelectionManager(null);
+        try {
+            PathRenderPlan.setConstraintSource(src);
+
+            settings.showConstraints = true;
+            PathRenderPlan withC = PathRenderPlan.build(boxes, settings, selection);
+            VertCounter facesWith = new VertCounter(BoxRenderer.Mode.FACES);
+            withC.faceEmitter.accept(facesWith);
+            VertCounter linesWith = new VertCounter(BoxRenderer.Mode.LINES);
+            withC.lineEmitter.accept(linesWith);
+
+            settings.showConstraints = false;
+            PathRenderPlan without = PathRenderPlan.build(boxes, settings, selection);
+            VertCounter facesWithout = new VertCounter(BoxRenderer.Mode.FACES);
+            without.faceEmitter.accept(facesWithout);
+            VertCounter linesWithout = new VertCounter(BoxRenderer.Mode.LINES);
+            without.lineEmitter.accept(linesWithout);
+
+            assertTrue(withC.constraintFaceVerts > 0);
+            assertEquals(withC.constraintFaceVerts, facesWith.count - facesWithout.count);
+            assertEquals(withC.constraintLineVerts, linesWith.count - linesWithout.count);
+        } finally {
+            PathRenderPlan.setConstraintSource(ConstraintBoxSource.NONE);
+        }
     }
 }

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/ConstraintVisualizationTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/ConstraintVisualizationTest.java
@@ -1,0 +1,269 @@
+package de.legoshi.parkourcalc.anglesolver;
+
+import de.legoshi.parkourcalc.core.anglesolver.AngleSolverState;
+import de.legoshi.parkourcalc.core.anglesolver.Constraint;
+import de.legoshi.parkourcalc.core.ports.BoxRenderer;
+import de.legoshi.parkourcalc.core.render.ConstraintBoxSource;
+import de.legoshi.parkourcalc.core.render.ConstraintShapes;
+import de.legoshi.parkourcalc.core.sim.AABB;
+import de.legoshi.parkourcalc.core.sim.TickState;
+import de.legoshi.parkourcalc.core.sim.Vec3dCore;
+import de.legoshi.parkourcalc.core.ui.BoxController;
+import de.legoshi.parkourcalc.core.ui.anglesolver.AngleSolverConstraintSource;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * gh-145: in-world constraint visualization geometry. Pins the constraint -> AABB mapping
+ * (anchored at the tick's simulated position), the open-ended clamping extent / side, and the
+ * BoxController emission + AngleSolverConstraintSource bridge.
+ */
+public class ConstraintVisualizationTest {
+
+    private static final double EPS = 1.0e-9;
+
+    /** Captures every AABB submitted, so tests can assert geometry without a real renderer. */
+    private static final class CapturingRenderer implements BoxRenderer {
+        final Mode mode;
+        final List<AABB> boxes = new ArrayList<>();
+        int lines;
+        int triangles;
+
+        CapturingRenderer(Mode mode) {
+            this.mode = mode;
+        }
+
+        @Override
+        public void drawBox(AABB box, int argb) {
+            boxes.add(box);
+        }
+
+        @Override
+        public void drawLine(double x1, double y1, double z1, double x2, double y2, double z2, int argb) {
+            lines++;
+        }
+
+        @Override
+        public void drawTriangle(double x1, double y1, double z1, double x2, double y2, double z2, double x3, double y3, double z3, int argb) {
+            triangles++;
+        }
+    }
+
+    private static TickState tickAt(Vec3dCore p) {
+        return new TickState(p, false, false, false, 0f, Collections.<Vec3dCore>emptyList(), Vec3dCore.ZERO, false, Double.NaN);
+    }
+
+    // ---- ConstraintShapes: range bands ----------------------------------------
+
+    @Test
+    public void rangeXMapsToBandAtTickPosition() {
+        Vec3dCore foot = new Vec3dCore(10.0, 64.0, 20.0);
+        Constraint c = Constraint.range(Constraint.Field.X, 12.0, 15.0, true, true);
+        AABB box = ConstraintShapes.boxFor(c, foot);
+
+        // Constrained axis spans the range exactly.
+        assertEquals(12.0, box.min.x, EPS);
+        assertEquals(15.0, box.max.x, EPS);
+        // Cross axis (Z) is a fixed plate centred on the tick.
+        assertEquals(20.0 - ConstraintShapes.CROSS_HALF_WIDTH, box.min.z, EPS);
+        assertEquals(20.0 + ConstraintShapes.CROSS_HALF_WIDTH, box.max.z, EPS);
+        // Y is a thin slab on the tick foot.
+        assertEquals(64.0, box.min.y, EPS);
+        assertEquals(64.0 + ConstraintShapes.SLAB_HEIGHT, box.max.y, EPS);
+    }
+
+    @Test
+    public void rangeZMapsToBandOnZAxis() {
+        Vec3dCore foot = new Vec3dCore(10.0, 64.0, 20.0);
+        Constraint c = Constraint.range(Constraint.Field.Z, -3.0, 2.0, true, true);
+        AABB box = ConstraintShapes.boxFor(c, foot);
+
+        assertEquals(-3.0, box.min.z, EPS);
+        assertEquals(2.0, box.max.z, EPS);
+        assertEquals(10.0 - ConstraintShapes.CROSS_HALF_WIDTH, box.min.x, EPS);
+        assertEquals(10.0 + ConstraintShapes.CROSS_HALF_WIDTH, box.max.x, EPS);
+    }
+
+    @Test
+    public void reversedRangeBoundsAreNormalised() {
+        Constraint c = Constraint.range(Constraint.Field.X, 15.0, 12.0, true, true);
+        AABB box = ConstraintShapes.boxFor(c, new Vec3dCore(0, 0, 0));
+        assertEquals(12.0, box.min.x, EPS);
+        assertEquals(15.0, box.max.x, EPS);
+    }
+
+    // ---- ConstraintShapes: open-ended clamping --------------------------------
+
+    @Test
+    public void greaterThanClampsToPositiveSide() {
+        Vec3dCore foot = new Vec3dCore(0.0, 64.0, 0.0);
+        Constraint c = Constraint.scalar(Constraint.Field.X, Constraint.Op.GT, 5.0);
+        AABB box = ConstraintShapes.boxFor(c, foot);
+        // Band starts at the bound and extends +X by OPEN_EXTENT (open toward +X).
+        assertEquals(5.0, box.min.x, EPS);
+        assertEquals(5.0 + ConstraintShapes.OPEN_EXTENT, box.max.x, EPS);
+    }
+
+    @Test
+    public void lessThanClampsToNegativeSide() {
+        Vec3dCore foot = new Vec3dCore(0.0, 64.0, 0.0);
+        Constraint c = Constraint.scalar(Constraint.Field.X, Constraint.Op.LE, 5.0);
+        AABB box = ConstraintShapes.boxFor(c, foot);
+        // Band ends at the bound and extends -X by OPEN_EXTENT (open toward -X).
+        assertEquals(5.0 - ConstraintShapes.OPEN_EXTENT, box.min.x, EPS);
+        assertEquals(5.0, box.max.x, EPS);
+    }
+
+    @Test
+    public void greaterEqualOnZClampsToPositiveZ() {
+        Constraint c = Constraint.scalar(Constraint.Field.Z, Constraint.Op.GE, -2.0);
+        AABB box = ConstraintShapes.boxFor(c, new Vec3dCore(0, 0, 0));
+        assertEquals(-2.0, box.min.z, EPS);
+        assertEquals(-2.0 + ConstraintShapes.OPEN_EXTENT, box.max.z, EPS);
+    }
+
+    @Test
+    public void equalityRendersThinSlabCentredOnValue() {
+        Constraint c = Constraint.scalar(Constraint.Field.X, Constraint.Op.EQ, 7.0);
+        AABB box = ConstraintShapes.boxFor(c, new Vec3dCore(0, 0, 0));
+        assertEquals(7.0 - ConstraintShapes.EQ_HALF_WIDTH, box.min.x, EPS);
+        assertEquals(7.0 + ConstraintShapes.EQ_HALF_WIDTH, box.max.x, EPS);
+        assertTrue("equality slab is thin", box.max.x - box.min.x < 0.1);
+    }
+
+    // ---- ConstraintShapes: non-spatial fields are not drawn -------------------
+
+    @Test
+    public void facingAndVelocityFieldsAreNotDrawable() {
+        assertNull(ConstraintShapes.spatialAxis(Constraint.scalar(Constraint.Field.F, Constraint.Op.GT, 0.1)));
+        assertNull(ConstraintShapes.spatialAxis(Constraint.scalar(Constraint.Field.DX, Constraint.Op.GT, 0.1)));
+        assertNull(ConstraintShapes.spatialAxis(Constraint.scalar(Constraint.Field.DZ, Constraint.Op.LT, -0.1)));
+        assertFalse(ConstraintShapes.isDrawable(Constraint.scalar(Constraint.Field.F, Constraint.Op.GT, 0.1)));
+        assertNull("non-spatial -> no box", ConstraintShapes.boxFor(Constraint.scalar(Constraint.Field.DZ, Constraint.Op.LT, -0.1), new Vec3dCore(0, 0, 0)));
+        assertEquals(AngleSolverState.Axis.X, ConstraintShapes.spatialAxis(Constraint.scalar(Constraint.Field.X, Constraint.Op.GT, 1.0)));
+        assertEquals(AngleSolverState.Axis.Z, ConstraintShapes.spatialAxis(Constraint.range(Constraint.Field.Z, 0, 1, true, true)));
+    }
+
+    // ---- BoxController emission -----------------------------------------------
+
+    @Test
+    public void boxControllerEmitsOnePlatePerConstraintInBothPasses() {
+        BoxController boxes = new BoxController();
+        boxes.add(tickAt(new Vec3dCore(0.5, 64.0, 0.5)));    // tick 0
+        boxes.add(tickAt(new Vec3dCore(1.5, 64.0, 0.5)));    // tick 1: two plates
+        boxes.add(tickAt(new Vec3dCore(2.5, 64.0, 0.5)));    // tick 2
+
+        final AABB a = new AABB(new Vec3dCore(1, 1, 1), new Vec3dCore(2, 2, 2));
+        final AABB b = new AABB(new Vec3dCore(3, 3, 3), new Vec3dCore(4, 4, 4));
+        ConstraintBoxSource source = new ConstraintBoxSource() {
+            @Override
+            public List<AABB> boxesAt(int tickIndex) {
+                if (tickIndex == 1) {
+                    List<AABB> l = new ArrayList<>();
+                    l.add(a);
+                    l.add(b);
+                    return l;
+                }
+                return Collections.emptyList();
+            }
+
+            @Override
+            public long revision() {
+                return 1L;
+            }
+        };
+
+        assertEquals(2, boxes.constraintBoxCount(source));
+
+        CapturingRenderer faces = new CapturingRenderer(BoxRenderer.Mode.FACES);
+        boxes.renderConstraints(faces, source, 0xFFFFFFFF, 0, 0, 0, Double.POSITIVE_INFINITY);
+        assertEquals(2, faces.boxes.size());
+        assertEquals(a, faces.boxes.get(0));
+        assertEquals(b, faces.boxes.get(1));
+
+        CapturingRenderer lines = new CapturingRenderer(BoxRenderer.Mode.LINES);
+        boxes.renderConstraints(lines, source, 0xFF00FF00, 0, 0, 0, Double.POSITIVE_INFINITY);
+        assertEquals(2, lines.boxes.size());
+    }
+
+    // ---- AngleSolverConstraintSource bridge -----------------------------------
+
+    private static BoxController boxesWith(Vec3dCore... feet) {
+        BoxController boxes = new BoxController();
+        for (Vec3dCore f : feet) boxes.add(tickAt(f));
+        return boxes;
+    }
+
+    @Test
+    public void sourceAnchorsRangeConstraintAtItsTickPosition() {
+        AngleSolverState state = new AngleSolverState();
+        BoxController boxes = boxesWith(
+                new Vec3dCore(0.5, 64.0, 0.5),
+                new Vec3dCore(1.25, 65.0, 3.5)); // tick 1 carries the constraint
+        state.tickConstraints(1).getConstraints().add(Constraint.range(Constraint.Field.X, 1.0, 2.0, true, true));
+
+        AngleSolverConstraintSource source = new AngleSolverConstraintSource(state, boxes, () -> true);
+
+        assertTrue(source.boxesAt(0).isEmpty());
+        List<AABB> at1 = source.boxesAt(1);
+        assertEquals(1, at1.size());
+        AABB box = at1.get(0);
+        assertEquals(1.0, box.min.x, EPS);
+        assertEquals(2.0, box.max.x, EPS);
+        // Anchored at tick 1's position (z = 3.5, y = 65.0), not tick 0's.
+        assertEquals(3.5 - ConstraintShapes.CROSS_HALF_WIDTH, box.min.z, EPS);
+        assertEquals(65.0, box.min.y, EPS);
+    }
+
+    @Test
+    public void sourceSkipsDisabledAndNonSpatialConstraints() {
+        AngleSolverState state = new AngleSolverState();
+        BoxController boxes = boxesWith(new Vec3dCore(0.5, 64.0, 0.5));
+        Constraint disabled = Constraint.range(Constraint.Field.X, 1.0, 2.0, true, true);
+        disabled.setEnabled(false);
+        state.tickConstraints(0).getConstraints().add(disabled);
+        state.tickConstraints(0).getConstraints().add(Constraint.scalar(Constraint.Field.DX, Constraint.Op.GT, 0.2)); // non-spatial
+        state.tickConstraints(0).getConstraints().add(Constraint.scalar(Constraint.Field.Z, Constraint.Op.GT, 0.0)); // the only drawable one
+
+        AngleSolverConstraintSource source = new AngleSolverConstraintSource(state, boxes, () -> true);
+        assertEquals(1, source.boxesAt(0).size());
+    }
+
+    @Test
+    public void sourceIsSilentWhenInactive() {
+        AngleSolverState state = new AngleSolverState();
+        BoxController boxes = boxesWith(new Vec3dCore(0.5, 64.0, 0.5));
+        state.tickConstraints(0).getConstraints().add(Constraint.range(Constraint.Field.X, 1.0, 2.0, true, true));
+
+        final boolean[] active = {false};
+        AngleSolverConstraintSource source = new AngleSolverConstraintSource(state, boxes, () -> active[0]);
+        assertTrue(source.boxesAt(0).isEmpty());
+        assertEquals(0L, source.revision());
+
+        active[0] = true;
+        assertEquals(1, source.boxesAt(0).size());
+        assertNotEquals(0L, source.revision());
+    }
+
+    @Test
+    public void revisionChangesWhenConstraintChanges() {
+        AngleSolverState state = new AngleSolverState();
+        BoxController boxes = boxesWith(new Vec3dCore(0.5, 64.0, 0.5));
+        Constraint c = Constraint.scalar(Constraint.Field.X, Constraint.Op.GT, 5.0);
+        state.tickConstraints(0).getConstraints().add(c);
+
+        AngleSolverConstraintSource source = new AngleSolverConstraintSource(state, boxes, () -> true);
+        long before = source.revision();
+        c.setValue(6.0);
+        assertNotEquals("editing a constraint value must bump the revision", before, source.revision());
+    }
+}

--- a/loader-fabric-1.21.10/src/client/java/de/legoshi/parkourcalc/fabric/render/CachedBoxGeometry.java
+++ b/loader-fabric-1.21.10/src/client/java/de/legoshi/parkourcalc/fabric/render/CachedBoxGeometry.java
@@ -61,12 +61,16 @@ public final class CachedBoxGeometry implements AutoCloseable {
     private int faceTotal;      // total face vertices (arrows occupy [arrowBase, faceTotal))
     private int lineMainTotal;  // first subtick vertex in the lines buffer
     private int lineTotal;      // total line vertices (subtick occupies [lineMainTotal, lineTotal))
+    private int constraintFaceVerts;
+    private int constraintLineVerts;
     private Set<Integer> bakedSelection = new HashSet<>();
 
     private record Segment(GpuBuffer buffer, int vertexCount) {
     }
 
-    public void ensureBuilt(BoxController boxController, int structuralHash, Set<Integer> selection, Consumer<BoxRenderer> faceEmitter, Consumer<BoxRenderer> lineEmitter, SelectionPatchSpec patch) {
+    public void ensureBuilt(BoxController boxController, int structuralHash, Set<Integer> selection, Consumer<BoxRenderer> faceEmitter, Consumer<BoxRenderer> lineEmitter, SelectionPatchSpec patch, int constraintFaceVerts, int constraintLineVerts) {
+        this.constraintFaceVerts = constraintFaceVerts;
+        this.constraintLineVerts = constraintLineVerts;
         long rev = boxController.getGeometryRev();
         if (built && rev == lastGeometryRev && structuralHash == lastStructuralHash) {
             if (!selection.equals(bakedSelection)) {
@@ -213,6 +217,7 @@ public final class CachedBoxGeometry implements AutoCloseable {
 
     public void drawFaces(Matrix4f modelView, int[] runs) {
         RenderPipeline pipeline = FabricRenderLayers.translucentBoxPipeline();
+        int constraintFaceBase = faceTotal - constraintFaceVerts;
         for (int k = 0; k + 1 < runs.length; k += 2) {
             int a = runs[k];
             int b = runs[k + 1];
@@ -220,7 +225,7 @@ public final class CachedBoxGeometry implements AutoCloseable {
             if (hitboxEdges != 0) {
                 drawRange(faceSegments, pipeline, VertexFormat.DrawMode.TRIANGLES, modelView,hitboxBase + hitboxStarts[a], hitboxStarts[b] - hitboxStarts[a]);
             }
-            if (arrowBase < faceTotal) {
+            if (arrowBase < constraintFaceBase) {
                 int arrowEnd = Math.min(b, boxCount - 1);
                 int arrowStart = Math.min(a, boxCount - 1);
                 if (arrowEnd > arrowStart) {
@@ -228,11 +233,15 @@ public final class CachedBoxGeometry implements AutoCloseable {
                 }
             }
         }
+        if (constraintFaceVerts > 0) {
+            drawRange(faceSegments, pipeline, VertexFormat.DrawMode.TRIANGLES, modelView, constraintFaceBase, constraintFaceVerts);
+        }
     }
 
     public void drawLines(Matrix4f modelView, int[] runs) {
         RenderPipeline pipeline = FabricRenderLayers.thinLinesPipeline();
-        boolean hasSubtick = lineMainTotal < lineTotal;
+        int constraintLineBase = lineTotal - constraintLineVerts;
+        boolean hasSubtick = lineMainTotal < constraintLineBase;
         for (int k = 0; k + 1 < runs.length; k += 2) {
             int a = runs[k];
             int b = runs[k + 1];
@@ -240,6 +249,9 @@ public final class CachedBoxGeometry implements AutoCloseable {
             if (hasSubtick) {
                 drawRange(lineSegments, pipeline, VertexFormat.DrawMode.DEBUG_LINES, modelView,lineMainTotal + subtickStarts[a], subtickStarts[b] - subtickStarts[a]);
             }
+        }
+        if (constraintLineVerts > 0) {
+            drawRange(lineSegments, pipeline, VertexFormat.DrawMode.DEBUG_LINES, modelView, constraintLineBase, constraintLineVerts);
         }
     }
 

--- a/loader-fabric-1.21.10/src/client/java/de/legoshi/parkourcalc/fabric/render/FabricWorldOverlayRenderer.java
+++ b/loader-fabric-1.21.10/src/client/java/de/legoshi/parkourcalc/fabric/render/FabricWorldOverlayRenderer.java
@@ -51,7 +51,7 @@ public final class FabricWorldOverlayRenderer {
         VertexConsumerProvider.Immediate consumers = client.getBufferBuilders().getEntityVertexConsumers();
 
         PathRenderPlan plan = PathRenderPlan.build(boxController, settings, selection);
-        cached.ensureBuilt(boxController, plan.structuralHash, plan.selection, plan.faceEmitter, plan.lineEmitter, plan.patch);
+        cached.ensureBuilt(boxController, plan.structuralHash, plan.selection, plan.faceEmitter, plan.lineEmitter, plan.patch, plan.constraintFaceVerts, plan.constraintLineVerts);
 
         Matrix4f modelView = new Matrix4f(positionMatrix).translate(
                 (float) (cached.anchorX() - cameraPos.x),

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/render/Forge12CachedBoxGeometry.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/render/Forge12CachedBoxGeometry.java
@@ -44,11 +44,16 @@ public final class Forge12CachedBoxGeometry {
     private int faceTotal;
     private int lineMainTotal;
     private int lineTotal;
+    private int constraintFaceVerts;
+    private int constraintLineVerts;
     private int lastBakeVertices;
     private Set<Integer> bakedSelection = new HashSet<Integer>();
 
     public void ensureBuilt(BoxController boxController, int structuralHash, Set<Integer> selection,
-                            Consumer<BoxRenderer> faceEmitter, Consumer<BoxRenderer> lineEmitter, SelectionPatchSpec patch) {
+                            Consumer<BoxRenderer> faceEmitter, Consumer<BoxRenderer> lineEmitter, SelectionPatchSpec patch,
+                            int constraintFaceVerts, int constraintLineVerts) {
+        this.constraintFaceVerts = constraintFaceVerts;
+        this.constraintLineVerts = constraintLineVerts;
         long rev = boxController.getGeometryRev();
         if (built && rev == lastGeometryRev && structuralHash == lastStructuralHash) {
             if (!selection.equals(bakedSelection)) {
@@ -172,6 +177,7 @@ public final class Forge12CachedBoxGeometry {
 
     public void drawFaces(int[] runs) {
         if (faceVbo == null) return;
+        int constraintFaceBase = faceTotal - constraintFaceVerts;
         beginArrays(faceVbo);
         for (int k = 0; k + 1 < runs.length; k += 2) {
             int a = runs[k];
@@ -182,7 +188,7 @@ public final class Forge12CachedBoxGeometry {
                 GL11.glDrawArrays(GL11.GL_TRIANGLES, hitboxBase + hitboxStarts[a],
                         hitboxStarts[b] - hitboxStarts[a]);
             }
-            if (arrowBase < faceTotal) {
+            if (arrowBase < constraintFaceBase) {
                 int arrowEnd = Math.min(b, boxCount - 1);
                 int arrowStart = Math.min(a, boxCount - 1);
                 if (arrowEnd > arrowStart) {
@@ -190,13 +196,17 @@ public final class Forge12CachedBoxGeometry {
                 }
             }
         }
+        if (constraintFaceVerts > 0) {
+            GL11.glDrawArrays(GL11.GL_TRIANGLES, constraintFaceBase, constraintFaceVerts);
+        }
         endArrays(faceVbo);
     }
 
     public void drawLines(int[] runs) {
         if (lineVbo == null) return;
+        int constraintLineBase = lineTotal - constraintLineVerts;
+        boolean hasSubtick = lineMainTotal < constraintLineBase;
         beginArrays(lineVbo);
-        boolean hasSubtick = lineMainTotal < lineTotal;
         for (int k = 0; k + 1 < runs.length; k += 2) {
             int a = runs[k];
             int b = runs[k + 1];
@@ -206,6 +216,9 @@ public final class Forge12CachedBoxGeometry {
                 GL11.glDrawArrays(GL11.GL_LINES, lineMainTotal + subtickStarts[a],
                         subtickStarts[b] - subtickStarts[a]);
             }
+        }
+        if (constraintLineVerts > 0) {
+            GL11.glDrawArrays(GL11.GL_LINES, constraintLineBase, constraintLineVerts);
         }
         endArrays(lineVbo);
     }

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/render/Forge12WorldOverlayRenderer.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/render/Forge12WorldOverlayRenderer.java
@@ -60,7 +60,7 @@ public final class Forge12WorldOverlayRenderer {
         GlStateManager.glLineWidth(BoxStyle.LINE_WIDTH);
 
         PathRenderPlan plan = PathRenderPlan.build(boxController, settings, selection);
-        cached.ensureBuilt(boxController, plan.structuralHash, plan.selection, plan.faceEmitter, plan.lineEmitter, plan.patch);
+        cached.ensureBuilt(boxController, plan.structuralHash, plan.selection, plan.faceEmitter, plan.lineEmitter, plan.patch, plan.constraintFaceVerts, plan.constraintLineVerts);
 
         int[] runs = boxController.inRangeRuns(camX, camY, camZ, BoxStyle.pathMaxDistanceSq(settings));
         GlStateManager.pushMatrix();

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/render/Forge8CachedBoxGeometry.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/render/Forge8CachedBoxGeometry.java
@@ -44,10 +44,14 @@ public final class Forge8CachedBoxGeometry {
     private int faceTotal;
     private int lineMainTotal;
     private int lineTotal;
+    private int constraintFaceVerts;
+    private int constraintLineVerts;
     private int lastBakeVertices;
     private Set<Integer> bakedSelection = new HashSet<Integer>();
 
-    public void ensureBuilt(BoxController boxController, int structuralHash, Set<Integer> selection, Consumer<BoxRenderer> faceEmitter, Consumer<BoxRenderer> lineEmitter, SelectionPatchSpec patch) {
+    public void ensureBuilt(BoxController boxController, int structuralHash, Set<Integer> selection, Consumer<BoxRenderer> faceEmitter, Consumer<BoxRenderer> lineEmitter, SelectionPatchSpec patch, int constraintFaceVerts, int constraintLineVerts) {
+        this.constraintFaceVerts = constraintFaceVerts;
+        this.constraintLineVerts = constraintLineVerts;
         long rev = boxController.getGeometryRev();
         if (built && rev == lastGeometryRev && structuralHash == lastStructuralHash) {
             if (!selection.equals(bakedSelection)) {
@@ -167,6 +171,7 @@ public final class Forge8CachedBoxGeometry {
 
     public void drawFaces(int[] runs) {
         if (faceVbo == null) return;
+        int constraintFaceBase = faceTotal - constraintFaceVerts;
         beginArrays(faceVbo);
         for (int k = 0; k + 1 < runs.length; k += 2) {
             int a = runs[k];
@@ -175,7 +180,7 @@ public final class Forge8CachedBoxGeometry {
             if (hitboxEdges != 0) {
                 GL11.glDrawArrays(GL11.GL_TRIANGLES, hitboxBase + hitboxStarts[a], hitboxStarts[b] - hitboxStarts[a]);
             }
-            if (arrowBase < faceTotal) {
+            if (arrowBase < constraintFaceBase) {
                 int arrowEnd = Math.min(b, boxCount - 1);
                 int arrowStart = Math.min(a, boxCount - 1);
                 if (arrowEnd > arrowStart) {
@@ -183,13 +188,17 @@ public final class Forge8CachedBoxGeometry {
                 }
             }
         }
+        if (constraintFaceVerts > 0) {
+            GL11.glDrawArrays(GL11.GL_TRIANGLES, constraintFaceBase, constraintFaceVerts);
+        }
         endArrays(faceVbo);
     }
 
     public void drawLines(int[] runs) {
         if (lineVbo == null) return;
+        int constraintLineBase = lineTotal - constraintLineVerts;
+        boolean hasSubtick = lineMainTotal < constraintLineBase;
         beginArrays(lineVbo);
-        boolean hasSubtick = lineMainTotal < lineTotal;
         for (int k = 0; k + 1 < runs.length; k += 2) {
             int a = runs[k];
             int b = runs[k + 1];
@@ -197,6 +206,9 @@ public final class Forge8CachedBoxGeometry {
             if (hasSubtick) {
                 GL11.glDrawArrays(GL11.GL_LINES, lineMainTotal + subtickStarts[a], subtickStarts[b] - subtickStarts[a]);
             }
+        }
+        if (constraintLineVerts > 0) {
+            GL11.glDrawArrays(GL11.GL_LINES, constraintLineBase, constraintLineVerts);
         }
         endArrays(lineVbo);
     }

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/render/Forge8WorldOverlayRenderer.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/render/Forge8WorldOverlayRenderer.java
@@ -60,7 +60,7 @@ public final class Forge8WorldOverlayRenderer {
         GL11.glLineWidth(BoxStyle.LINE_WIDTH);
 
         PathRenderPlan plan = PathRenderPlan.build(boxController, settings, selection);
-        cached.ensureBuilt(boxController, plan.structuralHash, plan.selection, plan.faceEmitter, plan.lineEmitter, plan.patch);
+        cached.ensureBuilt(boxController, plan.structuralHash, plan.selection, plan.faceEmitter, plan.lineEmitter, plan.patch, plan.constraintFaceVerts, plan.constraintLineVerts);
 
         int[] runs = boxController.inRangeRuns(camX, camY, camZ, BoxStyle.pathMaxDistanceSq(settings));
         GlStateManager.pushMatrix();


### PR DESCRIPTION
Render per-tick angle-solver position constraints (X/Z) as a translucent
plate anchored at the tick's simulated position: an outline (LINES) plus a
very light fill (FACES). Bounded ranges (X in [lo,hi]) draw a band of that
width; open-ended (> / <) draw a sub-area clamped to OPEN_EXTENT=1 block in
the open direction so it reads as "open this way" without being infinite; =
draws a thin slab. Non-spatial fields (F/dX/dZ) have no world extent and are
skipped.

Geometry lives in core (ConstraintShapes), produced through the BoxRenderer
port (BoxController.renderConstraints) and appended to the cached path
emitters in PathRenderPlan behind a new "Show constraints" toggle (default
on; only visible while the Angle Solver view is open). Colors are added to
BoxStyle/Settings (teal outline #33d6a6 full-alpha, same hue fill at 15%).
PathVertexLayout gains the constraint region offsets so the loader draw is a
one-slice follow-up; no loader change here (port-only). Tests cover the
range/open/equality geometry, the tick anchoring, and the source bridge.

