### PR TITLE
docs: add domain glossary and mcpk physics reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,8 @@
 # AGENTS.md
 
 Shared guidance for AI coding agents and contributors. This is the canonical guide; `CLAUDE.md` imports it so Claude Code picks it up automatically, and other tools that read `AGENTS.md` get the same content. Navigation reference: where to find what, and the rules that must not break. For deeper context:
+- `CONTEXT.md`: domain glossary. Decodes the Minecraft parkour and movement vocabulary (facing, direction, velocity, tier, neo, momentum, byte-exact, etc.). Read it first; almost none of these terms are in an LLM's training data.
+- `docs/reference/mcpk/`: in-repo mirror of the Minecraft Parkour Wiki physics (movement formulas, constants, the sine table, collision order, block friction, status effects, tiers). The byte-exact ground truth this tool replicates; if code disagrees with a number there, the code is the bug.
 - `docs/VISION.md`: north-star goal (two blocks in, full TAS out), the capability arc, design principles
 - `docs/CODING_GUIDE.md`: module rules, where new code goes, port pattern, per-module toolchains
 - `docs/research/`: angle-solver design record, ILS global-solve notes

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,237 @@
+# Parkour Calculator Mod
+
+Domain glossary for the Minecraft parkour and movement TASing niche this tool operates in. These terms come from the speedrun community and from Minecraft's movement internals; almost none are general programming concepts and almost none appear in an LLM's training data. For where code lives and the rules that must not break, see `AGENTS.md`. For the project's north star, see `docs/VISION.md`.
+
+This file is a glossary only: what terms mean, not how anything is implemented.
+
+The canonical community source is the Minecraft Parkour Wiki, `https://www.mcpk.wiki/wiki/Parkour_Nomenclature`. Its terms are mirrored here in-repo deliberately: that wiki sits behind a Cloudflare challenge and cannot be fetched by an agent, so a bare link would be useless. Aliases (the community shorthand, e.g. `bm`, `hh`, `cp`) are given in parentheses. The exact physics this tool replicates (movement formulas, constants, the sine table, collision order, block friction, status effects, tiers) is mirrored as reference under `docs/reference/mcpk/`.
+
+## Roles and workflow
+
+**TAS**:
+Tool Assisted Speedrun. A frame-perfect (tick-perfect) sequence of inputs crafted with tool help rather than executed live by a human. This tool produces TASes for parkour and movement.
+
+**Strat**:
+A specific method or setup to complete a jump: where to stand, what to press, how to turn. Stratfinding is discovering whether a jump is possible and exactly how to land it; a stratfinder is a person who does this. One of the tool's two audiences (the other is TAS creators).
+
+**Route**:
+A multi-jump sequence from a start block to a goal block, as opposed to a single jump.
+
+## Ticks and controls
+
+**Tick** (t):
+One Minecraft simulation step, 1/20 of a second (50 ms; 20 ticks per second). The atomic unit of the whole tool: inputs are per tick, the path is one position per tick, and the solver reasons tick by tick.
+
+**WASD**:
+The default movement controls: W forward, A left, S backward, D right.
+
+**Sprint** (ctrl):
+An action that makes the player move ~30% faster. Activated by the sprint key or by double-tapping W. A jump performed while sprinting (a sprint-jump) is the standard long jump and gets an extra forward velocity boost on the takeoff tick.
+
+**Sneak** (shift):
+An action that makes the player move ~70% slower and prevents them from walking off a block edge.
+
+**Strafe** (A or D):
+Moving sideways with A or D, optionally combined with W or S. Changes the player's direction of travel without turning the camera.
+
+**45 strafe**:
+Turning the camera 45 degrees while strafing accordingly, so the raw movement input points diagonally. Lets the player move up to ~2% further than W alone, but is hard to do consistently.
+
+**Timing**:
+A simple sequence of inputs used to gain momentum. Basic timings include jam (0t) and headhitter (1t).
+
+**Tap**:
+Moving in small intervals (1 or 2 ticks, usually while sneaking) to set the player in an optimal position.
+
+## Orientation and measurement
+
+Note: community canon and Minecraft's code use different words for the same things. The glossary uses the community word as canonical and notes the code field name.
+
+**Facing** (F_t):
+The player's look angle in degrees, the value shown in F3. It is the yaw wrapped to the range [-180, 180], and depends on rotation only. In the movement formulas it is `F_t`, and it sets the direction of the sprint-jump boost.
+
+**Yaw**:
+The raw float backing facing: horizontal rotation in degrees, unbounded. It keeps growing the longer you turn one way, losing float precision (jittery past 2^22, movement breaks at 360 * 2^15, the game crashes past ~8.59e9). Wrapped to [-180, 180] it becomes the facing.
+_Avoid_: rotationYaw (the code field name)
+
+**Pitch**:
+The vertical look angle. Does not affect horizontal parkour movement at all (it only matters for elytra and swimming, both out of scope), but it is still a per-tick input the tool records.
+
+**Direction** (D_t):
+The horizontal direction the player actually moves, `atan2(-vx, vz)`, determined by inputs and rotation together. In the movement formulas it is `D_t`, and it sets the direction of ground and air acceleration. Distinct from facing: facing is where you look (rotation only), direction is where you go (inputs plus rotation). The two coincide only when moving straight forward.
+_Avoid_: xz angle (internal name for the same quantity), heading
+
+**Significant angle**:
+The integer index, 0 to 65535, that Minecraft actually uses for trigonometry. `sin`/`cos` are a 65536-entry lookup table indexed by `(int)(radians * 10430.378) & 65535`, so any facing is effectively snapped to one of 65536 significant angles (~0.0055 degrees each) before the movement math runs. This snapping is why a tiny facing change can produce no movement change, and is the reason the angle solver's objective is a step function.
+
+**Half angle**:
+A yaw that lands between two significant angles, where floating-point error makes the sin/cos pair have a norm slightly off from 1: an "increasing" half angle (norm > 1) gains a little speed, a "decreasing" one (norm < 1) loses some. The gains are tiny (135.0055 degrees gives ~1.00005) and only practical in TAS; "large half angles" at extreme yaws are far stronger (up to ~1.003 in vanilla, more with Optifine Fast Math). Detail in `docs/reference/mcpk/`.
+
+**Coordinates** (coords):
+The player's position, readable via the F3 screen. Usually refers to the set of coordinates used to set up for a jump.
+
+**X facing** (x) / **Z facing** (z):
+The axis an obstacle is oriented along. An X-facing obstacle faces East/West and is harder to avoid; a Z-facing obstacle faces North/South and is easier. Visible via F3. (Distinct from the player's facing above.)
+
+**Block** (b):
+The standard unit of distance in Minecraft (visual block count). 1 block = 16 pixels.
+
+**Pixel** (px):
+1/16 of a block, 0.0625 blocks. A sub-block unit of distance and position.
+
+**Meter** (m):
+A distance unit that accounts for the player's 0.6-wide bounding box, so it reflects the physical gap rather than the visual block count. A "4 block" jump is ~3.4 meters of actual air travel.
+
+## Velocity and speed
+
+The project's own precise taxonomy. The one true quantity is velocity; speed and direction are its polar components.
+
+**Velocity**:
+The player's stored per-tick movement vector `(vx, vy, vz)`: the movement the player intends to apply next tick. Named instances appear throughout, e.g. entry velocity (the velocity a jump starts with) and rest velocity (standing still on the ground).
+_Avoid_: motion (a Minecraft-ism; being renamed to velocity everywhere)
+
+**Speed**:
+The magnitude of velocity, `||(vx, vy, vz)||`. A scalar.
+
+**XZ velocity**:
+The horizontal projection of velocity, `(vx, vz)`. The only velocity component that matters for parkour.
+
+**XZ speed**:
+The magnitude of the XZ velocity, `||(vx, vz)||`. With direction it gives the polar identity `(vx, vz) = xz_speed at angle direction`: the same vector in polar form.
+
+**Displacement**:
+The realized movement over one tick, `pos - lastPos`. Equals velocity when nothing is in the way, but diverges the moment the player collides: velocity is what the player intended, displacement is what actually happened. Shown in the MPK movement readout.
+_Avoid_: speed (speed is the magnitude of velocity, before collision; displacement is after)
+
+## Momentum
+
+**Momentum** (mm):
+1) The speed gained and conserved by moving. 2) The run-up space given to build enough speed for a jump.
+
+**Block momentum** (#bm):
+The distance given to gain momentum. 1bm is one block (1.6 m of momentum); 2bm is two consecutive blocks (2.6 m).
+
+**Flat momentum** (flat mm):
+The standard momentum setup, where the run-up space is flat ground (12 tick cycle).
+
+**Elevation momentum**:
+A more efficient setup where the run-up is elevated at each step: +0.125 is the lowest (11 tick cycle), +1 the default (9 tick cycle), +1.1875 the maximum (7 tick cycle).
+
+**Headhitter momentum** (hh mm):
+A very efficient momentum setup using a 2-block ceiling (3 tick cycle).
+
+**Trapdoor-headhitter momentum** (tdhh mm):
+The most efficient momentum setup (2 tick cycle).
+
+**Backwalled**:
+Describes a momentum that has a wall at its back, which reduces the run-up space.
+
+**Sidestep**:
+Jumping sideways while gaining momentum. Utilises 45 strafe and makes turning more consistent; common for 1bm butterfly neos.
+
+**Backward momentum** (bwmm):
+Moving backward to increase the run-up space before jumping. Useful on a short momentum, necessary for some jumps.
+
+**Loop momentum** (loop mm):
+Repeated backward momentum, alternating back and forth across the momentum. One backward momentum already gains distance because the player can stay airborne for a tick if the prior tick was still on the ground, and the more velocity they carry the further they get from the edge, which in turn gives more room to accelerate. Doing this at the next edge and jumping the other way extends it a little more, and looping accumulates slightly more momentum each pass.
+
+## Jumps: distance, ceilings, names
+
+**Distance**:
+The size of a jump, given in blocks (visual) or meters (accurate, accounting for the 0.6 m player width).
+
+**Length** (#b) / **Width** (x#) / **Height** (+#):
+A jump's dimensions. Length is the longest horizontal side, width the shortest horizontal side, height the vertical change. Max jump-up height is 1.249 blocks in 1.8, 1.252 in 1.9+.
+
+**Jump format** (#x#+#):
+The conventional notation for a simple jump, `length x width + height`. Width and height are dropped when zero; a bare length gets a "b". Examples: `3b`, `4x1`, `5-1`, `4+0.5`, `3x3+0.4375`.
+
+**Duration**:
+The number of ticks between jumping and landing. Depends on height: a flat jump is 12 ticks, a +1 jump is 9 ticks, a 2-block-ceiling jump is 3 ticks.
+
+**Tier**:
+An intuitive label for jump duration. Tier 0 is a flat jump by convention; positive tiers are jumps with positive height, negative tiers with negative height. (Reference: a Tier 0 sprint-jump maxes at ~4.3227043 m.)
+
+**Block ceiling** (#bc):
+The height of a ceiling, in blocks. 2bc and 3bc still affect movement; 4bc is the same as no ceiling. The player is 1.8 m tall.
+
+**Headhitter** (hh):
+A synonym for 2bc (a 2-block ceiling).
+
+**Trapdoor headhitter** (tdhh):
+A 2bc lowered further with a trapdoor (1.8125 bc), leaving 0.0125 b of room: the lowest ceiling a player can walk through in 1.8.
+
+**Linear jump**:
+A jump with no obstacles, completable without turning (apart from using 45 strafe).
+
+**Neo** (#b neo):
+A jump that goes around a wall; the number is the wall length (a 2b neo is a "double neo"). Variants: winged neo (wall extended outwards), nix neo (wall and landing extended), reverse nix neo (wall and momentum extended), butterfly neo (panes on its side).
+
+**Cross neo**:
+A jump that goes around a corner.
+
+**Squeeze jump**:
+A jump through a small gap.
+
+## Mechanics, glitches, and geometry
+
+**Stepping** (step-assist):
+Minecraft's auto-step assist: the player rises over obstacles up to 0.6 blocks tall without jumping.
+
+**Blip**:
+A glitch from landing between two blocks of different height (caused by stepping). The player "lands mid-air" and can jump with initial height.
+
+**Jump cancel**:
+A glitch from jumping into a ceiling or step (caused by stepping). Cancels the player's upward momentum, letting them jump again sooner.
+
+**Grinding**:
+Chaining multiple jump cancels to gain momentum. Stair grinding (called slab boost) is the easier form; ceiling grinding is much harder.
+
+**Bounding box**:
+An axis-aligned cuboid given by min/max on each axis. The player's is 0.6 x 1.8 x 0.6.
+
+**Collision box**:
+The volume of a block the player physically collides with (one or more bounding boxes). The player's bounding box is not allowed to intersect a collision box.
+
+## Map terminology
+
+**Checkpoint** (cp):
+A position the player can teleport back to.
+
+**Failsafe** (fs):
+A loose checkpoint that only allows partial recovery.
+
+**Life or death** (l/d):
+A section that is not failsafed; failing it loses some progress.
+
+**Room** (r#) / **Transition** (t#-#):
+A room is a subsection of a course; a transition connects two rooms and is sometimes life or death.
+
+## Tool concepts
+
+Specific to this tool, not on the wiki.
+
+**Byte-exact**:
+A prediction that reproduces Minecraft's movement bit-for-bit, with no approximation. Required to certify jumps whose success margin is 1e-4 of a block or tighter. Both the simulator and the solver's inner model are held byte-exact against real Minecraft.
+_Avoid_: bit-exact (same thing; prefer byte-exact)
+
+**Margin**:
+How much room to spare a jump succeeds by. The tool's goal is to certify routes down to a 1e-4 block margin or tighter, the regime where human stratfinding breaks down.
+
+**Run-up**:
+The movement before takeoff that builds the entry velocity a jump needs. The tool can find the run-up that produces a required velocity.
+
+**Takeoff**:
+The tick and the spot on the start block where the player leaves the ground to begin a jump.
+
+**Entry velocity**:
+The velocity a jump begins with, at takeoff. What the velocity finder solves for.
+
+**Rest velocity**:
+The velocity of a player standing at rest on the ground: horizontally zero, with a small downward `vy` so the player still registers as on the ground. Used as the default start velocity; a saved value of exactly `(0,0,0)` is treated as a legacy unset sentinel and replaced with this.
+
+**Constraint**:
+A positional requirement the solved path must satisfy at a given tick: land within these X/Z bounds, stay clear of this collision box, pass through this point. Constraints can be hand-entered or derived from picked blocks. A constraint on tick n affects the position at the start of tick n; to constrain what tick n's input produces, place it on tick n+1.
+
+**Mothball-string**:
+The save/load notation, shared with the Mothball and Stratfinder community tooling, that lets setups roundtrip between this tool and those.

--- a/docs/reference/mcpk/01-movement-formulas.md
+++ b/docs/reference/mcpk/01-movement-formulas.md
@@ -1,0 +1,316 @@
+# Minecraft Movement Formulas (mcpk.wiki reference)
+
+Mirrored from the Minecraft Parkour Wiki (mcpk.wiki); captured in-repo because the wiki is Cloudflare-gated. Reference, not implementation. Source pages: Player Movement, 45 Strafe, Horizontal Movement Formulas, Vertical Movement Formulas, Nonrecursive Movement Formulas.
+
+## Player Movement
+
+Every tick, the game checks for the player's inputs and translates them into motion.
+
+Minecraft's moveset: on top of jumping, the player has three move speeds:
+
+- Walking (default)
+- Sprinting (faster, jump further)
+- Sneaking (slower, can walk to block edge and grab ladders/vines)
+
+Each of these three actions has a base acceleration added to the player's velocity every tick:
+
+| Action | Base acceleration |
+| --- | --- |
+| Walking | 0.1 |
+| Sprinting | 0.13 |
+| Sneaking | 0.03 |
+
+This base value is multiplied by 0.2 when mid-air, and varies depending on whether the player is Strafing.
+
+## 45 Strafe
+
+45 degree Strafe grants more speed than regular movement, done by strafing and turning 45 degrees. Performed by: turning 45 left and strafing right, OR turning 45 right and strafing left. The turning must be quick (less than 1 tick) and precise (at least +/-11.5 degrees, closer to 0 is better). Some jumps require it, such as 1bm 4.375b.
+
+Effect on Movement: On every tick the player gains acceleration depending on inputs. When moving forward (without strafing), acceleration is scaled by 0.98. When strafing, acceleration is scaled by 1.0. Therefore 45 strafe is 1.0/0.98 times faster than regular movement (about 2% faster).
+
+Special case 45 Sneak: when sneaking forward without strafing, acceleration scaled by 0.98. When strafing while sneaking, acceleration scaled by 0.98*sqrt(2) (approx 1.386). 45 Sneak used for no-momentum jumps, and for bridging (about 41% faster than regular sneaking).
+
+Source code (simplified, from Entity and EntityLivingBase):
+
+```java
+public void onLivingUpdate()
+{
+    /* moveStrafing = 1.0 if moving left, -1.0 if moving right, else 0.0
+       moveForward = 1.0 if moving forward, -1.0 if moving backward, else 0.0
+       Furthermore, moveStrafing and moveForward *= 0.3 if the player is sneaking. */
+    this.moveStrafing *= 0.98F;
+    this.moveForward *= 0.98F;
+    this.moveEntityWithHeading(this.moveStrafing, this.moveForward);
+}
+public void moveEntityWithHeading(float strafe, float forward)
+{
+    /* inertia determines how much speed is conserved onto the next tick */
+    float mult = 0.91F;
+    if (this.onGround)
+    {
+        /* Get slipperiness 1 block below the player */
+        mult *= getBlockSlipperinessAt(this.posX, this.getEntityBoundingBox().minY - 1, this.posZ);
+    }
+    /* acceleration = (0.6*0.91)^3 / (slipperiness*0.91)^3) */
+    float acceleration = 0.16277136F / (mult * mult * mult);
+    float movementFactor;
+    if (this.onGround)
+        movementFactor = this.landMovementFactor * acceleration;
+        /* base: 0.1; x1.3 if sprinting, affected by potion effects. */
+    else
+        movementFactor = this.airMovementFactor;
+        /* base: 0.02; x1.3 if sprinting */
+    this.updateMotionXZ(strafe, forward, movementFactor);
+    this.moveEntity(this.motionX, this.motionY, this.motionZ);
+    this.motionY -= 0.08D; /* gravity */
+    this.motionY *= 0.98D; /* drag */
+    this.motionX *= mult;
+    this.motionZ *= mult;
+}
+public void updateMotionXZ(float strafe, float forward, float movementFactor)
+{
+    /* Sprint multiplier is contained within movementFactor; Sneak multiplier is contained within strafe and forward */
+    float distance = strafe * strafe + forward * forward;
+    if (distance >= 1.0E-4F)
+    {
+        distance = MathHelper.sqrt_float(distance);
+        if (distance < 1.0F)
+            distance = 1.0F;
+        distance = movementFactor / distance;
+        strafe = strafe * distance;
+        forward = forward * distance;
+        float sinYaw = MathHelper.sin(this.rotationYaw * Math.PI / 180.0F);
+        float cosYaw = MathHelper.cos(this.rotationYaw * Math.PI / 180.0F);
+        this.motionX += strafe * cosYaw - forward * sinYaw;
+        this.motionZ += forward * cosYaw + strafe * sinYaw;
+    }
+}
+```
+
+## Horizontal Movement Formulas
+
+On every tick:
+
+1. Acceleration is added to the player's velocity.
+2. The player is moved (new position = position + velocity).
+3. The player's velocity is reduced to simulate drag.
+
+### Multipliers
+
+Movement Multiplier M_t = (movement state) times (strafe state):
+
+Movement state factor:
+
+| State | Factor |
+| --- | --- |
+| Sprinting | 1.3 |
+| Walking | 1.0 |
+| Sneaking | 0.3 |
+| Stopping | 0.0 |
+
+Strafe state factor:
+
+| State | Factor |
+| --- | --- |
+| Default | 0.98 |
+| 45 degree Strafe | 1.0 |
+| 45 degree Sneak | 0.98*sqrt(2) |
+
+Effects Multiplier:
+
+```
+E_t = (1 + 0.2*Speed) * (1 - 0.15*Slowness)
+```
+
+This increases by 20% per level of Speed and decreases by 15% per level of Slowness, and is >= 0.
+
+Slipperiness Multiplier S_t:
+
+| Surface | Factor |
+| --- | --- |
+| Default | 0.6 |
+| Slime | 0.8 |
+| Ice | 0.98 |
+| Airborne | 1.0 |
+
+### Linear Formulas
+
+Linear movement, no change in direction. V_{H,0} is initial speed (default 0); V_{H,t} is speed on tick t.
+
+Ground Speed:
+
+```
+V_{H,t} = V_{H,t-1} * S_{t-1} * 0.91            (Momentum)
+        + 0.1 * M_t * E_t * (0.6/S_t)^3         (Acceleration)
+```
+
+Jump Speed:
+
+```
+V_{H,t} = V_{H,t-1} * S_{t-1} * 0.91
+        + 0.1 * M_t * E_t * (0.6/S_t)^3
+        + { 0.2 if Sprinting, 0.0 else }        (Sprintjump Boost)
+```
+
+Air Speed:
+
+```
+V_{H,t} = V_{H,t-1} * S_{t-1} * 0.91
+        + 0.02 * M_t
+```
+
+### Complete Formulas
+
+D_t is the player's Direction in degrees (defined by inputs and rotation); F_t is the player's Facing in degrees (defined by rotation only).
+
+Ground Velocity:
+
+```
+V_{X,t} = V_{X,t-1}*S_{t-1}*0.91 + 0.1*M_t*E_t*(0.6/S_t)^3 * sin(D_t)
+V_{Z,t} = V_{Z,t-1}*S_{t-1}*0.91 + 0.1*M_t*E_t*(0.6/S_t)^3 * cos(D_t)
+```
+
+Jump Velocity:
+
+```
+V_{X,t} = V_{X,t-1}*S_{t-1}*0.91 + 0.1*M_t*E_t*(0.6/S_t)^3 * sin(D_t) + { 0.2 if Sprinting, 0.0 else } * sin(F_t)
+V_{Z,t} = V_{Z,t-1}*S_{t-1}*0.91 + 0.1*M_t*E_t*(0.6/S_t)^3 * cos(D_t) + { 0.2 if Sprinting, 0.0 else } * cos(F_t)
+```
+
+Air Velocity:
+
+```
+V_{X,t} = V_{X,t-1}*S_{t-1}*0.91 + 0.02*M_t * sin(D_t)
+V_{Z,t} = V_{Z,t-1}*S_{t-1}*0.91 + 0.02*M_t * cos(D_t)
+```
+
+### Stopping Conditions
+
+Wall Collision: if the player hits an X-facing wall, momentum is cancelled and V_{X,t} only includes acceleration. If the player hits a Z-facing wall, momentum is cancelled and V_{Z,t} only includes acceleration. In either case the player stops sprinting.
+
+Negligible Speed Threshold: if |V_{X,t-1}*S_{t-1}*0.91| < 0.005, momentum is cancelled and only acceleration is left (same for Z). In 1.9+, compared to 0.003 instead.
+
+Note: Minecraft's coordinate system is oriented differently: 0 degrees points towards positive Z, 90 degrees points towards negative X. The wiki uses the standard coordinate system to make calculations more intuitive.
+
+## Vertical Movement Formulas
+
+Jump Formula:
+
+```
+V_{Y,1} = 0.42
+V_{Y,t} = (V_{Y,t-1} - 0.08 gravity) * 0.98 drag
+```
+
+If |V_{Y,t}| < 0.005, V_{Y,t} is set to 0 instead (the player's height doesn't change for that tick). In 1.9+ compared to 0.003 instead.
+
+Notes:
+
+- V_{Y,0} has no importance (0th tick = initial velocity before jumping).
+- V_{Y,1} = initial jump motion, increased by 0.1 per level of Jump Boost.
+- Jump height slightly higher in 1.9 due to momentum threshold reduced (old=1.249, new=1.252).
+- Terminal velocity is -3.92 m/t.
+- When the player collides vertically with a block, vertical momentum is cancelled and only the acceleration is left.
+
+Jump duration (number of ticks between jumping and landing; also the period of the jump's cycle when repeated):
+
+| Jump | Duration (ticks) |
+| --- | --- |
+| Flat Jump | 12 |
+| 3bc Jump | 11 |
+| +0.5 Jump | 10 |
+| +1 Jump | 9 |
+| 2.5bc Jump | 6 |
+| 2bc Jump | 3 |
+| 1.8125bc Jump | 2 |
+
+Source code (from EntityLivingBase):
+
+```java
+    protected float getJumpUpwardsMotion(){ return 0.42F; }
+    protected void jump()
+    {
+        this.motionY = this.getJumpUpwardsMotion();
+        if (this.isPotionActive(Potion.jump))
+        {
+            this.motionY += (this.getActivePotionEffect(Potion.jump).getAmplifier() + 1) * 0.1F;
+        }
+        this.isAirBorne = true;
+    }
+    public void moveEntityWithHeading(float strafe, float forward)
+    {
+        ... /* also moves the player horizontally */
+        this.motionY -= 0.08;
+        this.motionY *= 0.98;
+    }
+    public void onLivingUpdate()
+    {
+        if (this.jumpTicks > 0) --this.jumpTicks;
+        if (Math.abs(this.motionY) < 0.005D) this.motionY = 0.0D;
+        if (this.isJumping)
+        {
+            if (this.onGround && this.jumpTicks == 0)
+            {
+                this.jump();
+                this.jumpTicks = 10; //activate autojump cooldown (0.5s)
+            }
+        }
+        else { this.jumpTicks = 0; }
+        this.moveEntityWithHeading(this.moveStrafing, this.moveForward);
+    }
+```
+
+## Nonrecursive Movement Formulas
+
+Definitions:
+
+- v_0 is the player's initial speed (speed on t_0, before jumping).
+- t is the number of ticks considered (e.g. flat ground jump duration is t=12).
+- J is the "jump bonus": 0.3274 for sprintjump, 0.291924 for strafed sprintjump, 0.1 for 45 degree no-sprint jump.
+- M is the movement multiplier after jumping: 1.3 for 45 degree sprint, 1.274 for normal sprint, 1.0 for no-sprint 45 degree.
+
+### Vertical Movement (jump) [1.8], for t >= 6
+
+```
+V_Y(t)   = 4 * 0.98^(t-5) - 3.92
+Y_rel(t) = (197.4 - 217*0.98^5) [jumppeak] + 200*(0.98 - 0.98^(t-4)) - 3.92*(t-5)
+```
+
+### Vertical Movement (jump) [1.9+], for t >= 1
+
+```
+V_Y(t)   = 0.42*0.98^(t-1) + 4*0.98^t - 3.92
+Y_rel(t) = 217*(1 - 0.98^t) - 3.92*t        (for t >= 0)
+```
+
+### Horizontal Movement (instant jump)
+
+Assuming airborne before jumping, t >= 2:
+
+```
+V_H(v_0, t)  = 0.02M/0.09 + 0.6*0.91^t * ( v_0 + J/0.91 - 0.02M/(0.6*0.91*0.09) )
+Dist(v_0, t) = 1.91*v_0 + J + (0.02M/0.09)*(t-2) + (0.6*0.91^2/0.09) * (1 - 0.91^(t-2)) * ( v_0 + J/0.91 - 0.02M/(0.6*0.91*0.09) )
+```
+
+### Horizontal Movement (delayed jump)
+
+Assuming on ground at least 1 tick before jumping, t >= 2:
+
+```
+V_H*(v_0, t)  = 0.02M/0.09 + 0.6*0.91^t * ( 0.6*v_0 + J/0.91 - 0.02M/(0.6*0.91*0.09) )
+Dist*(v_0, t) = 1.546*v_0 + J + (0.02M/0.09)*(t-2) + (0.6*0.91^2/0.09) * (1 - 0.91^(t-2)) * ( 0.6*v_0 + J/0.91 - 0.02M/(0.6*0.91*0.09) )
+```
+
+Note: these formulas are accurate for most values of v_0, but some negative values can activate the speed threshold and reset the player's speed, rendering them inaccurate.
+
+### Advanced
+
+Horizontal speed after n consecutive sprintjumps on a momentum of period T (n >= 0, T >= 2):
+
+```
+V_H^n(v_0, T, n) = (0.6*0.91^T)^n * v_0
+                 + ( 0.6*0.91^(T-1)*J + 0.02M*(1 - 0.91^(T-1))/0.09 ) * (1 - (0.6*0.91^T)^n)/(1 - 0.6*0.91^T)
+```
+
+If the first sprintjump is delayed, multiply v_0 by 0.6.
+
+General note (Movement Formulas page): these formulas are not exact due to how floats are computed; only the first 4 to 6 decimals should be considered accurate. For a completely accurate simulation, you must replicate the source code.

--- a/docs/reference/mcpk/02-angles-and-mouse.md
+++ b/docs/reference/mcpk/02-angles-and-mouse.md
@@ -1,0 +1,140 @@
+# Angles and Mouse Movement
+
+Mirrored from the Minecraft Parkour Wiki (mcpk.wiki); captured in-repo because the wiki is Cloudflare-gated. Reference, not implementation. Source pages: Ticks, Mouse Movement, Angles.
+
+## Ticks
+
+Ticks are the standard unit of time in Minecraft, with one tick being equal to 50 milliseconds.
+
+**Tickrate:** The physics engine runs at 20 ticks per second, meaning the game's physics are updated every 50ms. This includes the player's position and speed, the environment, and entities. In-game actions are performed at the end of each tick, regardless of the time or order in which they were called. Due to this, inputs may take up to 50ms of delay between the button press and their activation.
+
+**Turn Tick:** Mouse Movement is not inherently tied to tickrate, but rather the framerate. However, the game keeps a copy of the player's rotation for movement calculations, which it updates once every tick. The moment the player's rotation is copied is called the turn tick. From the player's perspective there is no way to control when the turn tick happens. This has a severe impact on turn-based jumps, which become partially luck-based: given the same smooth turning sequence, the resulting movement could be quite different. One solution is to turn instantly every 50ms to land precisely on the wanted angle. This is feasible for simple turn strats such as 45 degree strafes, but not for more complex strats that require smooth turning.
+
+## Mouse Movement
+
+Mouse movement represents the instant displacement of the cursor on the screen in pixels `(dx, dy)`. In Minecraft it represents the instant rotation of the camera in degrees `(delta_x, delta_y)`.
+
+**Sensitivity** `s` is a parameter that changes how fast the camera turns, set in the Controls menu.
+
+| Sensitivity | Value of s |
+| --- | --- |
+| Default "100%" | s = 0.5 |
+| Lowest vanilla "0%" | s = 0.0 |
+| Highest vanilla "200%" | s = 1.0 |
+
+In 1.8, `delta_x` is calculated as:
+
+```
+delta_x = 1.2 * dx * (0.6*s + 0.2)^3
+```
+
+`delta_y` is obtained the same way, multiplied by -1 if "Invert Mouse" is ON.
+
+With default sensitivity (s = 0.5), one pixel of mouse movement translates into 0.15 degrees of rotation. So the camera moves in increments of 0.15 degrees: to turn 45 degrees you would move your mouse by 300px.
+
+`s` is not technically bounded by `[0, 1]` and can take any value (even negative). You can manually edit `mouseSensitivity` in `options.txt`.
+
+Inverse formula for the required sensitivity for a desired increment `delta`:
+
+```
+s = ( cbrt(delta / 1.2) - 0.2 ) / 0.6
+```
+
+Remarkable values table:
+
+| delta (deg) | s |
+| --- | --- |
+| 0 | -0.3333333 |
+| 0.1 | 0.3946504 |
+| 0.15 | 0.5 |
+| 0.25 | 0.6546926 |
+| 0.5 | 0.9115013 |
+| 1 | 1.2350600 |
+| 45 | 5.2452746 |
+| 180 | 8.5221547 |
+
+**Yaw and Pitch:** Yaw (horizontal rotation) and pitch (vertical rotation) are floats that keep track of an entity's head rotation. Facing is the restriction of the yaw to `[-180, 180]`, as represented in F3. Pitch is naturally clamped between `[-90, 90]`. Mouse movement directly modifies yaw and pitch:
+
+```java
+/* In EntityRenderer.java */
+public void updateMouseMovement(...)
+{
+    float f = this.mc.gameSettings.mouseSensitivity * 0.6F + 0.2F;
+    float mult = f * f * f * 8.0F;
+    float dX = (float)this.mc.mouseHelper.deltaX * mult;
+    float dY = (float)this.mc.mouseHelper.deltaY * mult;
+    int i = 1;
+    if (this.mc.gameSettings.invertMouse) i = -1;
+    this.mc.thePlayer.rotateEntity(dX, dY*i);
+}
+/* In Entity.java */
+public void rotateEntity(float dX, float dY)
+{
+    this.rotationYaw = this.rotationYaw + dX*0.15);
+    this.rotationPitch = this.rotationPitch - dY*0.15;
+    this.rotationPitch = MathHelper.clamp(this.rotationPitch, -90.0, 90.0);
+}
+```
+
+Pitch is clamped between -90 and 90 degrees, but yaw is NOT restricted to `[-180, 180]`; yaw is unbounded. Consequences of deliberately turning one direction long enough: by nature of being a float, precision worsens the bigger it gets.
+
+| Condition | Effect |
+| --- | --- |
+| `|yaw| > 4194304` (2^22) | yaw can only increase in increments of 0.5 deg |
+| `|yaw| > 8388608` (2^23) | yaw can only increase in increments of 1 deg |
+| `|yaw| >= 11796480` (= 360 * 2^15) | yaw gets too large to convert to a proper angle; movement stops the player in place |
+| `|yaw| > 8.59e9` | turning further can crash the game |
+
+## Angles
+
+The player's yaw is a float tracking horizontal rotation in degrees; it is unbounded. The player's facing is the restriction of the yaw to `[-180, 180]` degrees, as shown in F3. A significant angle, or simply angle, is an integer from 0 to 2^16 - 1.
+
+**Significant Angles:** Minecraft relies on significant angles for its trigonometry, so the player's yaw has to be converted to an angle. This conversion induces imprecision: a significant angle spans across ~0.0055 degrees.
+
+`Sin()` and `Cos()` source code (from class `MathHelper`):
+
+```java
+private static final float[] SIN_TABLE = new float[65536];
+public static float sin(float value) //in radians
+{
+    return SIN_TABLE[(int)(value * 10430.378F) & 65535];
+}
+public static float cos(float value) //in radians
+{
+    return SIN_TABLE[(int)(value * 10430.378F + 16384.0F) & 65535];
+}
+static
+{
+    for (int i = 0; i < 65536; ++i)
+    {
+        SIN_TABLE[i] = (float)Math.sin((double)i * Math.PI * 2.0D / 65536.0D);
+    }
+}
+```
+
+Note: `& 65535` gives the positive remainder of a division by 65536 (2^16). To convert the player's yaw into radians (when calling sin and cos), the game uses two formulas:
+
+```java
+// formula used in general
+f = this.rotationYaw * (float)Math.PI / 180.0F
+// formula used when adding sprintjump boost
+f = this.rotationYaw * 0.017453292F
+```
+
+Both have the same intent, but for large values the result may differ. In that case, sprintjumping moves the player slightly to the side, which may be useful for no-turn strats.
+
+**Half Angles:** `(int)(value * 10430.378F)` and `(int)(value * 10430.378F + 16384.0F)` should be 16384 units apart (90 deg), but because of floating point imprecision some values end up 1 or more units further, causing a slight shift from the intended calculation. Half angles are such values, found "between" consecutive angles. Their existence is entirely due to the `+ 16384` term being inside the parentheses. Each half-angle has an associated Multiplier representing its effectiveness, corresponding to the norm of the unit vector obtained from `cos(f)` and `sin(f)`; mathematically it should always equal 1, but it does not here. "Increasing" half angles have a norm greater than 1 (increase movement speed); "Decreasing" half angles have a norm lesser than 1 (decrease movement speed).
+
+```
+norm = sqrt( cos(f)^2 + sin(f)^2 )
+```
+
+When multiplied with a given jump distance, it gives an upper bound for the improved jump distance with its corresponding half-angle.
+
+**Large Half Angles:** On July 27 2021, kemytz discovered that certain yaws grant more speed when using Optifine Fast Math (a feature reducing significant angles down to 4096). This is not specific to fast math; vanilla "large half angles" were discovered soon after. Large half angles are more effective due to the low precision floats can work with at that range: instead of being shifted by a single unit, angles can be shifted by up to 64 units.
+
+Example: yaw 5898195 deg gives a multiplier of 1.003, huge compared to small half angles (135.0055 deg gives 1.00005). This is the most effective half angle that exists, making jumps like 2.125bm 4+0.5 possible. Reaching such values may require macros or mods.
+
+With Fast Math, half angles are further amplified and the player can move while their yaw is less than `360 * 2^19`, compared to `360 * 2^15` in vanilla. Example: yaw 121000000 deg gives a multiplier of 1.09, making flat momentum 5b possible; this relies on a mod and should not be considered official. New Optifine versions changed fast math, eliminating many FM half angles (since version U L5, December 2019).
+
+**Characterization:** Decreasing half angles are abundant between -90 and 0 degrees, because negative floats are truncated up while positive floats are truncated down. Decreasing half angles exist rarely between 0 and 90 degrees. Increasing half angles exist rarely between 90 and 180 degrees. Large half angles are of the form `360 * 2^n - theta`, with `theta` in `[0, 90]` and `n` in `{0, ..., 14}`. They are all increasing until `n >= 8`, at which point they may be increasing or decreasing.

--- a/docs/reference/mcpk/03-collisions-and-stepping.md
+++ b/docs/reference/mcpk/03-collisions-and-stepping.md
@@ -1,0 +1,63 @@
+# Collisions and Stepping
+
+Mirrored from the Minecraft Parkour Wiki (mcpk.wiki); captured in-repo because the wiki is Cloudflare-gated. Reference, not implementation. Source pages: Collisions, Stepping.
+
+## Collisions
+
+Minecraft's collision physics is very simplistic: instead of ray-tracing collisions, the game moves the player sequentially along each axis. Physics is updated 20 ticks per second; movement and collisions are updated once per tick.
+
+### Collision Box
+
+A collision box consists of one or multiple bounding boxes, which are cuboids defined by minimum and maximum X/Y/Z coordinates. Collisions usually involve an Entity and a Block; entities and blocks typically don't collide among themselves. The player has only one bounding box, 0.6 x 1.8 x 0.6 m^3; their position (as shown in F3) is at the bottom center. Blocks have more complicated collision boxes.
+
+Note: a "hitbox" is what the player can click on (attack an entity, press a button, open a door); it may or may not overlap with the collision box.
+
+### Collision Order
+
+Every tick, after the player's velocity has been updated, the game does these steps to check collisions:
+
+1. Move the player along the Y axis. If a vertical collision is detected while moving downward, the player is now considered to be on ground.
+2. Move the player along the X axis.
+3. Move the player along the Z axis.
+4. If the player is on ground and collided with a wall, they are able to step over it if it's less than 0.6m tall (see Stepping). This mechanic is responsible for Blips and Jump-Cancel, and their glitched variants.
+
+### Vertical Collisions (Y)
+
+Vertical movement is processed before horizontal movement. Due to this: the player is able to jump one tick after running off a block (this is why headhitter timing works). To land on a block, the player's bounding box must overlap its surface on the final tick of the jump. When the player hits a floor or ceiling, their vertical speed is reset to 0.
+
+### Horizontal Collisions (X/Z)
+
+The X axis is processed before the Z axis, so corner collisions don't behave the same depending on direction; this is especially noticeable with more speed. Distinguish "X-facing" jumps from "Z-facing":
+
+- X-facing: jumps pointing towards East/West. The corner is difficult to avoid, and the player may have to start jumping further back than expected.
+- Z-facing: jumps pointing towards North/South. The corner is easier to avoid, and it's possible to do a hh-timing from the front.
+
+The axis of a jump can be checked with F3. Players tend to find Z-facing neos more intuitive, but X-facing neos can be more lenient:
+
+- Z-facing neos are very similar to linear jumps (assuming optimal movement). To convert a neo, add 1.2 to its distance and increase its tier by one. For example a triple neo is equivalent to a "4.2+0.25" (which cannot be built, but is useful for analysis).
+- X-facing neos don't have a linear equivalent. Compared to Z-facing neos they are "shifted" by 1 tick (wall collision begins and ends 1 tick earlier). This shift reduces the momentum but makes it more efficient, as the player typically has more speed at the end of a jump than at the start.
+
+Some jumps are only possible facing one axis (for example, a 2bm triple neo is only possible X-facing).
+
+### 1.14+
+
+Collision physics were updated. The collision order now depends on the player's velocity: if the player has more Z speed than X speed (in absolute value), the order is Y-X-Z; otherwise it is Y-Z-X. In most cases all collisions now resemble X-facing. Some jumps involving cutting corners may be very different compared to pre-1.14.
+
+## Stepping
+
+Stepping, or Step-Assist, is a mechanic that assists the player in walking up obstacles of low height without jumping. The player's maximum step height is 0.6b, so they can step up blocks like carpets, slabs, and even beds. While simple in concept, the implementation is messy and introduces a wide range of collision-related glitches abused in parkour (Blips and Jump-Cancelling).
+
+### Summary
+
+The player's bounding box (0.6 x 1.8 x 0.6) is used to detect collisions (collision order is Y-X-Z). When a wall is detected while the player is on ground, the game attempts to make them "hop" over it. In the end, the game chooses the method that yields the longest horizontal distance.
+
+### Notes
+
+Prior to 1.8, the player couldn't step onto some blocks which had a ceiling above; to fix that, an alternative method was added to the stepping procedure. Prior to 1.8.1, stepping could be used to glitch into the floor, because the floor below the player's bounding box is never considered for collisions during step-assist, but the procedure could force the player below floor level anyway (the bounding box was lowered by 0.6b regardless of the amount it was elevated by); easier in 1.8.0 as you don't need a ceiling directly overhead. The current implementation of stepping is still somewhat flawed.
+
+### Related Glitches
+
+Stepping is intended for ground movement and works fine for walking up slabs and stairs. However, the game also tries to apply stepping at the start and end of any vertical motion, causing unintended mechanics:
+
+- Blipping can happen at the end of a jump, used to jump higher by landing above ground level.
+- Jump-Cancelling can happen at the start of a jump, used to gain momentum by staying at ground level.

--- a/docs/reference/mcpk/04-blocks-and-friction.md
+++ b/docs/reference/mcpk/04-blocks-and-friction.md
@@ -1,0 +1,152 @@
+# Blocks and Friction (mcpk.wiki reference)
+
+Mirrored from the Minecraft Parkour Wiki (mcpk.wiki); captured in-repo because the wiki is Cloudflare-gated. Reference, not implementation. Source pages: Blocks, Slipperiness, Soulsand, Cobweb, Ladders and Vines. All block data is for Minecraft 1.8.
+
+## Blocks
+
+A Block is a basic unit of structure occupying space in the world. A Collision Box is a solid volume of space the player is not meant to pass through, consisting of one or multiple Bounding Boxes (axis-aligned cuboids). Entities have their own bounding box but are not treated as solid space (except boats). Not to be confused with a Hitbox (a volume the player can interact with: attack, mine, right-click) or a Model (graphical representation). Some blocks have their own "effect box" (fluids, ladders, cacti, pressure plates) coded and applied differently. Example: a button has no collision box (player can walk through) but has a hitbox. A barrier block has overlapping bounding box and hitbox but is hard-coded to have no model. This lists collision boxes and properties of all blocks in 1.8.
+
+### Simple Collision Boxes (single bounding box)
+
+| Block | Widths (b) | Height (b) | Comments |
+| --- | --- | --- | --- |
+| Wall (4-sided) | 1 x 1 | 1.5 | Adjacent blocks must be solid, walls, or fencegates. |
+| Default | 1 x 1 | 1 | |
+| Soulsand | 1 x 1 | 0.875 | Looks like a full block but is 2px lower. Slows entities walking on top. |
+| End Portal Frame | 1 x 1 | 0.8125 | |
+| Enchantment Table | 1 x 1 | 0.75 | |
+| Bed block | 1 x 1 | 0.5625 | The bottom doesn't look tangible but it is. |
+| Slab | 1 x 1 | 0.5 | Inversible. |
+| Daylight Sensor | 1 x 1 | 0.375 | |
+| Trapdoor (horizontal) | 1 x 1 | 0.1875 | Inversible. Can be flipped to its vertical variant. |
+| Repeater | 1 x 1 | 0.125 | |
+| Carpet | 1 x 1 | 0.0625 | |
+| Lily Pad | 1 x 1 | 0.015625 | Is 1/4 of a pixel in height. |
+| Snow Layer | 1 x 1 | 0, 0.125, 0.25, 0.375, 0.5, 0.625, 0.75, 0.875 | Snow layers look 2px higher than their real height. Despite having no height, a single layer of snow is tangible. |
+| Wall (3-sided) | 1 x 0.75 | 1.5 | Orientable (4 variants). Adjacent blocks must be solid, walls, or fencegates. |
+| Anvil | 1 x 0.75 | 1 | Centered. Orientable (2 variants). Looks thinner than it is. |
+| Piston Base (Powered) | 1 x 0.75 | 1 | Orientable (4 variants). |
+| Wall (2-opposite) | 1 x 0.375 | 1.5 | Centered. Orientable (2 variants). Adjacent blocks must be solid, walls, or fencegates. Placing a block on top doesn't change its collision box. |
+| Fence (2-opposite) | 1 x 0.25 | 1.5 | Centered. Orientable (2 variants). Adjacent blocks must be solid, fences, or fencegates. |
+| Fencegate | 1 x 0.25 | 1.5 | Centered. Orientable (2 variants). Can be flipped to a variant with no collision box. |
+| Trapdoor (vertical) | 1 x 0.1875 | 1 | Orientable, Inversible (8 variants). Can be flipped to its horizontal variant. |
+| Door | 1 x 0.1875 | 1 | Orientable (4 variants). Can be flipped to another variant. |
+| Ladder | 1 x 0.125 | 1 | Orientable (4 variants). Can be climbed by entities. |
+| Pane (2-opposite) | 1 x 0.125 | 1 | Centered. Orientable (2 variants). Adjacent blocks must be solid, or panes/bars. |
+| Chest (long) | 0.9375 x 0.875 | 0.875 | Must be next to another chest. |
+| Dragon Egg | 0.875 x 0.875 | 1 | Centered. Looks drastically different from its collision box. |
+| Cactus | 0.875 x 0.875 | 0.9375 | Centered. Hurts entities close to it. |
+| Chest | 0.875 x 0.875 | 0.875 | Centered. |
+| Cake | 0.875 x 0.875, 0.875 x 0.75, 0.875 x 0.625, 0.875 x 0.5, 0.875 x 0.375, 0.875 x 0.25, 0.875 x 0.125 | 0.5 | The full cake is centered. Each bite takes away 0.125b from the West (-X). |
+| Wall (2-adjacent) | 0.75 x 0.75 | 1.5 | Orientable (4 variants). Adjacent blocks must be solid, walls, or fencegates. |
+| Wall (1-sided) | 0.75 x 0.5 | 1.5 | Orientable (4 variants). Adjacent block must be solid, a wall, or a fencegate. |
+| Fence (1-sided) | 0.625 x 0.25 | 1.5 | Orientable (4 variants). Adjacent block must be solid, a fence, or a fencegate. |
+| Wall (default) | 0.5 x 0.5 | 1.5 | Centered. |
+| Cocoa (big) | 0.5 x 0.5 | Low: 0.1875, Top: 0.75 | Orientable (4 variants). 1px away from the wall it's attached to. Top texture is only 7px wide. |
+| Head (walled) | 0.5 x 0.5 | Low: 0.25, Top: 0.75 | Orientable (4 variants). |
+| Head (default) | 0.5 x 0.5 | 0.5 | Centered. A head can be placed diagonally (16 variants total) but the collision box doesn't change. |
+| Pane (1-sided) | 0.5 x 0.125 | 1 | Orientable (4 variants). Appears 1px longer than it is. Adjacent block must be solid, or a pane/bar. |
+| Cocoa (medium) | 0.375 x 0.375 | Low: 0.3125, Top: 0.75 | Orientable (4 variants). 1px away from the wall it's attached to. |
+| Flowerpot | 0.375 x 0.375 | 0.375 | Centered. |
+| Fence (default) | 0.25 x 0.25 | 1.5 | Centered. |
+| Cocoa (small) | 0.25 x 0.25 | Low: 0.4375, Top: 0.75 | Orientable (4 variants). 1px away from the wall it's attached to. |
+
+### Composite Collision Boxes (two or more bounding boxes)
+
+"Except" represents an intangible zone rather than a tangible one.
+
+| Block | Widths (b) | Height (b) | Comments |
+| --- | --- | --- | --- |
+| Stair (normal) | Base: 1 x 1, Top: 1 x 0.5 | Base: 0.5, Top: 1 | Orientable, Inversible (8 variants). |
+| Stair (outer) | Base: 1 x 1, Top: 0.5 x 0.5 | Base: 0.5, Top: 1 | Orientable, Inversible (8 variants). Depends on adjacent stair blocks. |
+| Stair (inner) | Base: 1 x 1, Except: -0.5 x -0.5 | Base: 1, Except: -0.5 | Orientable, Inversible (8 variants). Depends on adjacent stair blocks. |
+| End Portal Frame (eye) | Base: 1 x 1, Eye: 0.375 x 0.375 | Base: 0.8125, Eye: 1 | The eye appears 8px wide but is actually 6px wide. |
+| Hopper | Base: 1 x 1, Except: -0.75 x -0.75 | Base: 1, Except: -0.375 | The bottom is tangible. Interior floor is 1px lower than it looks. |
+| Cauldron | Base: 1 x 1, Except: -0.75 x -0.75 | Base: 1, Except: -0.6875 | The bottom is tangible. Interior floor is 1px higher than it looks. |
+| Brewing Stand | Base: 1 x 1, Rod: 0.125 x 0.125 | Base: 0.125, Rod: 0.875 | |
+| Piston Head (Vertical) | Head: 1 x 1, Arm: 0.25 x 0.25 | Head: 0.25, Top: 1 | Centered. Inversible. Arm shorter than it looks (model extended by 4px). |
+| Piston Head (N/S/E) | Head: 1 x 0.25, Arm: 0.75 x 0.5 | Head: 1, Arm-Low: 0.375, Arm-Top: 0.625 | Orientable (3 variants). Arm wider than it looks (0.5m). Arm shorter than it looks (model extended 4px). |
+| Piston Head (West) | Head: 1 x 0.25, Arm: 0.75 x 0.25 | Head: 1, Arm-Low: 0.25, Arm-Top: 0.75 | Bugged (fixed in 1.9). The player can walk through a west extended piston. In 1.9 piston heads match their model. |
+| Fence (4-sided) | Post: 0.25 x 0.25, Sides: 0.375 x 0.25 | 1.5 | Adjacent blocks must be solid, fences, or fencegates. |
+| Fence (3-sided) | Post: 0.25 x 0.25, Sides: 0.375 x 0.25 | 1.5 | Orientable (4 variants). |
+| Fence (2-adjacent) | Post: 0.25 x 0.25, Sides: 0.375 x 0.25 | 1.5 | Orientable (4 variants). |
+| Pane (Default / 4-sided) | Sides: 0.5 x 0.125 | 1 | Adjacent blocks must be solid, or panes/bars. |
+| Pane (3-sided) | Sides: 0.5 x 0.125 | 1 | Orientable (4 variants). |
+| Pane (2-adjacent) | Sides: 0.5 x 0.125 | 1 | Orientable (4 variants). The exterior corner has a 1px wide opening. |
+
+### Other
+
+| Block | Widths (b) | Height (b) | Comments |
+| --- | --- | --- | --- |
+| Boat | 1.5 x 1.5 | 0.6 | Entity. |
+
+## Slipperiness
+
+Each block has a Slipperiness factor S. The greater S, the slipperier. By default S = 0.6 (includes air, soulsand, cobwebs, fluids). In 1.8 the only blocks with different slipperiness are: Ice and Packed Ice S = 0.98; Slime Blocks S = 0.8. In 1.13 Blue Ice was added, S = 0.989 (most slippery in the game).
+
+Effect on Movement: when moving, the player loses some speed between ticks (drag) and gains acceleration. On ground: the amount of speed conserved on ground is scaled by 0.91 * S. The acceleration gained on ground is proportional to (0.6/S)^3. When airborne, slipperiness is ignored.
+
+| Block | Slipperiness S |
+| --- | --- |
+| Default | 0.6 |
+| Slime | 0.8 |
+| Ice / Packed Ice | 0.98 |
+| Blue Ice [1.13+] | 0.989 |
+
+Application: every tick, if on ground, the game checks the block directly 1b below the player's position to get slipperiness. Partial blocks are affected by the slipperiness of the block below them (e.g. a slab above Ice has the same slipperiness as the Ice). Soulsand is a non-full block (14px tall) so it gets its slipperiness from the block below it. Two effects: slippery blocks grant less acceleration; soulsand reduces speed conservation; combined they create a net negative impact, so walking on soulsand with ice below is noticeably slower.
+
+Changes: In 1.15, slipperiness is taken 0.5m below the player (instead of 1.0m). Soulsand is no longer affected by slipperiness, among other blocks. A slab (0.5b height) is still affected; a bed (0.5625b height) is no longer affected.
+
+## Soulsand
+
+Soulsand is a special block that slows down entities walking on it. Soulsand is 0.875b tall, so it's affected by the slipperiness of ice and slime blocks; walking on soulsand with ice or slime below is slower than regular soulsand. Soulsand slows down entities by multiplying their horizontal velocity by 0.4 at the end of each tick. This can be applied even when airborne, notably on the last tick of a jump. The only requirement is that the player's bounding box collides with the voxel occupied by the soulsand (minus 0.001m on each side). The effect is cumulative: the 0.4 multiplier is applied for each soulsand block the player is standing on, so it's slightly slower to walk on the seam between two soulsand blocks. The player can stand on the outer edge of soulsand (up to 0.001m) without being slowed.
+
+Code:
+
+```java
+/* In Entity.java, called at the end of each tick (from Entity.moveEntity) */
+protected void doBlockCollisions()
+{
+    BlockPos posMin = new BlockPos(this.minX+0.001, this.minY+0.001, this.minZ+0.001);
+    BlockPos posMax = new BlockPos(this.maxX-0.001, this.maxY-0.001, this.maxZ-0.001);
+    for (int i = posMin.getX(); i <= posMax.getX(); ++i)
+        for (int j = posMin.getY(); j <= posMax.getY(); ++j)
+            for (int k = posMin.getZ(); k <= posMax.getZ(); ++k)
+            {
+                BlockPos pos = new BlockPos(i, j, k);
+                Block block = getBlockState(pos);
+                block.onEntityCollidedWithBlock(this);
+            }
+}
+/* In BlockSoulSand.java */
+public void onEntityCollidedWithBlock(Entity entityIn)
+{
+    entityIn.motionX *= 0.4;
+    entityIn.motionZ *= 0.4;
+    //NOTE: each soulsand block applies this effect individually.
+}
+```
+
+Version Differences: 1.13 generates upward bubble columns when placed underwater. 1.15 major changes: no longer affected by slipperiness (as are all blocks of height > 0.5b); slowdown now only applies to the inner surface (the 0.3m perimeter acts as a normal block); slowdown applies when the player is standing less than 0.5b above it (includes standing on a slab); inside a soulsand block there are intermediate floors at heights 0.125, 0.25, 0.375, 0.5, 0.625, 0.75 (the first four affected by slipperiness).
+
+## Cobweb
+
+The Cobweb slows down entities moving through it. Cobwebs are intangible (player can move through, no collision box) but have an "effect box" 0.001b smaller than a full block. If the player's bounding box intersects this effect box, their velocity is set to 0 and movement is hindered (effect applies if overlap is more than 0.001m). The player can stand next to a cobweb if at most 0.001m away from the edge.
+
+Vertical Movement: Vertical speed is slowed by a factor of 20 and is reset every tick. Jumping is severely limited, reaching just 0.021m in height. The player then immediately falls at a constant speed of -0.00392 m/t.
+
+Horizontal Movement: Horizontal speed is slowed by a factor of 4 and reset every tick. The player moves at a constant 0.03185 m/t when sprinting on ground, or 0.00637 m/t while airborne. With 45 strafe: 0.0325 m/t sprinting on ground, 0.0065 m/t airborne.
+
+Calculations: 0.42 / 20 = 0.021; (-0.08*0.98) / 20 = -0.00392; (0.098 * 1.3 * 0.2) / 4 = 0.03185; (0.1 * 1.3 * 0.2) / 4 = 0.0325.
+
+## Ladders and Vines
+
+Ladders are special blocks that allow entities to climb them. Vines (added Beta 1.8) share the same properties but have no collision.
+
+Strategy: when attempting a ladder jump, always sneak at the end of the jump. Don't sneak too late (won't catch the ladder) or too early (slows you down before reaching the ladder).
+
+Collision Box: a ladder's collision box is 2 pixels wide. Ladders are 2px wide (0.125b), 1 block high, 1 block long, resting 1px away from the wall. Vines are intangible (player moves through).
+
+Properties: while the player's coordinates are within a ladder's voxel, vertical movement is affected: colliding with any wall makes the player climb at a constant rate of 0.1176 b/t (0.12 * 0.98); sneaking prevents the player from falling. Horizontal movement: horizontal speeds (X/Z) are capped at 0.15 b/t; vertical speed (Y) has a lower bound of -0.15 b/t.
+
+Changes (1.9+): In 1.9, ladders were made larger by 1px, new bounding box comparable to trapdoors (3px wide, 0.1875b). In 1.14, the player can climb ladders and vines by pressing jump, making ladder jumps feel easier.

--- a/docs/reference/mcpk/05-status-effects-tiers-jumps.md
+++ b/docs/reference/mcpk/05-status-effects-tiers-jumps.md
@@ -1,0 +1,221 @@
+# Status Effects, Tiers, and Longest Jumps
+
+Mirrored from the Minecraft Parkour Wiki (mcpk.wiki); captured in-repo because the wiki is Cloudflare-gated. Reference, not implementation. Source pages: Status Effects, Tiers, Longest Jumps.
+
+## Status Effects
+
+The 3 main status effects relevant to parkour. Applied from most potions, some beacon effects, or the /effect command. Effect command: /effect <player> <effect> <Duration> <Level-1>.
+
+### Speed
+
+Speed increases the player's ground speed, making them move 20% faster per level. Speed does not affect airborne movement, so sprint-jumping becomes less efficient the higher the level (for Speed II, generally slower to sprint-jump than to run).
+
+| Speed Level | Max Walking Speed m/t | Max Sprinting Speed m/t |
+| --- | --- | --- |
+| None | 0.215 | 0.280 |
+| I | 0.259 | 0.336 |
+| II | 0.302 | 0.392 |
+| III | 0.345 | 0.448 |
+| IV | 0.388 | 0.505 |
+
+Speed presented in meters per tick (m/t); multiply by 20 for m/s. For max ground speed with 45 strafe, divide by 0.98.
+
+### Slowness
+
+Slowness slows the player's ground speed, 15% slower per level. Does not change airborne movement, so sprint-jumping is more efficient.
+
+| Slowness Level | Max Walking Speed m/t | Max Sprinting Speed m/t |
+| --- | --- | --- |
+| None | 0.215 | 0.280 |
+| I | 0.183 | 0.238 |
+| II | 0.151 | 0.196 |
+| III | 0.118 | 0.154 |
+| IV | 0.086 | 0.112 |
+| V | 0.053 | 0.070 |
+| VI | 0.021 | 0.028 |
+| VII | 0.000 | 0.000 |
+
+Multiply by 20 for m/s; divide by 0.98 for max ground speed with 45 strafe. Past level 7 (VII), Slowness completely stops the player.
+
+### Speed and Slowness Interaction
+
+Speed and Slowness multipliers multiply, not add. Example: Speed III (+60%) and Slowness IV (-60%) gives not +0% but -34%.
+
+### Jump Boost
+
+Jumping sets the player's vertical speed to 0.42 by default. Jump boost increases this initial vertical boost by 0.1 per level.
+
+| Jump Boost Level | Max Height m | Duration t on flat ground |
+| --- | --- | --- |
+| None | 1.249 | 12 |
+| I | 1.836 | 14 |
+| II | 2.516 | 16 |
+| III | 3.290 | 19 |
+| IV | 4.153 | 21 |
+| V | 5.103 | 23 |
+
+Notes: In 1.9+ the default jump height is 1.252m, but that does not change jump height with jump boost in general. Past level 129, Jump Boost becomes negative (player unable to jump unless using negative speed to bounce on a slime block). Levels 252-256 the player can jump again with reduced height; level 256 has the same jump height as default.
+
+## Tiers
+
+Because Minecraft's physics is tick-based, the player's movement is not updated continuously. Some jumps are identical in difficulty despite different heights. For example +0.5 and +0.75 jumps of the same length have equal difficulty, because the player lands at Y=0.7532 either way. The range of heights matching the same difficulty corresponds to a Tier.
+
+By convention: Tier 0 contains the default height (+0.0); positive Tiers correspond to positive heights; negative Tiers to negative heights.
+
+On flat ground (Tier 0) a jump lasts 12 ticks. Convert duration to tiers: Tier = 12 - Duration.
+
+### Jump Heights per Duration
+
+The reason the height peak is higher in 1.9+ is because the momentum threshold was lowered to 0.003 and no longer affects jumping.
+
+| Duration (ticks) | Height (1.8) | Height (1.9+) | Maximum Tier | Tier Updates |
+| --- | --- | --- | --- | --- |
+| 1 | 0.0 | 0.0 | - | |
+| 2 | 0.4200 | 0.4200 | - | |
+| 3 | 0.7532 | 0.7532 | - | |
+| 4 | 1.0013 | 1.0013 | - | |
+| 5 | 1.1661 | 1.1661 | - | |
+| 6 | 1.2492 | 1.2492 | - | |
+| 7 | 1.2492 | 1.2522 | 5 | 1.25 |
+| 8 | 1.1708 | 1.1768 | 4 | |
+| 9 | 1.0156 | 1.0244 | 3 | |
+| 10 | 0.7850 | 0.7967 | 2 | |
+| 11 | 0.4807 | 0.4952 | 1 | |
+| 12 | 0.1041 | 0.1213 | 0 | |
+| 13 | -0.3434 | -0.3235 | -1 | |
+| 14 | -0.8604 | -0.8379 | -2 | |
+| 15 | -1.4454 | -1.4203 | -3 | -1.4375 |
+| 16 | -2.0971 | -2.0695 | -4 | |
+| 17 | -2.8142 | -2.7841 | -5 | -2.8125 |
+| 18 | -3.5953 | -3.5628 | -6 | |
+| 19 | -4.4392 | -4.4044 | -7 | -4.4375 |
+| 20 | -5.3446 | -5.3075 | -8 | -5.3125 |
+| 21 | -6.3104 | -6.2709 | -9 | |
+| 22 | -7.3352 | -7.2935 | -10 | -7.3125 |
+| 23 | -8.4179 | -8.3740 | -11 | -8.375 |
+| 24 | -9.5573 | -9.5114 | -12 | |
+| 25 | -10.7524 | -10.7043 | -13 | -10.75 |
+| 26 | -12.0020 | -11.9518 | -14 | -12.0 |
+| 27 | -13.3050 | -13.2528 | -15 | |
+| 28 | -14.6603 | -14.6062 | -16 | -14.625 |
+| 29 | -16.0669 | -16.0108 | -17 | -16.0625 |
+| 30 | -17.5238 | -17.4658 | -18 | -17.5 |
+| 31 | -19.0299 | -18.9701 | -19 | -19.0 |
+| 32 | -20.5843 | -20.5227 | -20 | -20.5625 |
+| 33 | -22.1861 | -22.1226 | -21 | -22.125 |
+| 34 | -23.8341 | -23.7690 | -22 | -23.8125 |
+| 35 | -25.5277 | -25.4608 | -23 | -25.5 |
+| 36 | -27.2657 | -27.1972 | -24 | -27.25 |
+| 37 | -29.0474 | -28.9772 | -25 | -29.0 |
+| 38 | -30.8719 | -30.8001 | -26 | -30.8125 |
+| 39 | -32.7383 | -32.6649 | -27 | -32.6875 |
+| 40 | -34.6457 | -34.5708 | -28 | -34.625 |
+| 41 | -36.5934 | -36.5170 | -29 | -36.5625 |
+| 42 | -38.5806 | -38.5026 | -30 | -38.5625 |
+| 43 | -40.6064 | -40.5270 | -31 | -40.5625 |
+| 44 | -42.6701 | -42.5893 | -32 | -42.625 |
+| 45 | -44.7709 | -44.6887 | -33 | -44.75 |
+| 46 | -46.9081 | -46.8245 | -34 | -46.875 |
+| 47 | -49.0810 | -48.9960 | -35 | -49.0625, -49.0 |
+| 48 | -51.2888 | -51.2025 | -36 | -51.25 |
+| 49 | -53.5308 | -53.4432 | -37 | -53.5 |
+| 50 | -55.8064 | -55.7176 | -38 | -55.75 |
+| 51 | -58.1149 | -58.0248 | -39 | -58.0625 |
+| 52 | -60.4556 | -60.3643 | -40 | -60.4375, -60.375 |
+| 53 | -62.8279 | -62.7354 | -41 | -62.8125, -62.75 |
+| 54 | -65.2312 | -65.1375 | -42 | -65.1875 |
+| 55 | -67.6648 | -67.5700 | -43 | -67.625 |
+| 56 | -70.1281 | -70.0322 | -44 | -70.125, -70.0625 |
+| 57 | -72.6205 | -72.5235 | -45 | -72.5625 |
+| 58 | -75.1416 | -75.0435 | -46 | -75.125, -75.0625 |
+| 59 | -77.6905 | -77.5914 | -47 | -77.6875, -77.625 |
+| 60 | -80.2670 | -80.1668 | -48 | -80.25, -80.1875 |
+| 61 | -82.8702 | -82.7690 | -49 | -82.8125 |
+| 62 | -85.4998 | -85.3977 | -50 | -85.4375 |
+| 63 | -88.1553 | -88.0521 | -51 | -88.125, -88.0625 |
+| 64 | -90.8360 | -90.7319 | -52 | -90.8125, -90.75 |
+| 65 | -93.5415 | -93.4364 | -53 | -93.5, -93.4375 |
+| 66 | -96.2713 | -96.1653 | -54 | -96.25, -96.1875 |
+| 67 | -99.0249 | -98.9180 | -55 | -99.0, -98.9375 |
+| 68 | -101.8018 | -101.6940 | -56 | -101.75 |
+| 69 | -104.6016 | -104.4929 | -57 | -104.5625, -104.5 |
+| 70 | -107.4237 | -107.3143 | -58 | -107.375 |
+| 71 | -110.2679 | -110.1576 | -59 | -110.25, -110.1875 |
+| 72 | -113.1336 | -113.0224 | -60 | -113.125, -113.0625 |
+| 73 | -116.0203 | -115.9084 | -61 | -116.0, -115.9375 |
+| 74 | -118.9277 | -118.8150 | -62 | -118.875 |
+| 75 | -121.8554 | -121.7419 | -63 | -121.8125, -121.75 |
+| 76 | -124.8029 | -124.6887 | -64 | -124.75 |
+| 77 | -127.7698 | -127.6549 | -65 | -127.75, -127.6875 |
+| 78 | -130.7559 | -130.6402 | -66 | -130.75, -130.6875 |
+| 79 | -133.7606 | -133.6442 | -67 | -133.75, -133.6875 |
+| 80 | -136.7836 | -136.6665 | -68 | -136.75, -136.6875 |
+| 81 | -139.8245 | -139.7068 | -69 | -139.8125, -139.75 |
+| 82 | -142.8831 | -142.7647 | -70 | -142.875, -142.8125 |
+| 83 | -145.9588 | -145.8398 | -71 | -145.9375, -145.875 |
+| 84 | -149.0515 | -148.9318 | -72 | -149.0, -148.9375 |
+| 85 | -152.1606 | -152.0403 | -73 | -152.125, -152.0625 |
+| 86 | -155.2861 | -155.1651 | -74 | -155.25, -155.1875 |
+| 87 | -158.4273 | -158.3058 | -75 | -158.375, -158.3125 |
+| 88 | -161.5842 | -161.4621 | -76 | -161.5625, -161.5 |
+| 89 | -164.7564 | -164.6337 | -77 | -164.75, -164.6875 |
+| 90 | -167.9434 | -167.8202 | -78 | -167.9375, -167.875 |
+| 91 | -171.1452 | -171.0214 | -79 | -171.125, -171.0625 |
+| 92 | -174.3613 | -174.2370 | -80 | -174.3125, -174.25 |
+| 93 | -177.5915 | -177.4666 | -81 | -177.5625, -177.5 |
+| 94 | -180.8355 | -180.7101 | -82 | -180.8125, -180.75 |
+| 95 | -184.0930 | -183.9671 | -83 | -184.0625, -184.0 |
+| 96 | -187.3638 | -187.2374 | -84 | -187.3125, -187.25 |
+| 97 | -190.6475 | -190.5206 | -85 | -190.625, -190.5625 |
+| 98 | -193.9440 | -193.8166 | -86 | -193.9375, -193.875 |
+| 99 | -197.2529 | -197.1251 | -87 | -197.25, -197.1875 |
+| 100 | -200.5741 | -200.4458 | -88 | -200.5625, -200.5 |
+| 101 | -203.9072 | -203.7784 | -89 | -203.875, -203.8125 |
+| 102 | -207.2521 | -207.1229 | -90 | -207.25, -207.1875, -207.125 |
+| 103 | -210.6085 | -210.4788 | -91 | -210.5625, -210.5 |
+| 104 | -213.9761 | -213.8460 | -92 | -213.9375, -213.875 |
+| 105 | -217.3548 | -217.2243 | -93 | -217.3125, -217.25 |
+| 106 | -220.7443 | -220.6134 | -94 | -220.6875, -220.625 |
+| 107 | -224.1445 | -224.0132 | -95 | -224.125, -224.0625 |
+| 108 | -227.5550 | -227.4233 | -96 | -227.5, -227.4375 |
+| 109 | -230.9757 | -230.8436 | -97 | -230.9375, -230.875 |
+| 110 | -234.4064 | -234.2740 | -98 | -234.375, -234.3125 |
+| 111 | -237.8469 | -237.7141 | -99 | -237.8125, -237.75 |
+| 112 | -241.2970 | -241.1638 | -100 | -241.25, -241.1875 |
+| 113 | -244.7565 | -244.6229 | -101 | -244.75, -244.6875, -244.625 |
+| 114 | -248.2252 | -248.0913 | -102 | -248.1875, -248.125 |
+| 115 | -251.7029 | -251.5686 | -103 | -251.6875, -251.625 |
+| 116 | -255.1895 | -255.0549 | -104 | -255.1875, -255.125, -255.0625 |
+
+## Longest Jumps
+
+The longest jump configurations for each tier. Momentum is assumed to use flat ground, 45 strafe, and an optimal half angle.
+
+Formula to convert a jump's distance from block form to meters:
+
+```
+Dist(dx, dz) = sqrt( max(0, dx - 0.6)^2 + max(0, dz - 0.6)^2 )
+```
+
+Reminder: 1 pixel = 1/16 block = 0.0625b. Example: a configuration of (X:64 Z:32) maps to a 4x2 gap.
+
+Configurations are given in pixels, with their margin (between their distance and the max jump distance for that tier). Often the true margin is a bit smaller because half angles are less efficient for diagonal jumps.
+
+### Longest Jump per Tier with Flat Momentum
+
+| Tier | Height Range | Max Distance | Longest Jump (px) | Margin | Verification |
+| --- | --- | --- | --- | --- | --- |
+| 5 | +1.171 to +1.249 | 2.6861854m | 51 x 21 | 0.002380 | |
+| 4 | +1.016 to +1.170 | 3.0210507m | 57 x 19 | 0.000858 | |
+| 3 | +0.786 to +1.015 | 3.3517794m | 62 x 21 | 0.000171 | 3.875 x 1.3125 + 1 |
+| 2 | +0.481 to +0.785 | 3.6787438m | 60 x 40 | 0.000089 | 3.75 x 2.5 + 0.75 |
+| 1 | +0.105 to +0.480 | 4.0022827m | 60 x 49 | 0.003982 | |
+| 0 | -0.343 to +0.104 | 4.3227043m | 65 x 51 | 0.000198 | 4.0625 x 3.1875 |
+| -1 | -0.860 to -0.344 | 4.6402892m | 82 x 26 | 0.000650 | |
+| -2 | -1.445 to -0.861 | 4.9552927m | 81 x 44 | 0.001869 | |
+| -3 | -2.097 to -1.446 | 5.2679471m | 83 x 51 | 0.001040 | |
+| -4 | -2.814 to -2.098 | 5.5784640m | 87 x 54 | 0.001544 | |
+| -5 | -3.595 to -2.815 | 5.8870355m | 100 x 36 | 0.001035 | |
+| -104 | at most -255.190 | 34.6872685m | 550 x 136 | 0.000663 | 34.375 x 8.5 - 255.25 |
+
+Notes: Tier -104 is debatable because there are 4 longer jumps technically within the margin but unbuildable (too diagonal, half angles less effective). More jumps can be built if walled jumps are considered, some longer than those listed.

--- a/docs/reference/mcpk/06-timings-momentum-glitches.md
+++ b/docs/reference/mcpk/06-timings-momentum-glitches.md
@@ -1,0 +1,125 @@
+# Timings, Momentum, and Glitches
+
+Mirrored from the Minecraft Parkour Wiki (mcpk.wiki); captured in-repo because the wiki is Cloudflare-gated. Reference, not implementation. Source pages: Timings, Tapping, Backward Momentum, Anvil/Chest Manipulation, Ceiling Hover.
+
+## Timings
+
+Timing is at the core of parkour: understanding how ticks work and how to use them for gaining momentum is crucial. Basic timings are elementary bricks for advanced strategies like Backward Momentum.
+
+**Randomness:** Because Minecraft's physics is tick-based, there is inevitable luck in timing. Timing inputs perfectly (intervals of exactly 50ms) reduces but never fully negates randomness. Use timings that grant the most consistent results. Example: a simple timing for a 1bm headhitter jump is the hh timing, which has only a 1 tick opening and no failsafe. The pessi hh timing has a more lenient opening and offers recovery time.
+
+**Notations:** t stands for tick. W, A, S, D refer to movement keys (W=Forward, A=Left, S=Backward, D=Right). Unless mentioned otherwise, the player is always sprinting.
+
+### Basic Timings
+
+| Name (and aliases) | Description | Notes |
+| --- | --- | --- |
+| 0t (jam) | Hold W, Jump on the same tick. | The most basic timing, used to initiate momentum. |
+| 1t (hh) | Hold W, Jump one tick later. | hh refers to the most common use, headhitter jumps. Can be used when no momentum is given. |
+| 2t | Hold W, Jump two ticks later. | Used on extremely short momentums, such as a backwalled ladder. |
+| Jump 0t (jump jam) | Hold Jump (double tap if low ceiling). Press and hold W when landing. | Gives the same jump distance as a regular jam timing. |
+| Jump 1t (jump hh, a7hh) | Hold Jump (double tap if low ceiling). Press and hold W 1 tick before landing. | Used on X-facing neos with very little momentum. With no ceiling, W is pressed 11 ticks after jumping. |
+| -1t (fast pessi hh) | Hold Jump. Press and hold W a tick later. | Notably used for 1bm hh, can be used on short momentums. Could be called "Jump 11t" but that is not a good notation. |
+| -2t (slow pessi hh) | Hold Jump. Press and hold W two ticks later. | -1t, -2t, and -3t will all clear a 1bm hh if performed from the back looking straight. Very consistent for headhitter jumps. |
+| Burst 0t (burst jam, adv jam) | Hold Sneak and W. Release Sneak and press Jump on the same tick. | Sneaking on an edge does not reset the player's speed. Jump distance increases with how long you sneak forward (converges very quickly). Generally you want a burst 1t instead. |
+| Burst 1t (burst hh, adv hh) | Hold Sneak and W. Release Sneak, press Jump one tick later. | Used on the edge of a block when no momentum is given. You gain ~41% more momentum when sneaking with 45 strafe. With this and 45, a no-momentum 3+1 becomes possible. |
+| 1t run | When landing, run for 1 tick before jumping again. | Used for specific jumps where it's better than jumping immediately, or when the momentum doesn't allow jumping immediately. |
+
+Note: "semi-hh" refers to the use of jam or jump jam in cases where accidentally performing them one tick late (hh or jump hh) is not detrimental.
+
+### Essential Timings
+
+| Name (Aliases) | Description | Notes |
+| --- | --- | --- |
+| Force Momentum (fmm) | Perform a jam or jump jam without sprinting. Press Sprint 1 tick later, keep holding Jump. | Used as a simple 1bm strat starting from the back. Can easily do jumps like 4b, very consistent. |
+| Carpet 4.5 (c4.5) | Perform a jam or jump jam without sprinting. Press Sprint 4 ticks later, do a 1t run before jumping again. | More complicated than force momentum but goes further. Name refers to its original use: 1bm 4+0.4375. Depending on momentum, press Sprint sooner or later. |
+
+Examples: 1bm 3+1 is possible with only running from the back (7t timing). 1bm 4b is possible with only running from the back (7t timing) if you first do a tap (preferably 4). Backwalled 1bm 4b is possible with only running from the back (5t timing) if you first do a tap (preferably 3). Performing a jam on 2bm overjumps the momentum slightly; to correct, start jumping at a ~10 degree angle, or sneak backward, release S for 3 ticks, then release sneak and jam forward. When gaining momentum under a 2-block ceiling (headhitter momentum) the ideal is to press jump every 3 ticks; with a trapdoor added (1.8125bc) the ideal is every 2 ticks (10 times per second).
+
+## Tapping
+
+Tapping involves pressing keys for very short amounts of time (usually 1 tick). It covers short distances, useful to set the player at an optimal position. The most common taps are the Shift tap, the Walk tap, and the Air Shift tap. The Sprint tap is mostly unused.
+
+- **Shift tap:** While sneaking (shifting), press the forward key for 1 tick.
+- **Walk tap:** Press the forward key for 1 tick.
+- **Sprint tap:** While sprinting, press the forward key for 1 tick.
+- **Air shift tap:** Jump while shifting, and press the forward key for 1 tick while mid-air.
+
+**Applications:** A backwalled 1bm 4b requires 1-3 taps from the back to be possible with only running momentum. An easy setup for 3bc 1bm backward momentum is to Walk tap then Shift tap from the front. A good strat for 3bm jumps is to perform 2 Shift taps from the back and run for 2 ticks before jumping.
+
+**Analysis:** When the forward key is released, the player continues moving for a short time, then stops due to Momentum Threshold: their X and Z speed decrease until their absolute value is smaller than 0.005, at which point they are set to 0. In 1.9+ the momentum threshold was lowered to 0.003 (down from 0.005), which makes all common taps longer by 1 tick, except the air shift tap which is extended by a whole 6 ticks. So tap strats are radically different in 1.9+.
+
+**Nomenclature:** abbreviate the 4 taps: S=Sprint tap, W=Walk tap, s=Shift tap, a=Air shift tap. Syntax: [Forwards taps]-[Backwards taps]. Example: "1 walk tap backwards, 1 shift tap, 2 air shift tap" becomes "s2a-W". Order does not matter as long as you don't do them in too quick succession.
+
+## Backward Momentum
+
+Backward Momentum (bwmm) maximizes the potential of a given momentum. The principle: maximize the player's forward speed at the end of the provided momentum, achieved by walking off the back of the momentum then jumping forward. On some setups, repeated executions (alternating back and forth) may be needed. It's possible to calculate an upper bound for the jump distance by maximizing the initial speed such that the player doesn't overjump the momentum. When a bwmm strat involves turning back and forth it is called Loop Momentum. For real-time parkour, no-turn strats are preferred for consistency.
+
+**Considerations:** whether to "delay" the final jump (running 1 tick off the edge instead of jumping immediately). Delaying conserves less speed but allows a small headstart. On short momentums (less than 0.4375bm), delaying is always better. On longer momentums, the choice depends on the height of the jump. Momentum Threshold is also a consideration; it can be helpful or detrimental depending on how velocity is affected.
+
+**Common 1bm Strats:** bwmm was originally created to solve the 1bm 4.375b jump (first with 3bc momentum, then with no ceiling). The most well-known 1bm strats were force momentum and c4.5 timing, but their efficiencies pale compared to bwmm strats (though force momentum and c4.5 are still useful and easier to set up). Common bwmm strats for 1bm: 3bc 1bm strat, Rex bwmm, Cyn bwmm, 1bm 5-1 strat.
+
+## Anvil/Chest Manipulation
+
+Anvils don't have a fixed collision box: there is a single collision box for all variants (North, East, South, West), updated whenever the player looks at one (or by other actions). Normal, slightly damaged, and very damaged anvils are not independent. Chests behave the same, though only Double Chests have a different collision box; Chests and Trapped Chests are independent. By standing next to an anvil/chest and looking at another variant, the player can update the collision box so they are considered "inside the block", or artificially extend the length to stand one or two pixels further than intended. Do not look back at the original block, as that resets the collision box.
+
+**Collision boxes:** Anvils are a simple 1 x 0.75 bounding box (16 x 12 pixels), oriented along X or Z. Single chests are a simple 0.875 x 0.875 bounding box (14 x 14 pixels); the double chest variant extends one side by 1 pixel. Darker colors in the graphic indicate collision areas common to all variants (stand there to avoid falling during manipulation); lighter colors indicate areas specific to one variant (stand there to clip inside the block).
+
+```java
+/* In BlockAnvil.java */
+public void setBlockBoundsBasedOnState(BlockPos pos)
+{
+    EnumFacing enumfacing = getBlockState(pos).getValue(FACING);
+    if (enumfacing.getAxis() == EnumFacing.Axis.X)
+        this.setBlockBounds(0.0, 0.0, 0.125, 1.0, 1.0, 0.875);
+    else
+        this.setBlockBounds(0.125, 0.0, 0.0, 0.875, 1.0, 1.0);
+}
+/* In BlockChest.java */
+public void setBlockBoundsBasedOnState(BlockPos pos)
+{
+    if (getBlockState(pos.north()).getBlock() == this)
+        this.setBlockBounds(0.0625, 0.0, 0.0, 0.9375, 0.875, 0.9375);
+    else if (getBlockState(pos.south()).getBlock() == this)
+        this.setBlockBounds(0.0625, 0.0, 0.0625, 0.9375, 0.875, 1.0);
+    else if (getBlockState(pos.west()).getBlock() == this)
+        this.setBlockBounds(0.0, 0.0, 0.0625, 0.9375, 0.875, 0.9375);
+    else if (getBlockState(pos.east()).getBlock() == this)
+        this.setBlockBounds(0.0625, 0.0, 0.0625, 1.0, 0.875, 0.9375);
+    else //single chest
+        this.setBlockBounds(0.0625, 0.0, 0.0625, 0.9375, 0.875, 0.9375);
+}
+```
+
+**Manipulation actions:** simply looking at the block; shooting an arrow at it (persistent effect); causing it to re-render by updating surroundings; using rain to update it (randomly).
+
+**Limitations:** On Singleplayer the player can usually walk through an anvil or chest once clipped in. On Multiplayer the anticheat typically prevents walking through completely. In 1.9 this mechanic was patched (each variant now has its own collision box).
+
+## Ceiling Hover
+
+In 1.8 the only setup for a Ceiling Hover is 1.8125bc with slime underneath. Ceiling Hover makes the player "hover" between a ceiling and a bouncy block (slime, or beds since 1.12). It is performed by jumping under a ceiling such that the block 2.001b below the ceiling has bouncing properties.
+
+**Explanation:** when the player collides vertically with a block (floor or ceiling), the game applies collision physics. For almost every block that just means setting vertical speed to 0:
+
+```java
+/* in class Block */
+public void onVerticalCollision(Entity entityIn)
+{
+    entityIn.motionY = 0.0D;
+}
+```
+
+Exception: Slime Blocks (and Beds in 1.12+):
+
+```java
+/* in class BlockSlime */
+public void onVerticalCollision(Entity entityIn)
+{
+    if (entityIn.isSneaking())
+        super.onVerticalCollision(entityIn);
+    else if (entityIn.motionY < 0.0D)
+        entityIn.motionY = -entityIn.motionY;
+}
+```
+
+If the player is sneaking it's a regular collision (vertical motion set to 0). Otherwise it checks if speed is negative, then inverts it. Nothing happens if the player is moving at a positive speed and not sneaking, which is exactly what this glitch uses. When the game detects a vertical collision, it considers the block 0.2m under the player's position to apply collision physics (even for ceiling collisions). Steps for the 1.8125bc Ceiling Hover: (1) jumping under 1.8125bc applies vertical collision with the block 0.2m below the player (at ground level); (2) if that block is a slime block, vertical speed won't be set to 0 and the player remains suspended under the ceiling; (3) repeat until the player's vertical speed becomes negative due to gravity. With Jump Boost it takes longer. Ceiling hover can be interrupted at any time by sneaking. This glitch is insignificant and requires specific setups.

--- a/docs/reference/mcpk/README.md
+++ b/docs/reference/mcpk/README.md
@@ -1,0 +1,16 @@
+# Minecraft Parkour Wiki, in-repo reference
+
+A faithful mirror of the physics-and-mechanics pages of the Minecraft Parkour Wiki (`https://www.mcpk.wiki`), captured here because the wiki sits behind a Cloudflare challenge that an agent cannot fetch. This is reference material (constants, formulas, source snippets, tables), not implementation. The plain-language glossary lives in the repo-root `CONTEXT.md`.
+
+This tool is a byte-exact replica of the 1.8 movement model documented here, so these constants are ground truth: if the code disagrees with a number on these pages, the code is almost certainly the bug. Versions noted as 1.9+ / 1.13 / 1.14 / 1.15 are differences the Fabric 1.21.10 loader must account for.
+
+## Files
+
+- [01-movement-formulas.md](./01-movement-formulas.md) — the core horizontal and vertical movement formulas, the multipliers (move, effects, slipperiness), 45 strafe, and the non-recursive closed forms.
+- [02-angles-and-mouse.md](./02-angles-and-mouse.md) — ticks and the turn tick, mouse sensitivity, yaw vs facing, the sine table, significant angles, half angles.
+- [03-collisions-and-stepping.md](./03-collisions-and-stepping.md) — collision order (Y-X-Z), X-facing vs Z-facing, stepping, blips, jump-cancel, the 1.14+ change.
+- [04-blocks-and-friction.md](./04-blocks-and-friction.md) — block collision boxes, slipperiness, soulsand, cobweb, ladders and vines.
+- [05-status-effects-tiers-jumps.md](./05-status-effects-tiers-jumps.md) — speed/slowness/jump boost tables, tiers, jump durations, longest jump per tier.
+- [06-timings-momentum-glitches.md](./06-timings-momentum-glitches.md) — timings, tapping, backward momentum, anvil/chest manipulation, ceiling hover.
+
+Source pages were last edited between 2021 and 2026; see each section's attribution line.


### PR DESCRIPTION
## What

Adds the domain-knowledge layer for AI agents and contributors working in this repo.

- **`CONTEXT.md`** (repo root): a domain glossary for the Minecraft parkour and movement TASing niche. Defines facing, direction, the velocity/speed/displacement taxonomy, momentum (including loop momentum), neo, tier, byte-exact, and the tool-specific concepts (run-up, takeoff, entry velocity, constraint, mothball-string). Almost none of these terms appear in an LLM's training data.
- **`docs/reference/mcpk/`** (7 files, README + 01..06): a faithful in-repo mirror of the Minecraft Parkour Wiki physics pages: movement formulas and constants, the sine table, collision order, block collision boxes and friction, status effects, tiers, and timings. The wiki sits behind a Cloudflare challenge that agents cannot fetch, so this captures the byte-exact ground truth the tool replicates.
- **`AGENTS.md`**: wires both in, so `CLAUDE.md` and other AGENTS.md-aware tooling pick them up automatically.

## Why

The niche is nearly absent from model training data, which causes drift when agents work on the solver and simulator. A glossary plus a physics reference that an agent can read without leaving the repo is the highest-leverage fix. The reference is split out of `CONTEXT.md` so the glossary stays a glossary.

## Notes

- Docs only, no code changes. `docs:` prefix, so release-please will not cut a release.
- All transcribed physics constants were spot-checked against the source (0.16277136 acceleration base, 10430.378 sine-table factor, -3.92 terminal velocity, slipperiness 0.98/0.8/0.989, 0.005/0.003 momentum thresholds, tier-0 max 4.3227043, ladder climb 0.1176).

## Follow-ups (not in this PR)

- Rename `motion` to `velocity` across the codebase.
- Reconcile the code's yaw/facing field naming with the glossary canon.