### PR TITLE
fix(solver): keep the scenario seed on a window anchored at tick 0

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/LongRunSolver.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/LongRunSolver.java
@@ -243,8 +243,8 @@ public final class LongRunSolver {
     public static JumpSpec suffixSpec(JumpSpec full, int from, Vec3dCore pos, Vec3dCore vel, float yaw) {
         JumpPhysicsInputs sc = full.asScenario();
         JumpPhysicsInputs win = sliceScenario(sc, from, sc.numTicks, pos, vel, yaw);
-        win.incomingSprint = sc.sprintAt(from - 1);
-        win.incomingAmp = sc.speedAmplifierAt(from - 1);
+        win.incomingSprint = from == 0 ? sc.incomingSprint : sc.sprintAt(from - 1);
+        win.incomingAmp = from == 0 ? sc.incomingAmp : sc.speedAmplifierAt(from - 1);
         List<JumpConstraint> cons = sliceConstraints(full, from, sc.numTicks);
         Objective obj = new Objective(full.objective.axis, full.objective.sense, full.objective.tick - from);
         return new JumpSpec(win, cons, obj);

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/MomentumAssembly.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/MomentumAssembly.java
@@ -422,8 +422,8 @@ public final class MomentumAssembly {
         p.initialVelocity = vel;
         p.startYaw = yaw;
         p.strafeSign = sc.strafeSign;
-        p.incomingSprint = sc.sprintAt(a - 1);
-        p.incomingAmp = sc.speedAmplifierAt(a - 1);
+        p.incomingSprint = a == 0 ? sc.incomingSprint : sc.sprintAt(a - 1);
+        p.incomingAmp = a == 0 ? sc.incomingAmp : sc.speedAmplifierAt(a - 1);
         p.jumpPerTick = sliceBool(sc.jumpPerTick, a, len);
         p.strafePerTick = sliceBool(sc.strafePerTick, a, len);
         p.yawLockedPerTick = sliceBool(sc.yawLockedPerTick, a, len);

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/WindowSeedTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/WindowSeedTest.java
@@ -1,0 +1,51 @@
+package de.legoshi.parkourcalc.anglesolver;
+
+import de.legoshi.parkourcalc.core.anglesolver.solver.JumpPhysicsInputs;
+import de.legoshi.parkourcalc.core.anglesolver.solver.JumpSpec;
+import de.legoshi.parkourcalc.core.anglesolver.solver.LongRunSolver;
+import de.legoshi.parkourcalc.core.anglesolver.solver.Objective;
+import de.legoshi.parkourcalc.core.sim.Vec3dCore;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class WindowSeedTest {
+
+    private static JumpSpec fullSpec() {
+        JumpPhysicsInputs sc = new JumpPhysicsInputs(3);
+        sc.startPos = new Vec3dCore(0.5, 64.0, 0.5);
+        sc.sprintPerTick = new boolean[]{false, false, false};
+        sc.speedAmplifier = new int[]{0, 0, 0};
+        sc.incomingSprint = Boolean.TRUE;
+        sc.incomingAmp = 2;
+        return new JumpSpec(sc, Collections.emptyList(),
+                new Objective(JumpPhysicsInputs.Axis.X, Objective.Sense.MAX, 3));
+    }
+
+    @Test
+    public void aSuffixAtTickZeroKeepsTheScenarioSeed() {
+        JumpPhysicsInputs win = LongRunSolver.suffixSpec(fullSpec(), 0,
+                new Vec3dCore(0.5, 64.0, 0.5), Vec3dCore.ZERO, 0.0F).asScenario();
+
+        assertEquals(Boolean.TRUE, win.incomingSprint);
+        assertEquals(Integer.valueOf(2), win.incomingAmp);
+        assertTrue("the seed drives tick 0's movement factor", win.factorSprintAt(0));
+        assertEquals(2, win.factorAmpAt(0));
+    }
+
+    @Test
+    public void aSuffixPastTickZeroStillReadsThePrecedingTick() {
+        JumpSpec full = fullSpec();
+        full.asScenario().sprintPerTick = new boolean[]{true, true, false};
+        full.asScenario().speedAmplifier = new int[]{1, 1, 0};
+
+        JumpPhysicsInputs win = LongRunSolver.suffixSpec(full, 1,
+                new Vec3dCore(0.5, 64.0, 0.5), Vec3dCore.ZERO, 0.0F).asScenario();
+
+        assertEquals(Boolean.TRUE, win.incomingSprint);
+        assertEquals(Integer.valueOf(1), win.incomingAmp);
+    }
+}


### PR DESCRIPTION
LongRunSolver.suffixSpec and MomentumAssembly.tailSpec seeded a window's incomingSprint / incomingAmp from the preceding tick unconditionally. A window starting at tick 0 has no preceding tick: sprintAt(-1) returns false and speedAmplifierAt(-1) returns 0, so the seed the full scenario already carried was dropped. Since the ground/air factor lags sprint by one tick, that silently unsprints the window's first tick and drops its speed amplifier.

Both now fall back to the scenario's own incoming state at 0, matching the guard MomentumAssembly already uses for its single-tick spec.