### PR TITLE
fix: constraint chip delete crash and live best-path render crash

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/render/ConstraintBoxSource.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/render/ConstraintBoxSource.java
@@ -31,6 +31,9 @@ public interface ConstraintBoxSource {
     /** Drawable constraint plates anchored at the given tick, or an empty list if none. Never null. */
     List<ConstraintPlate> platesAt(int tickIndex);
 
+    default void beginFrame() {
+    }
+
     /**
      * Monotonic-ish content stamp: changes whenever the constraint geometry would change (edited
      * constraints, axis/value edits, etc.). Folded into the cached-geometry structural hash so the

--- a/core/src/main/java/de/legoshi/parkourcalc/core/render/PathRenderPlan.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/render/PathRenderPlan.java
@@ -103,6 +103,8 @@ public final class PathRenderPlan {
         // into the same buffers without disturbing the per-box offsets selection patching depends on.
         ConstraintBoxSource source = constraintSource;
         ConstraintBoxSource live = liveSource;
+        source.beginFrame();
+        live.beginFrame();
         boolean drawConstraints = settings.showConstraints && source != ConstraintBoxSource.NONE;
         boolean drawLive = live != ConstraintBoxSource.NONE;
         ConstraintPalette palette = new ConstraintPalette(

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverTable.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverTable.java
@@ -393,7 +393,7 @@ public final class AngleSolverTable {
         float baseRowH = ThemeManager.tableRowHeight();
 
         TickConstraints tc = state.tickConstraintsOrNull(rowIndex);
-        final List<Constraint> list = tc == null ? null : tc.getConstraints();
+        final List<Constraint> list = tc == null ? null : new ArrayList<>(tc.getConstraints());
         if (list == null || list.isEmpty()) {
             constraintCellRects.put(rowIndex, cellRect(origin, cellW, grownRowH));
             rowContentH.put(rowIndex, baseRowH);

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/LiveBestPathSource.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/LiveBestPathSource.java
@@ -32,20 +32,20 @@ public final class LiveBestPathSource implements ConstraintBoxSource {
         this.active = active;
     }
 
-    private LiveTrajectory current() {
+    @Override
+    public void beginFrame() {
         LiveTrajectory t = active.isActive() ? engine.liveTrajectory() : null;
-        if (t == shown) return shown;
+        if (t == shown) return;
         long now = System.nanoTime();
         if (t == null || shown == null || now - lastAdoptNanos >= ADOPT_INTERVAL_NANOS) {
             shown = t;
             lastAdoptNanos = now;
         }
-        return shown;
     }
 
     @Override
     public List<ConstraintPlate> platesAt(int tickIndex) {
-        LiveTrajectory t = current();
+        LiveTrajectory t = shown;
         if (t == null) return Collections.emptyList();
         int k = tickIndex - t.startTick;
         if (k < 0 || k >= t.pointCount()) return Collections.emptyList();
@@ -58,7 +58,7 @@ public final class LiveBestPathSource implements ConstraintBoxSource {
 
     @Override
     public long revision() {
-        LiveTrajectory t = current();
+        LiveTrajectory t = shown;
         return t == null ? 0L : t.seq;
     }
 }


### PR DESCRIPTION
Fixes #258
Fixes #259

Two render crashes with one shared root: render-side derived layout assumed a stable snapshot of data that mutated mid-frame.

**#258 (core UI, all loaders):** the constraint chip cell iterates the live constraints list, and the chip context menu renders inline mid-loop, so Delete / Move to tick shrinks the list and the next chip's `list.get(i)` throws (`Index 1 out of bounds for length 1`). Repro: 2+ constraints on one tick, right-click a non-last chip, Delete. Fixed by rendering the chips from a snapshot; mutations take effect next frame, matching how the expanded editor already defers its deletes.

**#259 (world overlay, all loaders):** during a solve the worker thread publishes live best-path trajectories mid-frame. The plate region was sampled several times per frame (structural hash and vertex count in `PathRenderPlan.build`, count and emit passes in the bake, the trailing-slice math at draw); a publish landing between samples made the baked region larger than the counted one, so `drawLines` inferred a subtick region that was never baked and indexed `subtickStarts` past its length (`ArrayIndexOutOfBoundsException: 1760` while running and cancelling solves). Fixed by freezing the trajectory once per frame: `ConstraintBoxSource.beginFrame()` is called once at plan build, `LiveBestPathSource` adopts the worker snapshot only there, and `platesAt`/`revision` read the frozen value, so hash, count, bake and draw all agree.

Testing: `:core:test` green. In-game QA pending; the #258 repro above is a quick manual check.