### PR TITLE
fix(solver): don't assume sprint on a sneak-scaled tick

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/AngleSolverEngine.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/AngleSolverEngine.java
@@ -593,7 +593,7 @@ public final class AngleSolverEngine {
                 if (sampled != null && sampled.hasMovementSample()) {
                     forwardIn[k] = sampled.moveForward;
                     strafeIn[k] = sampled.moveStrafe;
-                    sprintArr[k] = !deriveSprint || sampled.sprinting;
+                    sprintArr[k] = (!deriveSprint || sampled.sprinting) && forwardIn[k] >= SPRINT_SUSTAIN_F;
                 } else {
                     // No recorded run to sample: the rows' keys (gh-102) and the legacy sprint assumption.
                     forwardIn[k] = 0.98F * ((row.isKeyActive(InputRow.Key.W) ? 1 : 0) - (row.isKeyActive(InputRow.Key.S) ? 1 : 0));

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/LongRunSolver.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/LongRunSolver.java
@@ -243,8 +243,8 @@ public final class LongRunSolver {
     public static JumpSpec suffixSpec(JumpSpec full, int from, Vec3dCore pos, Vec3dCore vel, float yaw) {
         JumpPhysicsInputs sc = full.asScenario();
         JumpPhysicsInputs win = sliceScenario(sc, from, sc.numTicks, pos, vel, yaw);
-        win.incomingSprint = sc.sprintAt(from - 1);
-        win.incomingAmp = sc.speedAmplifierAt(from - 1);
+        win.incomingSprint = from == 0 ? sc.incomingSprint : sc.sprintAt(from - 1);
+        win.incomingAmp = from == 0 ? sc.incomingAmp : sc.speedAmplifierAt(from - 1);
         List<JumpConstraint> cons = sliceConstraints(full, from, sc.numTicks);
         Objective obj = new Objective(full.objective.axis, full.objective.sense, full.objective.tick - from);
         return new JumpSpec(win, cons, obj);

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/MomentumAssembly.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/MomentumAssembly.java
@@ -422,8 +422,8 @@ public final class MomentumAssembly {
         p.initialVelocity = vel;
         p.startYaw = yaw;
         p.strafeSign = sc.strafeSign;
-        p.incomingSprint = sc.sprintAt(a - 1);
-        p.incomingAmp = sc.speedAmplifierAt(a - 1);
+        p.incomingSprint = a == 0 ? sc.incomingSprint : sc.sprintAt(a - 1);
+        p.incomingAmp = a == 0 ? sc.incomingAmp : sc.speedAmplifierAt(a - 1);
         p.jumpPerTick = sliceBool(sc.jumpPerTick, a, len);
         p.strafePerTick = sliceBool(sc.strafePerTick, a, len);
         p.yawLockedPerTick = sliceBool(sc.yawLockedPerTick, a, len);

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/SprintSneakTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/SprintSneakTest.java
@@ -118,9 +118,12 @@ public class SprintSneakTest {
     }
 
     @Test
-    public void sprintAlwaysOverridesTheSampledFlag() {
-        // The default mode assumes sprint everywhere; only Derive reads the recorded flag. Inputs stay sampled.
+    public void sprintAlwaysOverridesTheSampledFlagOnlyWhereSprintIsPossible() {
+        // The default mode assumes sprint everywhere; only Derive reads the recorded flag. Inputs stay
+        // sampled. The assumption stops at a sneak-scaled forward: 0.294 is below MC's 0.8 sprint floor,
+        // so the sim cannot sprint there and a solve that assumes it leaves the path on the next tick.
         InputData inputs = rows(2);
+        inputs.get(1).setKeyActive(InputRow.Key.SNEAK, true);
         BoxController boxes = new BoxController();
         boxes.add(unsampled());
         boxes.add(sampled(false, F, 0.0F));
@@ -128,8 +131,8 @@ public class SprintSneakTest {
         AngleSolverState state = new AngleSolverState();
         assertEquals(AngleSolverState.SprintMode.ALWAYS, state.getDefaultSprint());
         JumpPhysicsInputs sc = compile(inputs, boxes, 2, state);
-        assertTrue(sc.sprintAt(0));
-        assertTrue(sc.sprintAt(1));
+        assertTrue("a lost sprint on a full W is still assumed back on", sc.sprintAt(0));
+        assertFalse("the sneak-scaled tick cannot sprint, whatever the mode assumes", sc.sprintAt(1));
         assertEquals("inputs still come from the sample", SNEAK_F, sc.forwardAt(1), 0.0F);
     }
 


### PR DESCRIPTION
Always forced sprint onto every tick, including ones holding sneak. Minecraft gates sprint on a raw forward input of 0.8, which a sneak-scaled 0.294 can never reach, so the model ran those ticks at the 1.3x sprinting ground attribute while the sim ran them unsprinted: `0.03822` vs `0.02940` of displacement on the first tick alone. The error compounds through the carried velocity and shows up as a "sim diverged" warning that blames the sneak row.