### PR TITLE
fix(fabric): keep ctrl+B cell constraints from toggling the vanilla narrator

### DIFF
--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricParkourCalculator.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricParkourCalculator.java
@@ -342,6 +342,20 @@ public class FabricParkourCalculator implements ClientModInitializer {
         }
     }
 
+    public static boolean consumeInGameConstraintChord(int glfwKey, int action, int modifiers) {
+        if (action != GLFW.GLFW_PRESS && action != GLFW.GLFW_REPEAT) return false;
+        if ((modifiers & GLFW.GLFW_MOD_CONTROL) == 0) return false;
+        Minecraft client = Minecraft.getInstance();
+        if (client.getWindow() == null || client.level == null) return false;
+        if (client.gui.screen() != null) return false;
+        if (glfwKey != boundKey(landingConstraintsKeyBinding)) return false;
+        if (action == GLFW.GLFW_PRESS) {
+            boolean enter = (modifiers & GLFW.GLFW_MOD_SHIFT) != 0;
+            application.onConstraintKey(enter, true);
+        }
+        return true;
+    }
+
     public static boolean dispatchOverlayHotkey(int glfwKey) {
         Minecraft client = Minecraft.getInstance();
         if (client.getWindow() == null) return false;

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/mixin/KeyboardHandlerMixin.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/mixin/KeyboardHandlerMixin.java
@@ -21,6 +21,9 @@ public class KeyboardHandlerMixin {
     @Inject(method = "keyPress", at = @At("HEAD"), cancellable = true)
     private void onKey(long window, int action, KeyEvent input, CallbackInfo ci) {
         if (!FabricParkourCalculator.isUiFocused()) {
+            if (FabricParkourCalculator.consumeInGameConstraintChord(input.key(), action, input.modifiers())) {
+                ci.cancel();
+            }
             return;
         }
 


### PR DESCRIPTION
Fixes #265

## Problem
On 26.2, opening the pause menu (or clicking any button or settings entry after ESC) froze the game for up to a second. The Forge loaders were unaffected.

## Root cause
Minecraft binds ctrl+B as the narrator hotkey (KeyboardHandler.keyPress, gated only by the narratorHotkey accessibility option, which defaults to on). The mod's cell constraint chord is also ctrl+B, so every in-game use of it silently cycled the narrator (OFF, ALL, CHAT, SYSTEM). Once the narrator is active, every Gui.setScreen runs Screen.init immediate narration, which calls the Windows SAPI voice over COM synchronously on the render thread.

Reproduced with a frame stall watchdog; captured stack during a screen change:

```
[PKC-WATCHDOG] render thread stalled 1787ms
--- Render thread
    at com.sun.jna.platform.win32.COM.COMInvoker._invokeNativeInt
    at com.mojang.text2speech.NarratorWindows.clear(NarratorWindows.java:90)
    at net.minecraft.client.GameNarrator.clear(GameNarrator.java:105)
    ...
```

The stall scales with how much queued narration the purge has to cancel, which is why quickly navigating menus feels like a freeze on every click. options.txt in my dev run dir already sat at narrator:3, exactly three ctrl+B cycles from OFF. The Forge loaders do not show this: 1.8.9 has no narrator, and 1.12.2 does not narrate screens on open.

## Fix
KeyboardHandlerMixin now consumes ctrl+B at the keyPress head while in game (no vanilla screen open, overlay not focused, ctrl held, key matching the bound constraint key) and dispatches the cell constraint action directly. Vanilla never sees the narrator chord, so the narrator state stays untouched. Ctrl+B inside vanilla menus still cycles the narrator, keeping the accessibility hotkey usable on purpose.

The overlay-focused path already cancelled keyPress wholesale, so it needed no change. Plain B (wall and footprint constraints) still flows through the normal KeyMapping path, including the B-then-ctrl ordering, which never matched the vanilla narrator chord in the first place.

## Verification
Scripted A/B against a live client on the branch:
1. In game ctrl+B with the fix: narrator option stayed unchanged (fix working; without it the value cycles).
2. Ctrl+B on the pause screen: narrator cycled SYSTEM to OFF (vanilla accessibility preserved).
3. With the narrator off, repeated ESC menu open/close over three pause saves produced zero render thread stalls above 200ms; with it on, screen changes stalled 200ms to 1.8s inside NarratorWindows.

`:core:test` and `:loader-fabric:build` are green.

## Note for affected setups
Anyone who used ctrl+B before this fix likely still has the narrator enabled and will keep freezing until it is turned off once: press ctrl+B in any vanilla menu until the narrator toast says disabled, or set Options, Accessibility, Narrator to OFF.