### PR TITLE
feat: add an option to disable creative flight during singleplayer playback

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/PlaybackController.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/PlaybackController.java
@@ -236,6 +236,9 @@ public final class PlaybackController {
             if (lastFrameNanos != 0L) lastFrameNanos += pausedFor;
             pausedAtNanos = 0L;
         }
+        if (settings.disableFlightDuringPlayback) {
+            bridge.suppressFlight();
+        }
         if (nextTick >= stopTick) {
             // Stop only once the visual has caught up to the final yaw and a tick
             // window has elapsed; a low cap can keep the ease running past the final input.

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ports/PlaybackBridge.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ports/PlaybackBridge.java
@@ -37,6 +37,8 @@ public interface PlaybackBridge {
 
     void releaseAllKeys();
 
+    default void suppressFlight() {}
+
     /** Close any open mod UI (control panel / GuiScreen) the same way the toggle key would. */
     void closeUI();
 

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/Settings.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/Settings.java
@@ -94,6 +94,7 @@ public final class Settings {
     private static final int DEFAULT_HUD_MESSAGE_ORDER = HUD_MESSAGE_ORDER_DOWNWARDS;
 
     private static final boolean DEFAULT_KEEP_BOXES_DURING_PLAYBACK = false;
+    private static final boolean DEFAULT_DISABLE_FLIGHT_DURING_PLAYBACK = true;
 
     private static final float DEFAULT_YAW_FLICK_SPEED = 7200.0f;
     public static final float MIN_YAW_FLICK_SPEED = 30.0f;
@@ -212,6 +213,8 @@ public final class Settings {
     // Keep the tick-box path overlay drawn in-world during playback.
     public boolean keepBoxesDuringPlayback = DEFAULT_KEEP_BOXES_DURING_PLAYBACK;
 
+    public boolean disableFlightDuringPlayback = DEFAULT_DISABLE_FLIGHT_DURING_PLAYBACK;
+
     public static int defaultTickInfoPrecision() {
         return DEFAULT_TICK_INFO_PRECISION;
     }
@@ -300,5 +303,6 @@ public final class Settings {
         hudMessageScale = DEFAULT_HUD_MESSAGE_SCALE;
         hudMessageOrder = DEFAULT_HUD_MESSAGE_ORDER;
         keepBoxesDuringPlayback = DEFAULT_KEEP_BOXES_DURING_PLAYBACK;
+        disableFlightDuringPlayback = DEFAULT_DISABLE_FLIGHT_DURING_PLAYBACK;
     }
 }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/SettingsModal.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/SettingsModal.java
@@ -62,6 +62,7 @@ public final class SettingsModal {
     private static final String TT_HUD_MESSAGE_COLOR = "Text color for normal notifications. Warnings keep their own color. While the main UI is open the window stays visible so it can be dragged; closed, it only appears while messages are showing.";
     private static final String TT_HUD_MESSAGE_ORDER = "Downwards: new messages appear at the top and the window grows downward. Upwards: new messages appear at the bottom and the window grows upward from its bottom edge, like chat.";
     private static final String TT_KEEP_BOXES_PLAYBACK = "Keeps the tick-box path overlay drawn in-world while playback is running, instead of hiding it.";
+    private static final String TT_DISABLE_FLIGHT_PLAYBACK = "Prevents double-tapping jump from starting creative flight while playback is running (singleplayer). Flight behaves normally again once playback ends.";
     private static final String TT_SOLVER_PRECISION = "Decimal places for Angle Solver stats: solved yaws, objective values, constraint chips, and the constraint value editor.";
     private static final String TT_EXPERIMENTAL_BLOCK_CAPTURE = "Enables in-world block capture: tag blocks by role with hotkeys (M momentum, N collision, K land, Delete clears). The hotkeys are registered at startup, so turning this on or off only takes effect after a game restart.";
 
@@ -420,6 +421,13 @@ public final class SettingsModal {
         sectionHeader("Overlays");
         if (beginLayoutTable("##settings_playback_overlays")) {
             checkboxRow("Keep tick boxes shown", "##keep_boxes_playback", settings.keepBoxesDuringPlayback, TT_KEEP_BOXES_PLAYBACK, v -> settings.keepBoxesDuringPlayback = v);
+            ThemeManager.endStandardFormTable();
+        }
+
+        ThemeManager.sectionSpacing();
+        sectionHeader("Player");
+        if (beginLayoutTable("##settings_playback_player")) {
+            checkboxRow("Disable creative flight", "##disable_flight_playback", settings.disableFlightDuringPlayback, TT_DISABLE_FLIGHT_PLAYBACK, v -> settings.disableFlightDuringPlayback = v);
             ThemeManager.endStandardFormTable();
         }
     }

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/AirborneStartJumpTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/AirborneStartJumpTest.java
@@ -1,7 +1,7 @@
 package de.legoshi.parkourcalc.anglesolver;
 
+import de.legoshi.parkourcalc.core.FakePlaybackBridge;
 import de.legoshi.parkourcalc.core.PlaybackController;
-import de.legoshi.parkourcalc.core.ports.PlaybackBridge;
 import de.legoshi.parkourcalc.core.ports.Simulator;
 import de.legoshi.parkourcalc.core.sim.Checkpoint;
 import de.legoshi.parkourcalc.core.sim.SimulationRunner;
@@ -85,20 +85,6 @@ public class AirborneStartJumpTest {
         OnGroundCheckpoint(boolean onGround) { this.onGround = onGround; }
     }
 
-    private static final class RecordingBridge implements PlaybackBridge {
-        Boolean teleportedOnGround;
-
-        @Override public boolean isSingleplayer() { return true; }
-        @Override public void teleport(Vec3dCore pos, Vec3dCore vel, float yaw, Checkpoint carry) {
-            teleportedOnGround = carry instanceof OnGroundCheckpoint ? ((OnGroundCheckpoint) carry).onGround : null;
-        }
-        @Override public void setKey(InputRow.Key key, boolean pressed) { }
-        @Override public void setYaw(float absoluteYaw) { }
-        @Override public void releaseAllKeys() { }
-        @Override public void closeUI() { }
-        @Override public void applyEffects(int speedAmplifier, int jumpBoostAmplifier) { }
-    }
-
     private static InputData jumpOnFirstRow() {
         InputData data = new InputData();
         InputRow row = new InputRow();
@@ -135,14 +121,15 @@ public class AirborneStartJumpTest {
         SimulationRunner runner = new SimulationRunner(new JumpGatedSimulator(false));
         runner.simulate(data);
 
-        RecordingBridge bridge = new RecordingBridge();
+        FakePlaybackBridge bridge = new FakePlaybackBridge();
         PlaybackController pc = new PlaybackController(data, runner, new Settings());
         pc.setBridge(bridge);
         pc.start();
 
-        assertEquals(
+        assertTrue("playback hands the sim's checkpoint to the teleport", bridge.teleportCarry instanceof OnGroundCheckpoint);
+        assertFalse(
                 "playback seats the player with the sim's airborne launch onGround, not a forced true",
-                Boolean.FALSE, bridge.teleportedOnGround
+                ((OnGroundCheckpoint) bridge.teleportCarry).onGround
         );
         assertFalse("the loader's tick-0 hook reads the same airborne value", pc.firstTickOnGround());
     }
@@ -153,14 +140,15 @@ public class AirborneStartJumpTest {
         SimulationRunner runner = new SimulationRunner(new JumpGatedSimulator(true));
         runner.simulate(data);
 
-        RecordingBridge bridge = new RecordingBridge();
+        FakePlaybackBridge bridge = new FakePlaybackBridge();
         PlaybackController pc = new PlaybackController(data, runner, new Settings());
         pc.setBridge(bridge);
         pc.start();
 
-        assertEquals(
+        assertTrue("playback hands the sim's checkpoint to the teleport", bridge.teleportCarry instanceof OnGroundCheckpoint);
+        assertTrue(
                 "a grounded start still launches on the ground so the jump fires",
-                Boolean.TRUE, bridge.teleportedOnGround
+                ((OnGroundCheckpoint) bridge.teleportCarry).onGround
         );
         assertTrue(pc.firstTickOnGround());
     }

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/PlaybackPauseTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/PlaybackPauseTest.java
@@ -1,17 +1,13 @@
 package de.legoshi.parkourcalc.anglesolver;
 
+import de.legoshi.parkourcalc.core.FakePlaybackBridge;
+import de.legoshi.parkourcalc.core.FakeSimulator;
 import de.legoshi.parkourcalc.core.PlaybackController;
-import de.legoshi.parkourcalc.core.ports.PlaybackBridge;
-import de.legoshi.parkourcalc.core.ports.Simulator;
 import de.legoshi.parkourcalc.core.sim.SimulationRunner;
-import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.InputData;
 import de.legoshi.parkourcalc.core.ui.InputRow;
 import de.legoshi.parkourcalc.core.ui.Settings;
 import org.junit.Test;
-
-import java.util.EnumMap;
-import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -24,82 +20,7 @@ import static org.junit.Assert.assertTrue;
  */
 public class PlaybackPauseTest {
 
-    private static final class FakeBridge implements PlaybackBridge {
-        boolean paused;
-        int releaseAllCalls;
-        final Map<InputRow.Key, Boolean> keys = new EnumMap<InputRow.Key, Boolean>(InputRow.Key.class);
-
-        @Override
-        public boolean isSingleplayer() {
-            return true;
-        }
-
-        @Override
-        public boolean isGamePaused() {
-            return paused;
-        }
-
-        @Override
-        public void teleport(Vec3dCore pos, Vec3dCore vel, float yaw, de.legoshi.parkourcalc.core.sim.Checkpoint carry) {
-        }
-
-        @Override
-        public void setKey(InputRow.Key key, boolean pressed) {
-            keys.put(key, pressed);
-        }
-
-        @Override
-        public void setYaw(float absoluteYaw) {
-        }
-
-        @Override
-        public void releaseAllKeys() {
-            releaseAllCalls++;
-            keys.clear();
-        }
-
-        @Override
-        public void closeUI() {
-        }
-
-        @Override
-        public void applyEffects(int speedAmplifier, int jumpBoostAmplifier) {
-        }
-    }
-
-    /** The controller only reads the launch state from the runner; everything else is unused here. */
-    private static final class FakeSimulator implements Simulator {
-        private Vec3dCore startPos = Vec3dCore.ZERO;
-        private Vec3dCore startVel = Vec3dCore.ZERO;
-        private float startYaw;
-
-        @Override public void resetToStart() { }
-        @Override public void applyInput(InputRow row) { }
-        @Override public void tick() { }
-        @Override public Vec3dCore getCurrentPosition() { return Vec3dCore.ZERO; }
-        @Override public boolean isCurrentOnGround() { return false; }
-        @Override public boolean isCurrentSneaking() { return false; }
-        @Override public boolean isCurrentSprinting() { return false; }
-        @Override public float getCurrentMoveForward() { return Float.NaN; }
-        @Override public float getCurrentMoveStrafe() { return Float.NaN; }
-        @Override public boolean isCurrentWallCollision() { return false; }
-        @Override public Vec3dCore getCurrentVelocity() { return Vec3dCore.ZERO; }
-        @Override public boolean isCurrentSoftCollision() { return false; }
-        @Override public double getCurrentCollisionAngleDegrees() { return Double.NaN; }
-        @Override public float getCurrentYaw() { return 0f; }
-        @Override public java.util.List<Vec3dCore> getCurrentSubtickPath() { return java.util.Collections.emptyList(); }
-        @Override public Vec3dCore getStartPosition() { return startPos; }
-        @Override public void setStartPosition(Vec3dCore pos) { startPos = pos; }
-        @Override public Vec3dCore getStartVelocity() { return startVel; }
-        @Override public void setStartVelocity(Vec3dCore vel) { startVel = vel; }
-        @Override public float getStartYaw() { return startYaw; }
-        @Override public void setStartYaw(float yaw) { startYaw = yaw; }
-        @Override public de.legoshi.parkourcalc.core.sim.Checkpoint saveCheckpoint() { return null; }
-        @Override public void restoreCheckpoint(de.legoshi.parkourcalc.core.sim.Checkpoint checkpoint) { }
-        @Override public void invalidate() { }
-    }
-
-    private static PlaybackController controller(FakeBridge bridge, InputData data) {
+    private static PlaybackController controller(FakePlaybackBridge bridge, InputData data) {
         SimulationRunner runner = new SimulationRunner(new FakeSimulator());
         PlaybackController pc = new PlaybackController(data, runner, new Settings());
         pc.setBridge(bridge);
@@ -114,7 +35,7 @@ public class PlaybackPauseTest {
             row.setKeyActive(t == 2 ? InputRow.Key.A : InputRow.Key.W, true);
             data.getRows().add(row);
         }
-        FakeBridge bridge = new FakeBridge();
+        FakePlaybackBridge bridge = new FakePlaybackBridge();
         PlaybackController pc = controller(bridge, data);
 
         pc.start();
@@ -146,7 +67,7 @@ public class PlaybackPauseTest {
     public void pauseDuringTheFinishEaseStillStops() throws Exception {
         InputData data = new InputData();
         data.getRows().add(new InputRow());
-        FakeBridge bridge = new FakeBridge();
+        FakePlaybackBridge bridge = new FakePlaybackBridge();
         PlaybackController pc = controller(bridge, data);
 
         pc.start();

--- a/core/src/test/java/de/legoshi/parkourcalc/core/AutoSaveTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/AutoSaveTest.java
@@ -2,9 +2,7 @@ package de.legoshi.parkourcalc.core;
 
 import de.legoshi.parkourcalc.core.anglesolver.AngleSolverState;
 import de.legoshi.parkourcalc.core.ports.MinecraftAccess;
-import de.legoshi.parkourcalc.core.ports.Simulator;
 import de.legoshi.parkourcalc.core.save.FileSystemSaveStore;
-import de.legoshi.parkourcalc.core.sim.Checkpoint;
 import de.legoshi.parkourcalc.core.sim.SimulationRunner;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.FileMenu;
@@ -15,8 +13,6 @@ import org.junit.Test;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collections;
-import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -29,37 +25,6 @@ import static org.junit.Assert.assertTrue;
  */
 public class AutoSaveTest {
 
-    private static final class NullSimulator implements Simulator {
-        private Vec3dCore startPos = Vec3dCore.ZERO;
-        private Vec3dCore startVel = Vec3dCore.ZERO;
-        private float startYaw;
-
-        @Override public void resetToStart() { }
-        @Override public void applyInput(InputRow row) { }
-        @Override public void tick() { }
-        @Override public Vec3dCore getCurrentPosition() { return Vec3dCore.ZERO; }
-        @Override public boolean isCurrentOnGround() { return false; }
-        @Override public boolean isCurrentSneaking() { return false; }
-        @Override public boolean isCurrentSprinting() { return false; }
-        @Override public float getCurrentMoveForward() { return Float.NaN; }
-        @Override public float getCurrentMoveStrafe() { return Float.NaN; }
-        @Override public boolean isCurrentWallCollision() { return false; }
-        @Override public Vec3dCore getCurrentVelocity() { return Vec3dCore.ZERO; }
-        @Override public boolean isCurrentSoftCollision() { return false; }
-        @Override public double getCurrentCollisionAngleDegrees() { return Double.NaN; }
-        @Override public float getCurrentYaw() { return 0f; }
-        @Override public List<Vec3dCore> getCurrentSubtickPath() { return Collections.emptyList(); }
-        @Override public Vec3dCore getStartPosition() { return startPos; }
-        @Override public void setStartPosition(Vec3dCore pos) { startPos = pos; }
-        @Override public Vec3dCore getStartVelocity() { return startVel; }
-        @Override public void setStartVelocity(Vec3dCore vel) { startVel = vel; }
-        @Override public float getStartYaw() { return startYaw; }
-        @Override public void setStartYaw(float yaw) { startYaw = yaw; }
-        @Override public Checkpoint saveCheckpoint() { return null; }
-        @Override public void restoreCheckpoint(Checkpoint checkpoint) { }
-        @Override public void invalidate() { }
-    }
-
     private static final class Rig {
         final InputData data = new InputData();
         final Settings settings = new Settings();
@@ -69,7 +34,7 @@ public class AutoSaveTest {
         final SimulationRunner runner;
 
         Rig(Path dir) {
-            runner = new SimulationRunner(new NullSimulator());
+            runner = new SimulationRunner(new FakeSimulator());
             controller = new SaveController(data, runner, (MinecraftAccess) null, () -> { });
             store = new FileSystemSaveStore(dir, "test", "1.8.9", () -> null);
             controller.setSaveStore(store);

--- a/core/src/test/java/de/legoshi/parkourcalc/core/FakePlaybackBridge.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/FakePlaybackBridge.java
@@ -1,0 +1,41 @@
+package de.legoshi.parkourcalc.core;
+
+import de.legoshi.parkourcalc.core.ports.PlaybackBridge;
+import de.legoshi.parkourcalc.core.sim.Checkpoint;
+import de.legoshi.parkourcalc.core.sim.Vec3dCore;
+import de.legoshi.parkourcalc.core.ui.InputRow;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+public class FakePlaybackBridge implements PlaybackBridge {
+
+    public boolean paused;
+    public int releaseAllCalls;
+    public int suppressFlightCalls;
+    public int teleportCalls;
+    public Vec3dCore teleportPos;
+    public Vec3dCore teleportVel;
+    public float teleportYaw;
+    public Checkpoint teleportCarry;
+    public final Map<InputRow.Key, Boolean> keys = new EnumMap<InputRow.Key, Boolean>(InputRow.Key.class);
+
+    @Override public boolean isSingleplayer() { return true; }
+    @Override public boolean isGamePaused() { return paused; }
+
+    @Override
+    public void teleport(Vec3dCore pos, Vec3dCore vel, float yaw, Checkpoint carry) {
+        teleportPos = pos;
+        teleportVel = vel;
+        teleportYaw = yaw;
+        teleportCarry = carry;
+        teleportCalls++;
+    }
+
+    @Override public void setKey(InputRow.Key key, boolean pressed) { keys.put(key, pressed); }
+    @Override public void setYaw(float absoluteYaw) { }
+    @Override public void releaseAllKeys() { releaseAllCalls++; keys.clear(); }
+    @Override public void suppressFlight() { suppressFlightCalls++; }
+    @Override public void closeUI() { }
+    @Override public void applyEffects(int speedAmplifier, int jumpBoostAmplifier) { }
+}

--- a/core/src/test/java/de/legoshi/parkourcalc/core/FakeSimulator.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/FakeSimulator.java
@@ -1,0 +1,41 @@
+package de.legoshi.parkourcalc.core;
+
+import de.legoshi.parkourcalc.core.ports.Simulator;
+import de.legoshi.parkourcalc.core.sim.Checkpoint;
+import de.legoshi.parkourcalc.core.sim.Vec3dCore;
+import de.legoshi.parkourcalc.core.ui.InputRow;
+
+import java.util.Collections;
+import java.util.List;
+
+public class FakeSimulator implements Simulator {
+
+    private Vec3dCore startPos = Vec3dCore.ZERO;
+    private Vec3dCore startVel = Vec3dCore.ZERO;
+    private float startYaw;
+
+    @Override public void resetToStart() { }
+    @Override public void applyInput(InputRow row) { }
+    @Override public void tick() { }
+    @Override public Vec3dCore getCurrentPosition() { return Vec3dCore.ZERO; }
+    @Override public boolean isCurrentOnGround() { return false; }
+    @Override public boolean isCurrentSneaking() { return false; }
+    @Override public boolean isCurrentSprinting() { return false; }
+    @Override public float getCurrentMoveForward() { return Float.NaN; }
+    @Override public float getCurrentMoveStrafe() { return Float.NaN; }
+    @Override public boolean isCurrentWallCollision() { return false; }
+    @Override public Vec3dCore getCurrentVelocity() { return Vec3dCore.ZERO; }
+    @Override public boolean isCurrentSoftCollision() { return false; }
+    @Override public double getCurrentCollisionAngleDegrees() { return Double.NaN; }
+    @Override public float getCurrentYaw() { return 0f; }
+    @Override public List<Vec3dCore> getCurrentSubtickPath() { return Collections.emptyList(); }
+    @Override public Vec3dCore getStartPosition() { return startPos; }
+    @Override public void setStartPosition(Vec3dCore pos) { startPos = pos; }
+    @Override public Vec3dCore getStartVelocity() { return startVel; }
+    @Override public void setStartVelocity(Vec3dCore vel) { startVel = vel; }
+    @Override public float getStartYaw() { return startYaw; }
+    @Override public void setStartYaw(float yaw) { startYaw = yaw; }
+    @Override public Checkpoint saveCheckpoint() { return null; }
+    @Override public void restoreCheckpoint(Checkpoint checkpoint) { }
+    @Override public void invalidate() { }
+}

--- a/core/src/test/java/de/legoshi/parkourcalc/core/LastOpenReopenTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/LastOpenReopenTest.java
@@ -1,20 +1,15 @@
 package de.legoshi.parkourcalc.core;
 
 import de.legoshi.parkourcalc.core.ports.MinecraftAccess;
-import de.legoshi.parkourcalc.core.ports.Simulator;
 import de.legoshi.parkourcalc.core.save.FileSystemSaveStore;
 import de.legoshi.parkourcalc.core.save.WorldDescriptor;
-import de.legoshi.parkourcalc.core.sim.Checkpoint;
 import de.legoshi.parkourcalc.core.sim.SimulationRunner;
-import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.InputData;
 import de.legoshi.parkourcalc.core.ui.InputRow;
 import org.junit.Test;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collections;
-import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -23,44 +18,13 @@ import static org.junit.Assert.assertTrue;
 
 public class LastOpenReopenTest {
 
-    private static final class NullSimulator implements Simulator {
-        private Vec3dCore startPos = Vec3dCore.ZERO;
-        private Vec3dCore startVel = Vec3dCore.ZERO;
-        private float startYaw;
-
-        @Override public void resetToStart() { }
-        @Override public void applyInput(InputRow row) { }
-        @Override public void tick() { }
-        @Override public Vec3dCore getCurrentPosition() { return Vec3dCore.ZERO; }
-        @Override public boolean isCurrentOnGround() { return false; }
-        @Override public boolean isCurrentSneaking() { return false; }
-        @Override public boolean isCurrentSprinting() { return false; }
-        @Override public float getCurrentMoveForward() { return Float.NaN; }
-        @Override public float getCurrentMoveStrafe() { return Float.NaN; }
-        @Override public boolean isCurrentWallCollision() { return false; }
-        @Override public Vec3dCore getCurrentVelocity() { return Vec3dCore.ZERO; }
-        @Override public boolean isCurrentSoftCollision() { return false; }
-        @Override public double getCurrentCollisionAngleDegrees() { return Double.NaN; }
-        @Override public float getCurrentYaw() { return 0f; }
-        @Override public List<Vec3dCore> getCurrentSubtickPath() { return Collections.emptyList(); }
-        @Override public Vec3dCore getStartPosition() { return startPos; }
-        @Override public void setStartPosition(Vec3dCore pos) { startPos = pos; }
-        @Override public Vec3dCore getStartVelocity() { return startVel; }
-        @Override public void setStartVelocity(Vec3dCore vel) { startVel = vel; }
-        @Override public float getStartYaw() { return startYaw; }
-        @Override public void setStartYaw(float yaw) { startYaw = yaw; }
-        @Override public Checkpoint saveCheckpoint() { return null; }
-        @Override public void restoreCheckpoint(Checkpoint checkpoint) { }
-        @Override public void invalidate() { }
-    }
-
     private static final class Rig {
         final InputData data = new InputData();
         final SaveController controller;
         final FileSystemSaveStore store;
 
         Rig(Path dir, WorldDescriptor world) {
-            SimulationRunner runner = new SimulationRunner(new NullSimulator());
+            SimulationRunner runner = new SimulationRunner(new FakeSimulator());
             controller = new SaveController(data, runner, (MinecraftAccess) null, () -> { });
             store = new FileSystemSaveStore(dir, "test", "1.8.9", () -> world);
             controller.setSaveStore(store);

--- a/core/src/test/java/de/legoshi/parkourcalc/core/PlaybackFlightSuppressionTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/PlaybackFlightSuppressionTest.java
@@ -1,9 +1,6 @@
 package de.legoshi.parkourcalc.core;
 
-import de.legoshi.parkourcalc.core.ports.PlaybackBridge;
-import de.legoshi.parkourcalc.core.ports.Simulator;
 import de.legoshi.parkourcalc.core.sim.SimulationRunner;
-import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.InputData;
 import de.legoshi.parkourcalc.core.ui.InputRow;
 import de.legoshi.parkourcalc.core.ui.Settings;
@@ -14,52 +11,6 @@ import static org.junit.Assert.assertTrue;
 
 public class PlaybackFlightSuppressionTest {
 
-    private static final class FakeBridge implements PlaybackBridge {
-        boolean paused;
-        int suppressFlightCalls;
-
-        @Override public boolean isSingleplayer() { return true; }
-        @Override public boolean isGamePaused() { return paused; }
-        @Override public void teleport(Vec3dCore pos, Vec3dCore vel, float yaw, de.legoshi.parkourcalc.core.sim.Checkpoint carry) { }
-        @Override public void setKey(InputRow.Key key, boolean pressed) { }
-        @Override public void setYaw(float absoluteYaw) { }
-        @Override public void releaseAllKeys() { }
-        @Override public void suppressFlight() { suppressFlightCalls++; }
-        @Override public void closeUI() { }
-        @Override public void applyEffects(int speedAmplifier, int jumpBoostAmplifier) { }
-    }
-
-    private static final class FakeSimulator implements Simulator {
-        private Vec3dCore startPos = Vec3dCore.ZERO;
-        private Vec3dCore startVel = Vec3dCore.ZERO;
-        private float startYaw;
-
-        @Override public void resetToStart() { }
-        @Override public void applyInput(InputRow row) { }
-        @Override public void tick() { }
-        @Override public Vec3dCore getCurrentPosition() { return Vec3dCore.ZERO; }
-        @Override public boolean isCurrentOnGround() { return false; }
-        @Override public boolean isCurrentSneaking() { return false; }
-        @Override public boolean isCurrentSprinting() { return false; }
-        @Override public float getCurrentMoveForward() { return Float.NaN; }
-        @Override public float getCurrentMoveStrafe() { return Float.NaN; }
-        @Override public boolean isCurrentWallCollision() { return false; }
-        @Override public Vec3dCore getCurrentVelocity() { return Vec3dCore.ZERO; }
-        @Override public boolean isCurrentSoftCollision() { return false; }
-        @Override public double getCurrentCollisionAngleDegrees() { return Double.NaN; }
-        @Override public float getCurrentYaw() { return 0f; }
-        @Override public java.util.List<Vec3dCore> getCurrentSubtickPath() { return java.util.Collections.emptyList(); }
-        @Override public Vec3dCore getStartPosition() { return startPos; }
-        @Override public void setStartPosition(Vec3dCore pos) { startPos = pos; }
-        @Override public Vec3dCore getStartVelocity() { return startVel; }
-        @Override public void setStartVelocity(Vec3dCore vel) { startVel = vel; }
-        @Override public float getStartYaw() { return startYaw; }
-        @Override public void setStartYaw(float yaw) { startYaw = yaw; }
-        @Override public de.legoshi.parkourcalc.core.sim.Checkpoint saveCheckpoint() { return null; }
-        @Override public void restoreCheckpoint(de.legoshi.parkourcalc.core.sim.Checkpoint checkpoint) { }
-        @Override public void invalidate() { }
-    }
-
     private static InputData rows(int n) {
         InputData data = new InputData();
         for (int i = 0; i < n; i++) {
@@ -68,7 +19,7 @@ public class PlaybackFlightSuppressionTest {
         return data;
     }
 
-    private static PlaybackController controller(FakeBridge bridge, Settings settings, InputData data) {
+    private static PlaybackController controller(FakePlaybackBridge bridge, Settings settings, InputData data) {
         PlaybackController pc = new PlaybackController(data, new SimulationRunner(new FakeSimulator()), settings);
         pc.setBridge(bridge);
         return pc;
@@ -82,7 +33,7 @@ public class PlaybackFlightSuppressionTest {
     @Test
     public void suppressesEveryRunningTickIncludingWarmupAndTail() {
         InputData data = rows(2);
-        FakeBridge bridge = new FakeBridge();
+        FakePlaybackBridge bridge = new FakePlaybackBridge();
         PlaybackController pc = controller(bridge, new Settings(), data);
 
         pc.tick();
@@ -106,7 +57,7 @@ public class PlaybackFlightSuppressionTest {
     @Test
     public void settingOffNeverSuppresses() {
         InputData data = rows(2);
-        FakeBridge bridge = new FakeBridge();
+        FakePlaybackBridge bridge = new FakePlaybackBridge();
         Settings settings = new Settings();
         settings.disableFlightDuringPlayback = false;
         PlaybackController pc = controller(bridge, settings, data);
@@ -122,7 +73,7 @@ public class PlaybackFlightSuppressionTest {
     @Test
     public void pausedTicksDoNotSuppress() {
         InputData data = rows(2);
-        FakeBridge bridge = new FakeBridge();
+        FakePlaybackBridge bridge = new FakePlaybackBridge();
         PlaybackController pc = controller(bridge, new Settings(), data);
 
         pc.start();

--- a/core/src/test/java/de/legoshi/parkourcalc/core/PlaybackFlightSuppressionTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/PlaybackFlightSuppressionTest.java
@@ -1,0 +1,138 @@
+package de.legoshi.parkourcalc.core;
+
+import de.legoshi.parkourcalc.core.ports.PlaybackBridge;
+import de.legoshi.parkourcalc.core.ports.Simulator;
+import de.legoshi.parkourcalc.core.sim.SimulationRunner;
+import de.legoshi.parkourcalc.core.sim.Vec3dCore;
+import de.legoshi.parkourcalc.core.ui.InputData;
+import de.legoshi.parkourcalc.core.ui.InputRow;
+import de.legoshi.parkourcalc.core.ui.Settings;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class PlaybackFlightSuppressionTest {
+
+    private static final class FakeBridge implements PlaybackBridge {
+        boolean paused;
+        int suppressFlightCalls;
+
+        @Override public boolean isSingleplayer() { return true; }
+        @Override public boolean isGamePaused() { return paused; }
+        @Override public void teleport(Vec3dCore pos, Vec3dCore vel, float yaw, de.legoshi.parkourcalc.core.sim.Checkpoint carry) { }
+        @Override public void setKey(InputRow.Key key, boolean pressed) { }
+        @Override public void setYaw(float absoluteYaw) { }
+        @Override public void releaseAllKeys() { }
+        @Override public void suppressFlight() { suppressFlightCalls++; }
+        @Override public void closeUI() { }
+        @Override public void applyEffects(int speedAmplifier, int jumpBoostAmplifier) { }
+    }
+
+    private static final class FakeSimulator implements Simulator {
+        private Vec3dCore startPos = Vec3dCore.ZERO;
+        private Vec3dCore startVel = Vec3dCore.ZERO;
+        private float startYaw;
+
+        @Override public void resetToStart() { }
+        @Override public void applyInput(InputRow row) { }
+        @Override public void tick() { }
+        @Override public Vec3dCore getCurrentPosition() { return Vec3dCore.ZERO; }
+        @Override public boolean isCurrentOnGround() { return false; }
+        @Override public boolean isCurrentSneaking() { return false; }
+        @Override public boolean isCurrentSprinting() { return false; }
+        @Override public float getCurrentMoveForward() { return Float.NaN; }
+        @Override public float getCurrentMoveStrafe() { return Float.NaN; }
+        @Override public boolean isCurrentWallCollision() { return false; }
+        @Override public Vec3dCore getCurrentVelocity() { return Vec3dCore.ZERO; }
+        @Override public boolean isCurrentSoftCollision() { return false; }
+        @Override public double getCurrentCollisionAngleDegrees() { return Double.NaN; }
+        @Override public float getCurrentYaw() { return 0f; }
+        @Override public java.util.List<Vec3dCore> getCurrentSubtickPath() { return java.util.Collections.emptyList(); }
+        @Override public Vec3dCore getStartPosition() { return startPos; }
+        @Override public void setStartPosition(Vec3dCore pos) { startPos = pos; }
+        @Override public Vec3dCore getStartVelocity() { return startVel; }
+        @Override public void setStartVelocity(Vec3dCore vel) { startVel = vel; }
+        @Override public float getStartYaw() { return startYaw; }
+        @Override public void setStartYaw(float yaw) { startYaw = yaw; }
+        @Override public de.legoshi.parkourcalc.core.sim.Checkpoint saveCheckpoint() { return null; }
+        @Override public void restoreCheckpoint(de.legoshi.parkourcalc.core.sim.Checkpoint checkpoint) { }
+        @Override public void invalidate() { }
+    }
+
+    private static InputData rows(int n) {
+        InputData data = new InputData();
+        for (int i = 0; i < n; i++) {
+            data.getRows().add(new InputRow());
+        }
+        return data;
+    }
+
+    private static PlaybackController controller(FakeBridge bridge, Settings settings, InputData data) {
+        PlaybackController pc = new PlaybackController(data, new SimulationRunner(new FakeSimulator()), settings);
+        pc.setBridge(bridge);
+        return pc;
+    }
+
+    @Test
+    public void defaultsToOn() {
+        assertTrue(new Settings().disableFlightDuringPlayback);
+    }
+
+    @Test
+    public void suppressesEveryRunningTickIncludingWarmupAndTail() {
+        InputData data = rows(2);
+        FakeBridge bridge = new FakeBridge();
+        PlaybackController pc = controller(bridge, new Settings(), data);
+
+        pc.tick();
+        assertEquals("idle ticks never suppress", 0, bridge.suppressFlightCalls);
+
+        pc.start();
+        pc.tick();
+        pc.tick();
+        assertEquals("warmup ticks suppress", 2, bridge.suppressFlightCalls);
+        pc.tick();
+        pc.tick();
+        assertEquals(4, bridge.suppressFlightCalls);
+        pc.tick();
+        assertEquals("the tail wait after the last row still suppresses", 5, bridge.suppressFlightCalls);
+
+        pc.stop();
+        pc.tick();
+        assertEquals(5, bridge.suppressFlightCalls);
+    }
+
+    @Test
+    public void settingOffNeverSuppresses() {
+        InputData data = rows(2);
+        FakeBridge bridge = new FakeBridge();
+        Settings settings = new Settings();
+        settings.disableFlightDuringPlayback = false;
+        PlaybackController pc = controller(bridge, settings, data);
+
+        pc.start();
+        pc.tick();
+        pc.tick();
+        pc.tick();
+        pc.tick();
+        assertEquals(0, bridge.suppressFlightCalls);
+    }
+
+    @Test
+    public void pausedTicksDoNotSuppress() {
+        InputData data = rows(2);
+        FakeBridge bridge = new FakeBridge();
+        PlaybackController pc = controller(bridge, new Settings(), data);
+
+        pc.start();
+        bridge.paused = true;
+        pc.tick();
+        pc.tick();
+        assertEquals(0, bridge.suppressFlightCalls);
+
+        bridge.paused = false;
+        pc.tick();
+        assertEquals(1, bridge.suppressFlightCalls);
+    }
+}

--- a/core/src/test/java/de/legoshi/parkourcalc/core/PlaybackRangeTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/PlaybackRangeTest.java
@@ -1,7 +1,5 @@
 package de.legoshi.parkourcalc.core;
 
-import de.legoshi.parkourcalc.core.ports.PlaybackBridge;
-import de.legoshi.parkourcalc.core.ports.Simulator;
 import de.legoshi.parkourcalc.core.sim.SimulationRunner;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.InputData;
@@ -9,70 +7,11 @@ import de.legoshi.parkourcalc.core.ui.InputRow;
 import de.legoshi.parkourcalc.core.ui.Settings;
 import org.junit.Test;
 
-import java.util.EnumMap;
-import java.util.Map;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class PlaybackRangeTest {
-
-    private static final class FakeBridge implements PlaybackBridge {
-        Vec3dCore teleportPos;
-        Vec3dCore teleportVel;
-        float teleportYaw;
-        int teleportCalls;
-        final Map<InputRow.Key, Boolean> keys = new EnumMap<>(InputRow.Key.class);
-
-        @Override public boolean isSingleplayer() { return true; }
-        @Override public boolean isGamePaused() { return false; }
-
-        @Override
-        public void teleport(Vec3dCore pos, Vec3dCore vel, float yaw, de.legoshi.parkourcalc.core.sim.Checkpoint carry) {
-            teleportPos = pos;
-            teleportVel = vel;
-            teleportYaw = yaw;
-            teleportCalls++;
-        }
-
-        @Override public void setKey(InputRow.Key key, boolean pressed) { keys.put(key, pressed); }
-        @Override public void setYaw(float absoluteYaw) { }
-        @Override public void releaseAllKeys() { keys.clear(); }
-        @Override public void closeUI() { }
-        @Override public void applyEffects(int speedAmplifier, int jumpBoostAmplifier) { }
-    }
-
-    private static final class FakeSimulator implements Simulator {
-        private Vec3dCore startPos = Vec3dCore.ZERO;
-        private Vec3dCore startVel = Vec3dCore.ZERO;
-        private float startYaw;
-
-        @Override public void resetToStart() { }
-        @Override public void applyInput(InputRow row) { }
-        @Override public void tick() { }
-        @Override public Vec3dCore getCurrentPosition() { return Vec3dCore.ZERO; }
-        @Override public boolean isCurrentOnGround() { return false; }
-        @Override public boolean isCurrentSneaking() { return false; }
-        @Override public boolean isCurrentSprinting() { return false; }
-        @Override public float getCurrentMoveForward() { return Float.NaN; }
-        @Override public float getCurrentMoveStrafe() { return Float.NaN; }
-        @Override public boolean isCurrentWallCollision() { return false; }
-        @Override public Vec3dCore getCurrentVelocity() { return Vec3dCore.ZERO; }
-        @Override public boolean isCurrentSoftCollision() { return false; }
-        @Override public double getCurrentCollisionAngleDegrees() { return Double.NaN; }
-        @Override public float getCurrentYaw() { return 0f; }
-        @Override public java.util.List<Vec3dCore> getCurrentSubtickPath() { return java.util.Collections.emptyList(); }
-        @Override public Vec3dCore getStartPosition() { return startPos; }
-        @Override public void setStartPosition(Vec3dCore pos) { startPos = pos; }
-        @Override public Vec3dCore getStartVelocity() { return startVel; }
-        @Override public void setStartVelocity(Vec3dCore vel) { startVel = vel; }
-        @Override public float getStartYaw() { return startYaw; }
-        @Override public void setStartYaw(float yaw) { startYaw = yaw; }
-        @Override public de.legoshi.parkourcalc.core.sim.Checkpoint saveCheckpoint() { return null; }
-        @Override public void restoreCheckpoint(de.legoshi.parkourcalc.core.sim.Checkpoint checkpoint) { }
-        @Override public void invalidate() { }
-    }
 
     private static InputData rows(int n) {
         InputRow.Key[] keys = InputRow.Key.values();
@@ -90,7 +29,7 @@ public class PlaybackRangeTest {
         return keys[rowIndex % keys.length];
     }
 
-    private static PlaybackController controller(FakeBridge bridge, SimulationRunner runner, InputData data) {
+    private static PlaybackController controller(FakePlaybackBridge bridge, SimulationRunner runner, InputData data) {
         PlaybackController pc = new PlaybackController(data, runner, new Settings());
         pc.setBridge(bridge);
         return pc;
@@ -99,7 +38,7 @@ public class PlaybackRangeTest {
     @Test
     public void startsAtTheChosenTickWithNoWarmupAndTeleportsToTheGivenState() {
         InputData data = rows(6);
-        FakeBridge bridge = new FakeBridge();
+        FakePlaybackBridge bridge = new FakePlaybackBridge();
         PlaybackController pc = controller(bridge, new SimulationRunner(new FakeSimulator()), data);
 
         Vec3dCore pos = new Vec3dCore(10, 64, -5);
@@ -121,7 +60,7 @@ public class PlaybackRangeTest {
     @Test
     public void rangeStopsAfterItsLastTickAndNeverPlaysBeyondIt() throws Exception {
         InputData data = rows(8);
-        FakeBridge bridge = new FakeBridge();
+        FakePlaybackBridge bridge = new FakePlaybackBridge();
         PlaybackController pc = controller(bridge, new SimulationRunner(new FakeSimulator()), data);
 
         pc.start(2, 5, Vec3dCore.ZERO, Vec3dCore.ZERO, 0f);
@@ -143,7 +82,7 @@ public class PlaybackRangeTest {
     @Test
     public void noArgStartWithoutResolverReplaysWholeTasFromTheTopWithWarmup() {
         InputData data = rows(3);
-        FakeBridge bridge = new FakeBridge();
+        FakePlaybackBridge bridge = new FakePlaybackBridge();
         SimulationRunner runner = new SimulationRunner(new FakeSimulator());
         runner.setStartPosition(new Vec3dCore(1, 2, 3));
         runner.setStartYaw(45f);
@@ -165,7 +104,7 @@ public class PlaybackRangeTest {
     @Test
     public void startRangeResolverDrivesTheNoArgStart() {
         InputData data = rows(6);
-        FakeBridge bridge = new FakeBridge();
+        FakePlaybackBridge bridge = new FakePlaybackBridge();
         PlaybackController pc = controller(bridge, new SimulationRunner(new FakeSimulator()), data);
 
         Vec3dCore pos = new Vec3dCore(7, 8, 9);
@@ -180,7 +119,7 @@ public class PlaybackRangeTest {
     @Test
     public void statusHintDescribesTheRangeButNotAFullFromTopReplay() {
         InputData data = rows(10);
-        FakeBridge bridge = new FakeBridge();
+        FakePlaybackBridge bridge = new FakePlaybackBridge();
         PlaybackController pc = controller(bridge, new SimulationRunner(new FakeSimulator()), data);
 
         assertEquals("idle has no hint", "", pc.statusHint());

--- a/core/src/test/java/de/legoshi/parkourcalc/core/UndoIntegrationTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/UndoIntegrationTest.java
@@ -2,10 +2,8 @@ package de.legoshi.parkourcalc.core;
 
 import de.legoshi.parkourcalc.core.anglesolver.AngleSolverState;
 import de.legoshi.parkourcalc.core.ports.MinecraftAccess;
-import de.legoshi.parkourcalc.core.ports.Simulator;
 import de.legoshi.parkourcalc.core.save.FileSystemSaveStore;
 import de.legoshi.parkourcalc.core.save.SaveIO;
-import de.legoshi.parkourcalc.core.sim.Checkpoint;
 import de.legoshi.parkourcalc.core.sim.SimulationRunner;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.InputData;
@@ -27,37 +25,6 @@ public class UndoIntegrationTest {
 
     private static final long STEP = UndoController.POLL_INTERVAL_NANOS + 50_000_000L;
 
-    private static final class NullSimulator implements Simulator {
-        private Vec3dCore startPos = Vec3dCore.ZERO;
-        private Vec3dCore startVel = Vec3dCore.ZERO;
-        private float startYaw;
-
-        @Override public void resetToStart() { }
-        @Override public void applyInput(InputRow row) { }
-        @Override public void tick() { }
-        @Override public Vec3dCore getCurrentPosition() { return Vec3dCore.ZERO; }
-        @Override public boolean isCurrentOnGround() { return false; }
-        @Override public boolean isCurrentSneaking() { return false; }
-        @Override public boolean isCurrentSprinting() { return false; }
-        @Override public float getCurrentMoveForward() { return Float.NaN; }
-        @Override public float getCurrentMoveStrafe() { return Float.NaN; }
-        @Override public boolean isCurrentWallCollision() { return false; }
-        @Override public Vec3dCore getCurrentVelocity() { return Vec3dCore.ZERO; }
-        @Override public boolean isCurrentSoftCollision() { return false; }
-        @Override public double getCurrentCollisionAngleDegrees() { return Double.NaN; }
-        @Override public float getCurrentYaw() { return 0f; }
-        @Override public List<Vec3dCore> getCurrentSubtickPath() { return Collections.emptyList(); }
-        @Override public Vec3dCore getStartPosition() { return startPos; }
-        @Override public void setStartPosition(Vec3dCore pos) { startPos = pos; }
-        @Override public Vec3dCore getStartVelocity() { return startVel; }
-        @Override public void setStartVelocity(Vec3dCore vel) { startVel = vel; }
-        @Override public float getStartYaw() { return startYaw; }
-        @Override public void setStartYaw(float yaw) { startYaw = yaw; }
-        @Override public Checkpoint saveCheckpoint() { return null; }
-        @Override public void restoreCheckpoint(Checkpoint checkpoint) { }
-        @Override public void invalidate() { }
-    }
-
     private static final class Rig {
         final InputData data = new InputData();
         final AngleSolverState solver = new AngleSolverState();
@@ -70,7 +37,7 @@ public class UndoIntegrationTest {
         long now = 1L;
 
         Rig(Path dir) {
-            runner = new SimulationRunner(new NullSimulator());
+            runner = new SimulationRunner(new FakeSimulator());
             runner.setStartVelocity(Vec3dCore.GROUND_REST_VELOCITY);
             controller = new SaveController(data, runner, (MinecraftAccess) null, () -> fullResims++);
             controller.setRetriggerFrom(partialResims::add);

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricPlaybackBridge.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricPlaybackBridge.java
@@ -5,6 +5,7 @@ import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.InputRow;
 import de.legoshi.parkourcalc.fabric.mixin.LocalPlayerAccessor;
 import de.legoshi.parkourcalc.fabric.mixin.KeyMappingAccessor;
+import de.legoshi.parkourcalc.fabric.mixin.PlayerAccessor;
 import de.legoshi.parkourcalc.fabric.sim.GhostPlayerEntity;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
@@ -16,6 +17,7 @@ import net.minecraft.network.protocol.game.ServerboundMovePlayerPacket;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.PositionMoveRotation;
+import net.minecraft.world.entity.player.Abilities;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
@@ -264,6 +266,19 @@ public final class FabricPlaybackBridge implements PlaybackBridge {
     public void releaseAllKeys() {
         for (InputRow.Key k : InputRow.Key.values()) {
             setKey(k, false);
+        }
+    }
+
+    @Override
+    public void suppressFlight() {
+        if (ghostMode) return;
+        LocalPlayer p = Minecraft.getInstance().player;
+        if (p == null) return;
+        ((PlayerAccessor) p).pkc$setJumpTriggerTime(0);
+        Abilities abilities = p.getAbilities();
+        if (abilities.flying) {
+            abilities.flying = false;
+            p.onUpdateAbilities();
         }
     }
 

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/mixin/PlayerAccessor.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/mixin/PlayerAccessor.java
@@ -1,0 +1,11 @@
+package de.legoshi.parkourcalc.fabric.mixin;
+
+import net.minecraft.world.entity.player.Player;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(Player.class)
+public interface PlayerAccessor {
+
+    @Accessor("jumpTriggerTime") void pkc$setJumpTriggerTime(int v);
+}

--- a/loader-fabric/src/client/resources/parkourcalculator.client.mixins.json
+++ b/loader-fabric/src/client/resources/parkourcalculator.client.mixins.json
@@ -13,7 +13,8 @@
     "KeyboardHandlerMixin",
     "LandingParticleSuppressMixin",
     "MinecraftMixin",
-    "MouseHandlerMixin"
+    "MouseHandlerMixin",
+    "PlayerAccessor"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12PlaybackBridge.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12PlaybackBridge.java
@@ -273,6 +273,18 @@ public final class Forge12PlaybackBridge implements PlaybackBridge {
     }
 
     @Override
+    public void suppressFlight() {
+        if (ghostMode) return;
+        EntityPlayerSP p = Minecraft.getMinecraft().player;
+        if (p == null) return;
+        p.flyToggleTimer = 0;
+        if (p.capabilities.isFlying) {
+            p.capabilities.isFlying = false;
+            p.sendPlayerAbilities();
+        }
+    }
+
+    @Override
     public void closeUI() {
         Minecraft mc = Minecraft.getMinecraft();
         if (mc.currentScreen != null) {

--- a/loader-forge-1.12.2/src/main/resources/META-INF/parkourcalculator_at.cfg
+++ b/loader-forge-1.12.2/src/main/resources/META-INF/parkourcalculator_at.cfg
@@ -1,5 +1,6 @@
 public net.minecraft.entity.EntityLivingBase jumpTicks
 public net.minecraft.entity.EntityLivingBase isJumping
+public net.minecraft.entity.player.EntityPlayer flyToggleTimer
 public net.minecraft.client.entity.EntityPlayerSP lastReportedPosX
 public net.minecraft.client.entity.EntityPlayerSP lastReportedPosY
 public net.minecraft.client.entity.EntityPlayerSP lastReportedPosZ

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8PlaybackBridge.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8PlaybackBridge.java
@@ -274,6 +274,18 @@ public final class Forge8PlaybackBridge implements PlaybackBridge {
     }
 
     @Override
+    public void suppressFlight() {
+        if (ghostMode) return;
+        EntityPlayerSP p = Minecraft.getMinecraft().thePlayer;
+        if (p == null) return;
+        p.flyToggleTimer = 0;
+        if (p.capabilities.isFlying) {
+            p.capabilities.isFlying = false;
+            p.sendPlayerAbilities();
+        }
+    }
+
+    @Override
     public void closeUI() {
         Minecraft mc = Minecraft.getMinecraft();
         if (mc.currentScreen != null) {

--- a/loader-forge-1.8.9/src/main/resources/META-INF/parkourcalculator_at.cfg
+++ b/loader-forge-1.8.9/src/main/resources/META-INF/parkourcalculator_at.cfg
@@ -1,5 +1,6 @@
 public net.minecraft.entity.EntityLivingBase jumpTicks
 public net.minecraft.entity.EntityLivingBase isJumping
+public net.minecraft.entity.player.EntityPlayer flyToggleTimer
 public net.minecraft.client.entity.EntityPlayerSP lastReportedPosX
 public net.minecraft.client.entity.EntityPlayerSP lastReportedPosY
 public net.minecraft.client.entity.EntityPlayerSP lastReportedPosZ


### PR DESCRIPTION
Closes #256

## What

Adds a "Disable creative flight" checkbox to Settings -> Playback (default on). While playback runs, double-tapping jump can no longer start creative flight, and a player already flying at playback start is forced out of flight. Flight behaves normally again the moment playback ends; nothing changes while playback is idle.

## How

The double-tap toggle arms a 7-tick timer on the base player class (`flyToggleTimer` on 1.8.9/1.12.2, `jumpTriggerTime` on 26.2). Each playback tick, before the player's physics tick, the new `PlaybackBridge.suppressFlight()` zeroes that timer and clears an active `flying` state (re-syncing abilities to the server), so flight never engages, not even for a single physics tick. `PlaybackController` calls it on every running tick (warmup and tail included, paused ticks excluded) when the setting is on.

- core: `Settings` field (persisted automatically), `SettingsModal` checkbox + tooltip, `PlaybackBridge.suppressFlight()` port, `PlaybackController` per-tick call
- loader-fabric: `PlayerAccessor` mixin for `jumpTriggerTime`; clears `abilities.flying` + `onUpdateAbilities()`; no-op in ghost mode so a flying spectating player in multiplayer is untouched
- loader-forge-1.8.9 / 1.12.2: AT entry for `EntityPlayer.flyToggleTimer`; clears `capabilities.isFlying` + `sendPlayerAbilities()`; both final jars verified to carry the SRG-remapped AT entry (`field_71101_bC`)

## Tests

- New `PlaybackFlightSuppressionTest` in core: default-on, suppression on every running tick including warmup and tail, no suppression when the setting is off or while paused
- `:core:test` and full `./gradlew build` green

## QA

In-game QA pending on all three loaders (all touched): creative double-jump TAS in singleplayer with the setting on (no flight), off (old behavior), and toggling flight manually after playback ends.
