### PR TITLE
fix: recognize vines for ctrl+B cell constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A TAS input planning mod for Minecraft. Simulate and visualize parkour movements
 - **Angle Solver**: give it constraints and it finds the yaw inputs that land the jump
 - **Free start position**: the solver picks the best starting spot within the start block's footprint
 - **Constraints**: absolute X/Z/F, relative X/Z against any reference tick, per-tick dX/dZ/dF deltas, and a dX vs dZ axis comparison
-- **Constraint hotkeys**: `B` adds wall and footprint constraints for the block you are looking at, `Ctrl+B` adds ladder/slime/ice cell constraints
+- **Constraint hotkeys**: `B` adds wall and footprint constraints for the block you are looking at, `Ctrl+B` adds climbable (ladder, vine)/slime/ice cell constraints
 - **Solver hotkeys**: `V` solves and applies, `I`/`O` set the solver start/goal tick to the selected tick, `H` fills per-tick slipperiness and medium from the recorded path; a HUD status line shows solve progress and outcome while the UI is closed
 - **Node-graph solver pipelines** with per-stage time budgets (Custom effort)
 - Plan movement inputs tick-by-tick (WASD, jump, sneak, sprint, yaw, pitch)
@@ -70,7 +70,7 @@ Click and drag the first box in the world to reposition.
 | `G` | Toggle UI (rebindable) |
 | `ESC` | Close UI |
 | `B` | Add wall/footprint constraints for the targeted block |
-| `Ctrl+B` | Add ladder/slime/ice cell constraints |
+| `Ctrl+B` | Add climbable (ladder, vine)/slime/ice cell constraints |
 | `Ctrl+Click` | Toggle selection |
 | `Shift+Click` | Range select |
 | `Right-Click` | Context menu |

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ports/MinecraftAccess.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ports/MinecraftAccess.java
@@ -38,7 +38,7 @@ public interface MinecraftAccess {
         return false;
     }
 
-    default boolean isLadder(int x, int y, int z) {
+    default boolean isClimbable(int x, int y, int z) {
         return false;
     }
 

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/ConstraintKeyController.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/ConstraintKeyController.java
@@ -43,7 +43,7 @@ public final class ConstraintKeyController {
         if (tick < 0) return;
         int bx = block[0], by = block[1], bz = block[2];
 
-        if (remove && mc.isLadder(bx, by, bz)) {
+        if (remove && mc.isClimbable(bx, by, bz)) {
             List<AABB> obstacles = mc.getCollisionBoxes(bx - 1, by, bz - 1, bx + 1, by + 1, bz + 1);
             double[] r = ConstraintDeriver.deriveCell(bx, bz, by, bx + 0.5, bz + 0.5, obstacles);
             state.setFootprint(tick, r[0], r[1], r[2], r[3]);

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricMinecraftAccess.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricMinecraftAccess.java
@@ -13,6 +13,7 @@ import net.minecraft.world.level.ClipContext;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.tags.BlockTags;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.core.BlockPos;
@@ -94,10 +95,10 @@ public final class FabricMinecraftAccess implements MinecraftAccess {
     }
 
     @Override
-    public boolean isLadder(int x, int y, int z) {
+    public boolean isClimbable(int x, int y, int z) {
         ClientLevel world = Minecraft.getInstance().level;
         if (world == null) return false;
-        return world.getBlockState(new BlockPos(x, y, z)).is(Blocks.LADDER);
+        return world.getBlockState(new BlockPos(x, y, z)).is(BlockTags.CLIMBABLE);
     }
 
     @Override

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12MinecraftAccess.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12MinecraftAccess.java
@@ -87,10 +87,11 @@ public final class Forge12MinecraftAccess implements MinecraftAccess {
     }
 
     @Override
-    public boolean isLadder(int x, int y, int z) {
+    public boolean isClimbable(int x, int y, int z) {
         World world = Minecraft.getMinecraft().world;
         if (world == null) return false;
-        return world.getBlockState(new BlockPos(x, y, z)).getBlock() == Blocks.LADDER;
+        Block block = world.getBlockState(new BlockPos(x, y, z)).getBlock();
+        return block == Blocks.LADDER || block == Blocks.VINE;
     }
 
     @Override

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8MinecraftAccess.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8MinecraftAccess.java
@@ -89,10 +89,11 @@ public final class Forge8MinecraftAccess implements MinecraftAccess {
     }
 
     @Override
-    public boolean isLadder(int x, int y, int z) {
+    public boolean isClimbable(int x, int y, int z) {
         World world = Minecraft.getMinecraft().theWorld;
         if (world == null) return false;
-        return world.getBlockState(new BlockPos(x, y, z)).getBlock() == Blocks.ladder;
+        Block block = world.getBlockState(new BlockPos(x, y, z)).getBlock();
+        return block == Blocks.ladder || block == Blocks.vine;
     }
 
     @Override


### PR DESCRIPTION
Closes #245

## What

Ctrl+B derived a cell constraint on ladders but did nothing on vines: every loader's `isLadder` matched only the ladder block.

## Changes

- Renamed the `MinecraftAccess` port method `isLadder` to `isClimbable` (core default, call site in `ConstraintKeyController`, all three loader overrides).
- Forge 1.8.9 / 1.12.2: match `ladder` or `vine` (the only vanilla climbables in those versions).
- Fabric 26.2: check the vanilla `CLIMBABLE` block tag, the same check `LivingEntity.onClimbable` uses, so the hotkey stays consistent with what the sim entity can actually climb (also covers weeping/twisting/cave vines and scaffolding).
- README: updated the Ctrl+B wording.

No sim change needed; `SimulatorEntity` is a real MC player and already climbs vines.

## Testing

- `:core:test` green.
- `:loader-fabric:build`, `:loader-forge-1.8.9:build`, `:loader-forge-1.12.2:build` all green.
- In-game QA on the touched loaders still pending (reported on Forge 1.8.9).