### PR TITLE
feat: click a Tick Info row to copy its values

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
@@ -217,7 +217,7 @@ public final class Application {
             }
         });
 
-        TickInfoPanel tickInfoPanel = new TickInfoPanel(boxController, inputData, selection, settings, runner);
+        TickInfoPanel tickInfoPanel = new TickInfoPanel(boxController, inputData, selection, settings, runner, this::pushHudMessage);
         PerfOverlay perfOverlay = new PerfOverlay();
         FileMenu fileMenu = new FileMenu(saveController, filePicker, settings, this::saveSettings);
         SettingsModal settingsModal = new SettingsModal(settings, this::saveSettings);

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/TickInfoPanel.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/TickInfoPanel.java
@@ -8,10 +8,8 @@ import de.legoshi.parkourcalc.core.ui.theme.ThemeManager;
 import de.legoshi.parkourcalc.core.ui.util.TooltipUtil;
 import imgui.ImGui;
 import imgui.ImGuiIO;
-import imgui.ImVec2;
 import imgui.flag.ImGuiCond;
 import imgui.flag.ImGuiMouseCursor;
-import imgui.flag.ImGuiSelectableFlags;
 import imgui.flag.ImGuiTableColumnFlags;
 import imgui.flag.ImGuiWindowFlags;
 
@@ -135,7 +133,7 @@ public final class TickInfoPanel implements RenderInterface {
 
     private void rowText(String label, String text, String tooltip) {
         labelCell(label, tooltip, text);
-        centerSingleValueInMiddleColumn(text);
+        copyableMiddleCell(text, label);
     }
 
     private void renderTable(int idx, TickState cur, TickState prev, TickState prev2, float appliedYaw, float appliedPitch, boolean isStart) {
@@ -287,8 +285,7 @@ public final class TickInfoPanel implements RenderInterface {
 
     private void labelCell(String label, String tooltip, String copyText) {
         ImGui.tableNextRow();
-        int row = rowCounter++;
-        ThemeManager.paintTableRowBg(row);
+        ThemeManager.paintTableRowBg(rowCounter++);
         ImGui.tableNextColumn();
         if (copyText == null) {
             ThemeManager.tableLeftmostCellPad();
@@ -298,51 +295,51 @@ public final class TickInfoPanel implements RenderInterface {
             TooltipUtil.onHover(tooltip);
             return;
         }
-        ImVec2 cellStart = ImGui.getCursorScreenPos();
-        float labelColumnRight = cellStart.x + ImGui.getContentRegionAvail().x;
         ThemeManager.pushTextColor(ThemeManager.textMutedColor());
-        boolean clicked = ThemeManager.leftAlignedSelectable("copy-row-" + row, label, false, ImGuiSelectableFlags.SpanAllColumns);
+        boolean clicked = ThemeManager.leftAlignedSelectable("row-" + label, label, false, 0);
         ThemeManager.popTextColor();
         if (clicked) {
-            ImGui.setClipboardText(copyText);
-            hudMessage.accept("Copied " + label);
+            copyToClipboard(copyText, label);
         }
         if (ImGui.isItemHovered()) {
             ImGui.setMouseCursor(ImGuiMouseCursor.Hand);
-            if (ImGui.getMousePos().x <= labelColumnRight) {
-                TooltipUtil.wrappedTooltip(tooltip);
-            }
+            TooltipUtil.wrappedTooltip(tooltip);
         }
+    }
+
+    private void copyToClipboard(String text, String what) {
+        ImGui.setClipboardText(text);
+        hudMessage.accept("Copied " + what);
     }
 
     private void rowTriple(String label, double x, double y, double z, int decimals, String tooltip) {
         String fmt = fmtNumSingle(decimals);
         labelCell(label, tooltip, String.format(Locale.US, fmt + " " + fmt + " " + fmt, x, y, z));
-        numCell(x, decimals);
-        numCell(y, decimals);
-        numCell(z, decimals);
+        numCell(x, decimals, label + " " + COL_X);
+        numCell(y, decimals, label + " " + COL_Y);
+        numCell(z, decimals, label + " " + COL_Z);
         ThemeManager.tableRightmostCellTrailingPad();
     }
 
     private void rowXZ(String label, double x, double z, int decimals, String tooltip) {
         String fmt = fmtNumSingle(decimals);
         labelCell(label, tooltip, String.format(Locale.US, fmt + " " + fmt, x, z));
-        numCell(x, decimals);
+        numCell(x, decimals, label + " " + COL_X);
         emptyCell();
-        numCell(z, decimals);
+        numCell(z, decimals, label + " " + COL_Z);
         ThemeManager.tableRightmostCellTrailingPad();
     }
 
     private void rowNum(String label, double v, int decimals, String tooltip) {
         String text = String.format(Locale.US, fmtNumSingle(decimals), v);
         labelCell(label, tooltip, text);
-        centerSingleValueInMiddleColumn(text);
+        copyableMiddleCell(text, label);
     }
 
     private void rowInt(String label, int v, String tooltip) {
         String text = Integer.toString(v);
         labelCell(label, tooltip, text);
-        centerSingleValueInMiddleColumn(text);
+        copyableMiddleCell(text, label);
     }
 
     private void rowBool(String label, boolean v, String tooltip) {
@@ -350,30 +347,41 @@ public final class TickInfoPanel implements RenderInterface {
         labelCell(label, tooltip, text);
         int color = v ? ThemeManager.okColor() : ThemeManager.dangerColor();
         ThemeManager.pushTextColor(color);
-        centerSingleValueInMiddleColumn(text);
+        copyableMiddleCell(text, label);
         ThemeManager.popTextColor();
     }
 
     private void rowNa(String label, String tooltip) {
         labelCell(label, tooltip, null);
         ThemeManager.pushTextColor(ThemeManager.textDimColor());
-        centerSingleValueInMiddleColumn(NA);
+        ImGui.tableNextColumn();
+        ImGui.tableNextColumn();
+        ThemeManager.textCenter(NA);
+        ImGui.tableNextColumn();
+        ThemeManager.tableRightmostCellTrailingPad();
         ThemeManager.popTextColor();
     }
 
-    private void numCell(double v, int decimals) {
+    private void numCell(double v, int decimals, String what) {
         ImGui.tableNextColumn();
-        ThemeManager.textCenter(String.format(Locale.US, fmtNum(decimals), v));
+        String display = String.format(Locale.US, fmtNum(decimals), v);
+        if (ThemeManager.centeredSelectable("cell-" + what, display, false, 0)) {
+            copyToClipboard(String.format(Locale.US, fmtNumSingle(decimals), v), what);
+        }
+        if (ImGui.isItemHovered()) ImGui.setMouseCursor(ImGuiMouseCursor.Hand);
     }
 
     private static void emptyCell() {
         ImGui.tableNextColumn();
     }
 
-    private void centerSingleValueInMiddleColumn(String text) {
+    private void copyableMiddleCell(String text, String what) {
         ImGui.tableNextColumn();
         ImGui.tableNextColumn();
-        ThemeManager.textCenter(text);
+        if (ThemeManager.centeredSelectable("cell-" + what, text, false, 0)) {
+            copyToClipboard(text, what);
+        }
+        if (ImGui.isItemHovered()) ImGui.setMouseCursor(ImGuiMouseCursor.Hand);
         ImGui.tableNextColumn();
         ThemeManager.tableRightmostCellTrailingPad();
     }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/TickInfoPanel.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/TickInfoPanel.java
@@ -8,12 +8,16 @@ import de.legoshi.parkourcalc.core.ui.theme.ThemeManager;
 import de.legoshi.parkourcalc.core.ui.util.TooltipUtil;
 import imgui.ImGui;
 import imgui.ImGuiIO;
+import imgui.ImVec2;
 import imgui.flag.ImGuiCond;
+import imgui.flag.ImGuiMouseCursor;
+import imgui.flag.ImGuiSelectableFlags;
 import imgui.flag.ImGuiTableColumnFlags;
 import imgui.flag.ImGuiWindowFlags;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.function.Consumer;
 
 public final class TickInfoPanel implements RenderInterface {
 
@@ -35,17 +39,19 @@ public final class TickInfoPanel implements RenderInterface {
     private final SelectionManager selection;
     private final Settings settings;
     private final SimulationRunner runner;
+    private final Consumer<String> hudMessage;
     private int rowCounter;
 
     private int sampleDecimals = -1;
     private String numSample = "";
 
-    public TickInfoPanel(BoxController boxController, InputData inputData, SelectionManager selection, Settings settings, SimulationRunner runner) {
+    public TickInfoPanel(BoxController boxController, InputData inputData, SelectionManager selection, Settings settings, SimulationRunner runner, Consumer<String> hudMessage) {
         this.boxController = boxController;
         this.inputData = inputData;
         this.selection = selection;
         this.settings = settings;
         this.runner = runner;
+        this.hudMessage = hudMessage;
     }
 
     private float effectivePitch(int idx) {
@@ -128,7 +134,7 @@ public final class TickInfoPanel implements RenderInterface {
     }
 
     private void rowText(String label, String text, String tooltip) {
-        labelCell(label, tooltip);
+        labelCell(label, tooltip, text);
         centerSingleValueInMiddleColumn(text);
     }
 
@@ -279,19 +285,39 @@ public final class TickInfoPanel implements RenderInterface {
         }
     }
 
-    private void labelCell(String label, String tooltip) {
+    private void labelCell(String label, String tooltip, String copyText) {
         ImGui.tableNextRow();
-        ThemeManager.paintTableRowBg(rowCounter++);
+        int row = rowCounter++;
+        ThemeManager.paintTableRowBg(row);
         ImGui.tableNextColumn();
-        ThemeManager.tableLeftmostCellPad();
+        if (copyText == null) {
+            ThemeManager.tableLeftmostCellPad();
+            ThemeManager.pushTextColor(ThemeManager.textMutedColor());
+            ThemeManager.textLeft(label);
+            ThemeManager.popTextColor();
+            TooltipUtil.onHover(tooltip);
+            return;
+        }
+        ImVec2 cellStart = ImGui.getCursorScreenPos();
+        float labelColumnRight = cellStart.x + ImGui.getContentRegionAvail().x;
         ThemeManager.pushTextColor(ThemeManager.textMutedColor());
-        ThemeManager.textLeft(label);
+        boolean clicked = ThemeManager.leftAlignedSelectable("copy-row-" + row, label, false, ImGuiSelectableFlags.SpanAllColumns);
         ThemeManager.popTextColor();
-        TooltipUtil.onHover(tooltip);
+        if (clicked) {
+            ImGui.setClipboardText(copyText);
+            hudMessage.accept("Copied " + label);
+        }
+        if (ImGui.isItemHovered()) {
+            ImGui.setMouseCursor(ImGuiMouseCursor.Hand);
+            if (ImGui.getMousePos().x <= labelColumnRight) {
+                TooltipUtil.wrappedTooltip(tooltip);
+            }
+        }
     }
 
     private void rowTriple(String label, double x, double y, double z, int decimals, String tooltip) {
-        labelCell(label, tooltip);
+        String fmt = fmtNumSingle(decimals);
+        labelCell(label, tooltip, String.format(Locale.US, fmt + " " + fmt + " " + fmt, x, y, z));
         numCell(x, decimals);
         numCell(y, decimals);
         numCell(z, decimals);
@@ -299,7 +325,8 @@ public final class TickInfoPanel implements RenderInterface {
     }
 
     private void rowXZ(String label, double x, double z, int decimals, String tooltip) {
-        labelCell(label, tooltip);
+        String fmt = fmtNumSingle(decimals);
+        labelCell(label, tooltip, String.format(Locale.US, fmt + " " + fmt, x, z));
         numCell(x, decimals);
         emptyCell();
         numCell(z, decimals);
@@ -307,25 +334,28 @@ public final class TickInfoPanel implements RenderInterface {
     }
 
     private void rowNum(String label, double v, int decimals, String tooltip) {
-        labelCell(label, tooltip);
-        centerSingleValueInMiddleColumn(String.format(Locale.US, fmtNumSingle(decimals), v));
+        String text = String.format(Locale.US, fmtNumSingle(decimals), v);
+        labelCell(label, tooltip, text);
+        centerSingleValueInMiddleColumn(text);
     }
 
     private void rowInt(String label, int v, String tooltip) {
-        labelCell(label, tooltip);
-        centerSingleValueInMiddleColumn(Integer.toString(v));
+        String text = Integer.toString(v);
+        labelCell(label, tooltip, text);
+        centerSingleValueInMiddleColumn(text);
     }
 
     private void rowBool(String label, boolean v, String tooltip) {
-        labelCell(label, tooltip);
+        String text = Boolean.toString(v);
+        labelCell(label, tooltip, text);
         int color = v ? ThemeManager.okColor() : ThemeManager.dangerColor();
         ThemeManager.pushTextColor(color);
-        centerSingleValueInMiddleColumn(Boolean.toString(v));
+        centerSingleValueInMiddleColumn(text);
         ThemeManager.popTextColor();
     }
 
     private void rowNa(String label, String tooltip) {
-        labelCell(label, tooltip);
+        labelCell(label, tooltip, null);
         ThemeManager.pushTextColor(ThemeManager.textDimColor());
         centerSingleValueInMiddleColumn(NA);
         ThemeManager.popTextColor();


### PR DESCRIPTION
Closes #233

Two-level click-to-copy in the Tick Info panel, confirmed with a HUD toast:

- Clicking a value cell copies just that value ("Copied Position X").
- Clicking the row's label copies the whole row's value(s), space-separated for triples and XZ pairs, e.g. `-12.345678 64.000000 8.250000` ("Copied Position").
- The copy is WYSIWYG: values are formatted at the row's configured decimals; raising a stat's precision in the stats editor raises the copied precision (individual copies are trimmed, no column padding).
- Bool cells copy `true`/`false`, the Tick cell copies the tick number (or `Start`).
- Rows currently showing `n/a` are not clickable and keep their explanatory tooltip.
- Clickable cells show a hand cursor; the stat tooltip stays on the Field column so scanning values does not pop tooltips.

Copy goes through `ImGui.setClipboardText`, which works on all three loaders (GLFW clipboard on Fabric, the shim's native clipboard on LWJGL2). Core-only change; QA on one loader suffices per CONTRIBUTING.

`:core:build` green (full test suite + tableStyleCheck).
