### PR TITLE
fix: send playback move packets before the client tick end packet

### DIFF
--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricParkourCalculator.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricParkourCalculator.java
@@ -189,6 +189,9 @@ public class FabricParkourCalculator implements ClientModInitializer {
         // Restore visual yaw after MC physics so render frames don't briefly show
         // the snap value the physics tick used.
         application.postTickPlayback();
+    }
+
+    public static void syncFrozenPlayerToServer() {
         playbackBridge.syncFrozenPlayerToServer();
     }
 

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/mixin/MinecraftMixin.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/mixin/MinecraftMixin.java
@@ -29,4 +29,10 @@ public class MinecraftMixin {
         ImGuiImpl.dispose();
     }
 
+    @Inject(method = "tick", at = @At(value = "INVOKE",
+            target = "Lnet/minecraft/client/multiplayer/ClientPacketListener;send(Lnet/minecraft/network/protocol/Packet;)V"))
+    private void pkc$syncFrozenPlayerBeforeTickEndPacket(CallbackInfo ci) {
+        FabricParkourCalculator.syncFrozenPlayerToServer();
+    }
+
 }


### PR DESCRIPTION
## Problem

During multiplayer client-sided replay, players get kicked on Hypixel. `syncFrozenPlayerToServer()` ran from Fabric's `END_CLIENT_TICK`, which fires at `RETURN` of `Minecraft.tick`. Vanilla sends `ServerboundClientTickEnd` from inside `Minecraft.tick`, after entity ticking and before the method returns. So every replay tick the server received the tick end packet first and the frozen player's move packets after it. A vanilla client always sends move packets before the tick end packet (they go out from `LocalPlayer.tick` during entity ticking), so this ordering is a per-tick fingerprint that anticheats can match.

The frozen player is otherwise silent because `LocalPlayer.sendPosition` is gated on `isControlledCamera()` and replay mode points the camera at the replay entity, which is exactly why the manual sync exists.

## Fix

- New injection in `MinecraftMixin` at the `ClientPacketListener.send(Packet)` call inside `Minecraft.tick` (the tick end packet send, the only such call site there); it runs `syncFrozenPlayerToServer()` after entity ticking but before the tick end packet, restoring vanilla packet order.
- `onEndTick` keeps only `postTickPlayback()` (visual yaw restore), which is render-facing and fine at `RETURN`.

This also removes a start-tick artifact: when playback started via the P key, the old end tick sync ran in the same tick as vanilla's `sendPosition` (replay mode flips on between the two), double-incrementing `positionReminder`. The injection point runs before the mod's key handling on `END_CLIENT_TICK`, so that race is gone and no first-tick guard is needed.

The Forge loaders are unaffected: the 1.8.9 and 1.12.2 protocols have no client tick end packet, so this ordering cannot be observed there.

## Validation against decompiled sources

Checked against the local decompiled 26.2 sources and the mapped bytecode from the loom cache:

- `Minecraft.tick` bytecode contains exactly one `ClientPacketListener.send(Lnet/minecraft/network/protocol/Packet;)V` invoke (offset 544), after `level.tickEntities` (244) and before the single `return` (595), so the injection matches once and lands where intended. `tick` is the only method with that name in the class.
- `LocalPlayer.sendPosition` is gated on `isControlledCamera()` (camera entity must be the player); move packets go out during entity ticking.
- fabric-lifecycle-events-v1 4.1.3 injects `END_CLIENT_TICK` at `@At("RETURN")` of `tick`, confirming the old ordering inversion.
- No client tick end packet class exists in the 1.8.9 or 1.12.2 decompiled sources.
