### PR TITLE
fix(solver): accept range constraint bounds in either order

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/Constraint.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/Constraint.java
@@ -109,7 +109,7 @@ public final class Constraint {
             loInclusive = true;
             hiInclusive = true;
         } else if (op != Op.IN && this.op == Op.IN) {
-            value = lo;
+            value = Math.min(lo, hi);
         }
         this.op = op;
     }
@@ -123,7 +123,7 @@ public final class Constraint {
     }
 
     public double getLo() {
-        return lo;
+        return Math.min(lo, hi);
     }
 
     public void setLo(double lo) {
@@ -131,7 +131,7 @@ public final class Constraint {
     }
 
     public double getHi() {
-        return hi;
+        return Math.max(lo, hi);
     }
 
     public void setHi(double hi) {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverConstraintSource.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverConstraintSource.java
@@ -119,8 +119,10 @@ public final class AngleSolverConstraintSource implements ConstraintBoxSource {
         Constraint r = c.copy();
         r.setRefTick(null);
         r.setValue(r.getValue() + base);
-        r.setLo(r.getLo() + base);
-        r.setHi(r.getHi() + base);
+        double lo = r.getLo() + base;
+        double hi = r.getHi() + base;
+        r.setLo(lo);
+        r.setHi(hi);
         return r;
     }
 

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/ConstraintRangeOrderTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/ConstraintRangeOrderTest.java
@@ -1,0 +1,88 @@
+package de.legoshi.parkourcalc.anglesolver;
+
+import de.legoshi.parkourcalc.core.anglesolver.AngleSolverEngine;
+import de.legoshi.parkourcalc.core.anglesolver.AngleSolverState;
+import de.legoshi.parkourcalc.core.anglesolver.Constraint;
+import de.legoshi.parkourcalc.core.anglesolver.solver.ExactJumpModel;
+import de.legoshi.parkourcalc.core.anglesolver.solver.JumpConstraint;
+import de.legoshi.parkourcalc.core.anglesolver.solver.JumpSpec;
+import de.legoshi.parkourcalc.core.sim.TickState;
+import de.legoshi.parkourcalc.core.sim.Vec3dCore;
+import de.legoshi.parkourcalc.core.ui.BoxController;
+import de.legoshi.parkourcalc.core.ui.InputData;
+import de.legoshi.parkourcalc.core.ui.InputRow;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class ConstraintRangeOrderTest {
+
+    private static final double EPS = 1.0e-9;
+    private static final int TICKS = 4;
+
+    private static JumpSpec compile(AngleSolverState state) {
+        InputData inputs = new InputData();
+        BoxController boxes = new BoxController();
+        for (int t = 0; t < TICKS; t++) {
+            InputRow row = new InputRow();
+            row.setKeyActive(InputRow.Key.W, true);
+            inputs.getRows().add(row);
+            boxes.add(new TickState(new Vec3dCore(0.5, 64.0, 0.5), false, false, false, 0f,
+                    Collections.<Vec3dCore>emptyList(), Vec3dCore.ZERO, false, Double.NaN));
+        }
+        state.setStartTick(0);
+        state.setLandingTick(TICKS);
+        AngleSolverEngine engine = new AngleSolverEngine(state, boxes, inputs, t -> { },
+                ExactJumpModel.forMcVersion("1.8.9"));
+        JumpSpec spec = engine.debugBuildSpec();
+        assertNotNull(spec);
+        return spec;
+    }
+
+    @Test
+    public void reversedFactoryBoundsReadNormalized() {
+        Constraint c = Constraint.range(Constraint.Field.X, -250.0, -251.0, true, true);
+        assertEquals(-251.0, c.getLo(), EPS);
+        assertEquals(-250.0, c.getHi(), EPS);
+    }
+
+    @Test
+    public void reversedSetterBoundsReadNormalized() {
+        Constraint c = Constraint.scalar(Constraint.Field.Z, Constraint.Op.EQ, -250.0);
+        c.setOp(Constraint.Op.IN);
+        c.setHi(-251.0);
+        assertEquals(-251.0, c.getLo(), EPS);
+        assertEquals(-250.0, c.getHi(), EPS);
+    }
+
+    @Test
+    public void leavingAReversedRangeKeepsTheLowerBound() {
+        Constraint c = Constraint.range(Constraint.Field.X, -250.0, -251.0, true, true);
+        c.setOp(Constraint.Op.GE);
+        assertEquals(-251.0, c.getValue(), EPS);
+    }
+
+    @Test
+    public void reversedRangeCompilesSatisfiableBounds() {
+        AngleSolverState state = new AngleSolverState();
+        state.tickConstraints(2).getConstraints().add(Constraint.range(Constraint.Field.X, -250.0, -251.0, true, true));
+
+        JumpSpec spec = compile(state);
+        Double ge = null;
+        Double le = null;
+        for (JumpConstraint jc : spec.constraints) {
+            if (!jc.name.startsWith("X@2")) continue;
+            if (jc.cmp == JumpConstraint.Cmp.GE) ge = jc.rhs;
+            if (jc.cmp == JumpConstraint.Cmp.LE) le = jc.rhs;
+        }
+        assertNotNull(ge);
+        assertNotNull(le);
+        assertEquals(-251.0, ge, EPS);
+        assertEquals(-250.0, le, EPS);
+        assertTrue("reversed bounds must still compile to a satisfiable pair", ge <= le);
+    }
+}

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/ConstraintVisualizationTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/ConstraintVisualizationTest.java
@@ -435,6 +435,21 @@ public class ConstraintVisualizationTest {
     }
 
     @Test
+    public void relativeReversedRangeResolvesBothBounds() {
+        AngleSolverState state = new AngleSolverState();
+        BoxController boxes = boxesWith(new Vec3dCore(0.5, 64.0, 0.5), new Vec3dCore(1.5, 64.0, 3.5));
+        Constraint c = Constraint.range(Constraint.Field.X, 2.0, 1.0, true, true);
+        c.setRefTick(0);
+        state.tickConstraints(1).getConstraints().add(c);
+
+        List<ConstraintPlate> plates = source(state, boxes).platesAt(1);
+        assertEquals(1, plates.size());
+        AABB front = plates.get(0).front.get(0);
+        assertEquals((0.5 + 1.0) - H, front.min.x, EPS);
+        assertEquals("upper bound survives the shift with reversed input order", (0.5 + 2.0) + H, front.max.x, EPS);
+    }
+
+    @Test
     public void relativeConstraintWithoutReferencePositionDrawsNothing() {
         AngleSolverState state = new AngleSolverState();
         BoxController boxes = boxesWith(new Vec3dCore(0.5, 64.0, 0.5), new Vec3dCore(1.5, 64.0, 0.5));


### PR DESCRIPTION
Closes #250

A range constraint entered in reverse order (from -250 to -251) stored lo > hi and compiled to an empty interval (GE -250 plus LE -251), so it was always unmet.

- `Constraint#getLo()`/`getHi()` now normalize on read (min/max), so the compiled spec, met check, save files, velocity map edges, plates, and chips all see the same ordered interval regardless of typing order. The raw fields keep their box identity, so per-keystroke edits never destroy the other bound.
- `AngleSolverConstraintSource#resolveRelative` reads both bounds before shifting; the old sequential read-modify-write interleaves badly with normalized reads on a reversed range and corrupted the upper bound.

Trade-off: inclusivity brackets stay with the box they were set on, so a reversed range with an exclusive bound puts the open end on the swapped value. Epsilon-level in practice (the met check works in MET_TOL bands).

Testing: new `ConstraintRangeOrderTest` (normalized reads via factory and setters, op-switch keeps the true lower bound, reversed range compiles a satisfiable GE/LE pair), `ConstraintVisualizationTest#relativeReversedRangeResolvesBothBounds` pins the relative-shift path. Full `:core:build` green (tests plus tableStyleCheck).
