### PR TITLE
fix(solver): read the modern air sprint factor live so Derive catches tick-0 engagement

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/AngleSolverEngine.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/AngleSolverEngine.java
@@ -632,6 +632,7 @@ public final class AngleSolverEngine {
         phys.forwardInputPerTick = forwardIn;
         phys.strafeInputPerTick = strafeIn;
         phys.sprintPerTick = sprintArr;
+        phys.liveAirSprintFactor = modernCollision;
         phys.incomingSprint = effSprint(startTick) == AngleSolverState.SprintMode.DERIVE
                 ? (seed.hasMovementSample() ? seed.sprinting : Boolean.TRUE)
                 : Boolean.TRUE;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/Scoring.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/Scoring.java
@@ -114,6 +114,7 @@ public final class Scoring {
         a.sprintPerTick = b.sprintPerTick;
         a.incomingSprint = b.incomingSprint;
         a.incomingAmp = b.incomingAmp;
+        a.liveAirSprintFactor = b.liveAirSprintFactor;
         a.forwardInputPerTick = b.forwardInputPerTick;
         a.strafeInputPerTick = b.strafeInputPerTick;
         return a;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/AlmSnapStage.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/AlmSnapStage.java
@@ -327,6 +327,7 @@ public final class AlmSnapStage {
         a.sprintPerTick = b.sprintPerTick;
         a.incomingSprint = b.incomingSprint;
         a.incomingAmp = b.incomingAmp;
+        a.liveAirSprintFactor = b.liveAirSprintFactor;
         a.forwardInputPerTick = b.forwardInputPerTick;
         a.strafeInputPerTick = b.strafeInputPerTick;
         return new JumpSpec(a, spec.constraints, spec.objective);

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/ExactJumpModel.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/ExactJumpModel.java
@@ -156,7 +156,7 @@ public final class ExactJumpModel implements ForwardModel {
             boolean fluidGroundJump = modern && fluid && contact && scenario.jumpAt(t);
             boolean isJumpTick = fluidGroundJump || (!fluid && scenario.jumpAt(t) && contact);
             boolean sprint = scenario.sprintAt(t);
-            boolean factorSprint = scenario.factorSprintAt(t);
+            boolean airSprint = modern ? sprint : scenario.factorSprintAt(t);
             if (modern && water && scenario.sneakAt(t)) {
                 vy -= FLUID_JUMP_BOOST;
             }
@@ -195,7 +195,7 @@ public final class ExactJumpModel implements ForwardModel {
                 accelSpeed = Constants.attrValueF(amp, sprint) * ground;
             } else {
                 f4 = 0.91F;
-                accelSpeed = factorSprint ? Constants.AIR_SPEED_F : Constants.AIR_SPEED_NO_SPRINT_F;
+                accelSpeed = airSprint ? Constants.AIR_SPEED_F : Constants.AIR_SPEED_NO_SPRINT_F;
             }
 
             // (4) input acceleration. Inputs are authored per tick (gh-102): force-45 ticks carry the W+A

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/FreeStartSolve.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/FreeStartSolve.java
@@ -377,6 +377,7 @@ public final class FreeStartSolve {
         a.sprintPerTick = b.sprintPerTick;
         a.incomingSprint = b.incomingSprint;
         a.incomingAmp = b.incomingAmp;
+        a.liveAirSprintFactor = b.liveAirSprintFactor;
         a.forwardInputPerTick = b.forwardInputPerTick;
         a.strafeInputPerTick = b.strafeInputPerTick;
         return a;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/JumpLinearModel.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/JumpLinearModel.java
@@ -115,7 +115,7 @@ public final class JumpLinearModel {
                 accelSpeed = Constants.attrValueF(sc.factorAmpAt(t), sprint) * (0.16277136 / (f4[t] * f4[t] * f4[t]));
             } else {
                 f4[t] = 0.91;
-                accelSpeed = sc.factorSprintAt(t) ? Constants.AIR_SPEED_F : Constants.AIR_SPEED_NO_SPRINT_F;
+                accelSpeed = sc.airFactorSprintAt(t) ? Constants.AIR_SPEED_F : Constants.AIR_SPEED_NO_SPRINT_F;
             }
             // Same per-tick input authoring as ExactJumpModel step (4) (gh-102).
             double forward0 = sc.forwardAt(t);

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/JumpPhysicsInputs.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/JumpPhysicsInputs.java
@@ -61,6 +61,8 @@ public final class JumpPhysicsInputs {
      *  single-tick model callers' behavior. */
     public Boolean incomingSprint = null;
 
+    public boolean liveAirSprintFactor = false;
+
     /** Speed-effect amplifier in force on the tick before this window's first tick. The ground attribute
      *  (getAIMoveSpeed = the movementSpeed snapshot) carries both the sprint and the speed-effect modifier,
      *  so the speed amplifier lags by the same one tick as sprint (see {@link #factorAmpAt}). Air is
@@ -99,6 +101,7 @@ public final class JumpPhysicsInputs {
         c.yawLockedPerTick = yawLockedPerTick;
         c.sprintPerTick = sprintPerTick;
         c.incomingSprint = incomingSprint;
+        c.liveAirSprintFactor = liveAirSprintFactor;
         c.incomingAmp = incomingAmp;
         c.forwardInputPerTick = forwardInputPerTick;
         c.strafeInputPerTick = strafeInputPerTick;
@@ -139,6 +142,10 @@ public final class JumpPhysicsInputs {
     public boolean factorSprintAt(int tick) {
         if (tick == 0) return incomingSprint != null ? incomingSprint : sprintAt(0);
         return sprintAt(tick - 1);
+    }
+
+    public boolean airFactorSprintAt(int tick) {
+        return liveAirSprintFactor ? sprintAt(tick) : factorSprintAt(tick);
     }
 
     /** Speed amplifier that drives this tick's ground movement factor, lagged one tick like the sprint

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/LongRunSolver.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/LongRunSolver.java
@@ -269,6 +269,7 @@ public final class LongRunSolver {
         p.sneakPerTick = sliceBool(sc.sneakPerTick, a, len);
         // null arrays stay null so the slice keeps the source's legacy fallbacks (always-sprint, W held).
         p.sprintPerTick = sliceBool(sc.sprintPerTick, a, len);
+        p.liveAirSprintFactor = sc.liveAirSprintFactor;
         p.forwardInputPerTick = sliceFloat(sc.forwardInputPerTick, a, len, 1.0F * 0.98F);
         p.strafeInputPerTick = sliceFloat(sc.strafeInputPerTick, a, len, 0.0F);
         return p;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/MomentumAssembly.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/MomentumAssembly.java
@@ -157,6 +157,7 @@ public final class MomentumAssembly {
         p.startYaw = sc.startYaw;
         p.incomingSprint = sc.incomingSprint;
         p.incomingAmp = sc.incomingAmp;
+        p.liveAirSprintFactor = sc.liveAirSprintFactor;
         p.strafeSign = sc.strafeSign;
         p.jumpPerTick = sc.jumpPerTick;
         p.strafePerTick = sc.strafePerTick;
@@ -388,6 +389,7 @@ public final class MomentumAssembly {
         sc.startYaw = (float) MENU[ai];
         sc.incomingSprint = t == 0 ? full.incomingSprint : full.sprintAt(t - 1);
         sc.incomingAmp = t == 0 ? full.incomingAmp : full.speedAmplifierAt(t - 1);
+        sc.liveAirSprintFactor = full.liveAirSprintFactor;
         sc.strafeSign = full.strafeSign;
         sc.jumpPerTick = new boolean[]{full.jumpAt(t)};
         sc.slipPerTick = new double[]{full.slipAt(t)};
@@ -430,6 +432,7 @@ public final class MomentumAssembly {
         p.strafeSign = sc.strafeSign;
         p.incomingSprint = a == 0 ? sc.incomingSprint : sc.sprintAt(a - 1);
         p.incomingAmp = a == 0 ? sc.incomingAmp : sc.speedAmplifierAt(a - 1);
+        p.liveAirSprintFactor = sc.liveAirSprintFactor;
         p.jumpPerTick = sliceBool(sc.jumpPerTick, a, len);
         p.strafePerTick = sliceBool(sc.strafePerTick, a, len);
         p.yawLockedPerTick = sliceBool(sc.yawLockedPerTick, a, len);

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/velocity/VelocityFinder.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/velocity/VelocityFinder.java
@@ -417,6 +417,7 @@ public final class VelocityFinder {
         c.sneakPerTick = s.sneakPerTick;
         c.yawLockedPerTick = s.yawLockedPerTick;
         c.sprintPerTick = s.sprintPerTick;
+        c.liveAirSprintFactor = s.liveAirSprintFactor;
         c.forwardInputPerTick = s.forwardInputPerTick;
         c.strafeInputPerTick = s.strafeInputPerTick;
         return c;

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/SprintSneakTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/SprintSneakTest.java
@@ -35,11 +35,16 @@ public class SprintSneakTest {
 
     private static JumpPhysicsInputs compile(InputData inputs, BoxController boxes, int numTicks,
                                              AngleSolverState state) {
+        return compile(inputs, boxes, numTicks, state, "1.8.9");
+    }
+
+    private static JumpPhysicsInputs compile(InputData inputs, BoxController boxes, int numTicks,
+                                             AngleSolverState state, String mcVersion) {
         state.setDefaultInputs(AngleSolverState.InputMode.KEEP);
         state.setStartTick(0);
         state.setLandingTick(numTicks);
         AngleSolverEngine engine = new AngleSolverEngine(state, boxes, inputs, t -> { },
-                ExactJumpModel.forMcVersion("1.8.9"));
+                ExactJumpModel.forMcVersion(mcVersion));
         JumpSpec spec = engine.debugBuildSpec();
         assertNotNull(spec);
         return spec.asScenario();
@@ -281,6 +286,74 @@ public class SprintSneakTest {
         assertEquals(on.posZ[1], pr.posZ[1], 0.0);
         assertTrue("tick 0's amplifier is what drives tick 1's ground factor",
                 Math.abs(pr.posZ[2] - on.posZ[2]) > 1.0E-9 || Math.abs(pr.posX[2] - on.posX[2]) > 1.0E-9);
+    }
+
+    @Test
+    public void modernAirSprintFactorEngagesSameTick() {
+        double[] yaws = {0.0};
+
+        JumpPhysicsInputs engage = scenario(1, Double.NaN, false);
+        engage.sprintPerTick = new boolean[]{true};
+        engage.incomingSprint = Boolean.FALSE;
+
+        ForwardPath m = ExactJumpModel.forMcVersion("26.2").forward(engage, engage.toGameFacings(yaws));
+        assertEquals("modern reads the off-ground speed live: tick 0 already gets the sprint air accel",
+                F * (double) Constants.AIR_SPEED_F, m.posZ[1] - m.posZ[0], 0.0);
+
+        ForwardPath l = ExactJumpModel.forMcVersion("1.8.9").forward(engage, engage.toGameFacings(yaws));
+        assertEquals("legacy keeps the lagged jumpMovementFactor on tick 0",
+                (double) (F * Constants.AIR_SPEED_NO_SPRINT_F), l.posZ[1] - l.posZ[0], 0.0);
+    }
+
+    @Test
+    public void modernAirSprintReleaseIsLiveToo() {
+        double[] yaws = {0.0};
+
+        JumpPhysicsInputs release = scenario(1, Double.NaN, false);
+        release.sprintPerTick = new boolean[]{false};
+        release.incomingSprint = Boolean.TRUE;
+
+        ForwardPath m = ExactJumpModel.forMcVersion("26.2").forward(release, release.toGameFacings(yaws));
+        assertEquals("modern drops to the non-sprint air accel the same tick",
+                F * (double) Constants.AIR_SPEED_NO_SPRINT_F, m.posZ[1] - m.posZ[0], 0.0);
+
+        ForwardPath l = ExactJumpModel.forMcVersion("1.8.9").forward(release, release.toGameFacings(yaws));
+        assertEquals("legacy carries the sprint factor one tick past the release",
+                (double) (F * Constants.AIR_SPEED_F), l.posZ[1] - l.posZ[0], 0.0);
+    }
+
+    @Test
+    public void airFactorSprintAtFollowsTheLiveFlag() {
+        JumpPhysicsInputs sc = scenario(2, Double.NaN, false);
+        sc.sprintPerTick = new boolean[]{true, false};
+        sc.incomingSprint = Boolean.FALSE;
+        assertFalse(sc.airFactorSprintAt(0));
+        assertTrue(sc.airFactorSprintAt(1));
+        sc.liveAirSprintFactor = true;
+        assertTrue(sc.airFactorSprintAt(0));
+        assertFalse(sc.airFactorSprintAt(1));
+    }
+
+    @Test
+    public void deriveSeedsAnAirborneSprintStartPerEra() {
+        InputData inputs = rows(1);
+        BoxController boxes = new BoxController();
+        boxes.add(sampled(false, 0.0F, 0.0F));
+        boxes.add(sampled(true, F, 0.0F));
+        JumpPhysicsInputs mc = compile(inputs, boxes, 1, deriving(), "26.2");
+        assertTrue("a modern engine authors the live air factor", mc.liveAirSprintFactor);
+        assertTrue(mc.sprintAt(0));
+        assertEquals(Boolean.FALSE, mc.incomingSprint);
+        ForwardPath p = ExactJumpModel.forMcVersion("26.2").forward(mc, mc.toGameFacings(new double[]{0.0}));
+        assertEquals("an airborne standstill start under Derive engages the sprint air accel on tick 0",
+                F * (double) Constants.AIR_SPEED_F, p.posZ[1] - p.posZ[0], 0.0);
+
+        InputData legacyInputs = rows(1);
+        BoxController legacyBoxes = new BoxController();
+        legacyBoxes.add(sampled(false, 0.0F, 0.0F));
+        legacyBoxes.add(sampled(true, F, 0.0F));
+        JumpPhysicsInputs lc = compile(legacyInputs, legacyBoxes, 1, deriving(), "1.8.9");
+        assertFalse("a legacy engine keeps the lagged air factor", lc.liveAirSprintFactor);
     }
 
     @Test


### PR DESCRIPTION
Fixes #251.

## Problem

With Sprint = Derive and a solve window starting airborne at standstill, the model ran tick 0 with the non-sprint air accel (0.02F x 0.98F = 0.0196) while real 26.2 engages sprint during tick 0 before travel and moves at the sprint air accel (0.026F x 0.98F = 0.02548). Every prediction from such a start drifted from the first tick.

## Cause (verified against the local decompiled sources)

- Modern (26.2): LocalPlayer.aiStep engages/releases sprint before travel, and Player.getFlyingSpeed reads isSprinting() live during travel. The air factor never lags, in either direction.
- Legacy (1.8.9 / 1.12.2): EntityPlayer.onLivingUpdate refreshes jumpMovementFactor only after super.onLivingUpdate() has run travel, and setSprinting touches only the movementSpeed attribute (the issue's hint that it also updates jumpMovementFactor is wrong; only the flying branch does). So the legacy air factor genuinely lags one tick, engage and release both. The ground attribute is read live in every era (EntityPlayer overrides getAIMoveSpeed to the attribute), which is what the sprint-lag-v2 split already modeled.

The model applied the legacy lag (factorSprintAt + incomingSprint seed) to the air factor in every era; the seed from the standstill pre-tick state (sprinting: false) then killed the tick-0 sprint accel on modern. This is the incomingSprint half-latent edge from the PR #239 review.

## Fix

- ExactJumpModel picks the air sprint flag per era: the tick's own sprint on the modern chain, factorSprintAt on the legacy chain. Ground and jump-boost gating are untouched.
- JumpPhysicsInputs gains liveAirSprintFactor + airFactorSprintAt so the era-blind JumpLinearModel stays aligned with the exact model; AngleSolverEngine.buildPhys authors the flag from the model era and all scenario clone sites carry it.
- Legacy behavior is bit-identical (the legacy path still evaluates factorSprintAt), so the capture-validated grounded-start problems and the era pins in SprintSneakTest are untouched.

## Tests

New pins in SprintSneakTest: modern tick-0 engage at the exact sprint air accel with the lagged legacy counterpart, the release direction, the airFactorSprintAt flag switch, and an engine-level repro of the airborne standstill Derive start per era (flag authored, incomingSprint seeded false, tick 0 at the sprint accel on 26.2).

Ran (green): SprintSneakTest, ModernStepRegressionTest (untouched), WindowSeedTest, CaptureReplayRegressionTest + PlanRealizationRegressionTest + ApplyYawRowsTest (the only modern captures with a sprint transition are the deserthard pair these replay), and tableStyleCheck. The remaining suite only exercises the unchanged legacy path or all-sprint modern captures.

In-game QA on one loader still pending (core-only change).