### PR TITLE
fix: carry cobweb slowdown state across checkpoints

### DIFF
--- a/loader-fabric-1.21.10/src/client/java/de/legoshi/parkourcalc/fabric/sim/SimulatorEntity.java
+++ b/loader-fabric-1.21.10/src/client/java/de/legoshi/parkourcalc/fabric/sim/SimulatorEntity.java
@@ -398,6 +398,7 @@ public class SimulatorEntity extends PlayerEntity {
         c.ticksLeftToDoubleTapSprint = this.ticksLeftToDoubleTapSprint;
         c.playerInput = this.input.playerInput;
         c.jumpingCooldown = this.jumpingCooldown;
+        c.movementMultiplier = this.movementMultiplier;
         return c;
     }
 
@@ -415,6 +416,7 @@ public class SimulatorEntity extends PlayerEntity {
         this.ticksLeftToDoubleTapSprint = c.ticksLeftToDoubleTapSprint;
         this.input.playerInput = c.playerInput;
         this.jumpingCooldown = c.jumpingCooldown;
+        this.movementMultiplier = c.movementMultiplier;
     }
 
     public static void applyCheckpoint(net.minecraft.client.network.ClientPlayerEntity p, de.legoshi.parkourcalc.core.sim.Checkpoint state) {
@@ -425,6 +427,7 @@ public class SimulatorEntity extends PlayerEntity {
         p.collidedSoftly = c.collidedSoftly;
         p.setSprinting(c.sprinting);
         p.jumpingCooldown = c.jumpingCooldown;
+        p.movementMultiplier = c.movementMultiplier;
     }
 
     public static final class Checkpoint implements de.legoshi.parkourcalc.core.sim.Checkpoint {
@@ -438,5 +441,6 @@ public class SimulatorEntity extends PlayerEntity {
         int ticksLeftToDoubleTapSprint;
         PlayerInput playerInput;
         int jumpingCooldown;
+        Vec3d movementMultiplier;
     }
 }

--- a/loader-fabric-1.21.10/src/client/resources/parkourcalculator.accesswidener
+++ b/loader-fabric-1.21.10/src/client/resources/parkourcalculator.accesswidener
@@ -14,3 +14,9 @@ accessible method net/minecraft/client/render/RenderLayer of (Ljava/lang/String;
 # so replay preserves the post-jump cooldown; without it, edits upstream of a
 # jump tick can drop the jump on re-simulation.
 accessible field net/minecraft/entity/LivingEntity jumpingCooldown I
+
+# Entity.movementMultiplier (private): the cobweb slowdown carries across ticks
+# (slowMovement sets it; move() consumes and resets it). Captured in
+# SimulatorEntity.Checkpoint so re-simulation and replay resuming inside a cobweb
+# keep the pending slowdown instead of dropping a tick of it.
+accessible field net/minecraft/entity/Entity movementMultiplier Lnet/minecraft/util/math/Vec3d;

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/sim/SimulatorEntity.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/sim/SimulatorEntity.java
@@ -283,7 +283,9 @@ public class SimulatorEntity extends EntityPlayer {
         p.setAIMoveSpeed(c.landMovementFactor);
         p.jumpMovementFactor = c.jumpMovementFactor;
         p.jumpTicks = c.jumpTicks;
-        p.isInWeb = c.isInWeb;
+        if (c.isInWeb) {
+            p.setInWeb();
+        }
     }
 
     public static final class Checkpoint implements de.legoshi.parkourcalc.core.sim.Checkpoint {

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/sim/SimulatorEntity.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/sim/SimulatorEntity.java
@@ -249,6 +249,7 @@ public class SimulatorEntity extends EntityPlayer {
         c.jumpMovementFactor = this.jumpMovementFactor;
         c.landMovementFactor = this.getAIMoveSpeed();
         c.jumpTicks = this.jumpTicks;
+        c.isInWeb = this.isInWeb;
         return c;
     }
 
@@ -268,6 +269,7 @@ public class SimulatorEntity extends EntityPlayer {
         this.jumpMovementFactor = c.jumpMovementFactor;
         this.setAIMoveSpeed(c.landMovementFactor);
         this.jumpTicks = c.jumpTicks;
+        this.isInWeb = c.isInWeb;
         this.setPosition(c.posX, c.posY, c.posZ);
     }
 
@@ -281,6 +283,7 @@ public class SimulatorEntity extends EntityPlayer {
         p.setAIMoveSpeed(c.landMovementFactor);
         p.jumpMovementFactor = c.jumpMovementFactor;
         p.jumpTicks = c.jumpTicks;
+        p.isInWeb = c.isInWeb;
     }
 
     public static final class Checkpoint implements de.legoshi.parkourcalc.core.sim.Checkpoint {
@@ -294,5 +297,6 @@ public class SimulatorEntity extends EntityPlayer {
         float jumpMovementFactor;
         float landMovementFactor;
         int jumpTicks;
+        boolean isInWeb;
     }
 }

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/sim/SimulatorEntity.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/sim/SimulatorEntity.java
@@ -278,7 +278,9 @@ public class SimulatorEntity extends EntityPlayer {
         p.setAIMoveSpeed(c.landMovementFactor);
         p.jumpMovementFactor = c.jumpMovementFactor;
         p.jumpTicks = c.jumpTicks;
-        p.isInWeb = c.isInWeb;
+        if (c.isInWeb) {
+            p.setInWeb();
+        }
     }
 
     public static final class Checkpoint implements de.legoshi.parkourcalc.core.sim.Checkpoint {

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/sim/SimulatorEntity.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/sim/SimulatorEntity.java
@@ -244,6 +244,7 @@ public class SimulatorEntity extends EntityPlayer {
         c.jumpMovementFactor = this.jumpMovementFactor;
         c.landMovementFactor = this.getAIMoveSpeed();
         c.jumpTicks = this.jumpTicks;
+        c.isInWeb = this.isInWeb;
         return c;
     }
 
@@ -263,6 +264,7 @@ public class SimulatorEntity extends EntityPlayer {
         this.jumpMovementFactor = c.jumpMovementFactor;
         this.setAIMoveSpeed(c.landMovementFactor);
         this.jumpTicks = c.jumpTicks;
+        this.isInWeb = c.isInWeb;
         this.setPosition(c.posX, c.posY, c.posZ);
     }
 
@@ -276,6 +278,7 @@ public class SimulatorEntity extends EntityPlayer {
         p.setAIMoveSpeed(c.landMovementFactor);
         p.jumpMovementFactor = c.jumpMovementFactor;
         p.jumpTicks = c.jumpTicks;
+        p.isInWeb = c.isInWeb;
     }
 
     public static final class Checkpoint implements de.legoshi.parkourcalc.core.sim.Checkpoint {
@@ -289,5 +292,6 @@ public class SimulatorEntity extends EntityPlayer {
         float jumpMovementFactor;
         float landMovementFactor;
         int jumpTicks;
+        boolean isInWeb;
     }
 }


### PR DESCRIPTION
The cobweb slowdown is a cross-tick effect: vanilla sets the web flag during
a tick's block-collision pass and applies the velocity multiplier at the start
of the next move. The simulator's Checkpoint snapshot did not capture this
state, so any path resuming from a checkpoint taken inside a cobweb (incremental
re-simulation after an input edit, or a mid-range replay teleport) dropped one
tick of web slowdown and desynced from a full run.

Capture isInWeb in the Forge 1.8.9 and 1.12.2 Checkpoints and movementMultiplier
in the Fabric 1.21.10 Checkpoint, restoring it on both the simulator entity and
the replayed real player. Access-widen Entity.movementMultiplier for Fabric.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01S6gJeSunrSzqYCHJ2WGn6B