### PR TITLE
test: gate slow solver suites behind -PslowTests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       - name: make gradle wrapper executable
         run: chmod +x ./gradlew
       - name: build
-        run: ./gradlew build -x tableStyleCheck -Dorg.gradle.java.home="$JAVA_HOME"
+        run: ./gradlew build -x tableStyleCheck -PslowTests -Dorg.gradle.java.home="$JAVA_HOME"
       - name: capture build artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
       - name: build
-        run: ./gradlew build -x tableStyleCheck -PreleaseVersion=${{ steps.version.outputs.version }} -Dorg.gradle.java.home="$JAVA_HOME"
+        run: ./gradlew build -x tableStyleCheck -PslowTests -PreleaseVersion=${{ steps.version.outputs.version }} -Dorg.gradle.java.home="$JAVA_HOME"
 
       - name: create github release
         uses: softprops/action-gh-release@v2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,11 +70,16 @@ JDK 21 runs the Gradle daemon. `:runClient` auto-switches toolchain: Fabric uses
 
 ## Tests
 
-The real gate is `:core:test`. All tests are pure Java in `core/src/test/`, no MC needed, runs in seconds.
+The real gate is `:core:test`. All tests are pure Java in `core/src/test/`, no MC needed.
+
+The default run excludes the expensive solver suites and finishes in seconds; `-PslowTests` includes them (a few minutes, `ProblemsTest` alone is most of it). The slow set is every class tagged with the JUnit category `de.legoshi.parkourcalc.SlowSolverTests` (currently `ProblemsTest`, the `J008Velocity*` suites, `VelocityFieldReuseEquivalenceTest`, `VelocityFinderConstraintTest`, `IlsPolishTest`, `WrapWindowIlsTest`, `TranslationEliminationTest`, `EngineFreeStartTest`, `AnytimeRaceTest`, `GraphPresetSolveTest`, `GraphRunnerTest`). CI always runs with `-PslowTests`, so nothing merges on the fast suite alone.
 
 ```bash
-./gradlew :core:test
+./gradlew :core:test             # fast suite; run after any change
+./gradlew :core:test -PslowTests # full suite; required when solver code changes
 ```
+
+Run the full suite locally whenever the change touches solver code (`core/.../anglesolver/`, the model classes, velocity finder, graph) or the problem/capture resources; for anything else the fast suite is enough, CI covers the rest. When a new test class drives the solver engine on real captures, tag it `@Category(SlowSolverTests.class)` so the default run stays fast.
 
 - Folder-driven problem checks: `core/src/test/.../anglesolver/ProblemsTest.java` (parameterized over `problems/solve/` and `problems/closedform/`, sharing captures in `core/src/test/resources/captures/`). Map in `anglesolver/TESTS.md`.
 - Bit-exact model regression: `core/src/test/.../anglesolver/ModernStepRegressionTest.java` pins `ExactJumpModel`, `McSineTable`, `Constants` against a recorded 1.21.10 run. A failure means the model drifted; do not edit model code without a green run first.

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -48,7 +48,11 @@ dependencies {
 }
 
 tasks.named('test') {
-	useJUnit()
+	useJUnit {
+		if (!project.hasProperty('slowTests')) {
+			excludeCategories 'de.legoshi.parkourcalc.SlowSolverTests'
+		}
+	}
 	if (project.hasProperty('testCpus')) {
 		jvmArgs "-XX:ActiveProcessorCount=${project.property('testCpus')}"
 	}

--- a/core/src/test/java/de/legoshi/parkourcalc/SlowSolverTests.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/SlowSolverTests.java
@@ -1,0 +1,4 @@
+package de.legoshi.parkourcalc;
+
+public interface SlowSolverTests {
+}

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/AnytimeRaceTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/AnytimeRaceTest.java
@@ -1,5 +1,6 @@
 package de.legoshi.parkourcalc.anglesolver;
 
+import de.legoshi.parkourcalc.SlowSolverTests;
 import de.legoshi.parkourcalc.anglesolver.harness.ProblemFixture;
 import de.legoshi.parkourcalc.core.anglesolver.AngleSolverState;
 import de.legoshi.parkourcalc.core.anglesolver.solver.Angles;
@@ -11,6 +12,7 @@ import de.legoshi.parkourcalc.core.anglesolver.solver.JumpPhysicsInputs;
 import de.legoshi.parkourcalc.core.anglesolver.solver.JumpSpec;
 import de.legoshi.parkourcalc.core.anglesolver.solver.LongRunSolver;
 import de.legoshi.parkourcalc.core.anglesolver.solver.SolveCore;
+import org.junit.experimental.categories.Category;
 import org.junit.Test;
 
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -18,6 +20,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+@Category(SlowSolverTests.class)
 public class AnytimeRaceTest {
 
     private static final double SIGMA = 90.0;

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/EngineFreeStartTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/EngineFreeStartTest.java
@@ -1,17 +1,20 @@
 package de.legoshi.parkourcalc.anglesolver;
 
+import de.legoshi.parkourcalc.SlowSolverTests;
 import de.legoshi.parkourcalc.anglesolver.harness.ProblemFixture;
 import de.legoshi.parkourcalc.core.anglesolver.SolveResult;
 import de.legoshi.parkourcalc.core.anglesolver.solver.JumpConstraint;
 import de.legoshi.parkourcalc.core.anglesolver.solver.JumpPhysicsInputs;
 import de.legoshi.parkourcalc.core.anglesolver.solver.JumpSpec;
 import de.legoshi.parkourcalc.core.anglesolver.solver.StartBox;
+import org.junit.experimental.categories.Category;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+@Category(SlowSolverTests.class)
 public class EngineFreeStartTest {
 
     private static final String CAPTURE = "j318_Waza_-0_to_Block_Pane_Postwalled";

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/IlsPolishTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/IlsPolishTest.java
@@ -1,5 +1,6 @@
 package de.legoshi.parkourcalc.anglesolver;
 
+import de.legoshi.parkourcalc.SlowSolverTests;
 import de.legoshi.parkourcalc.anglesolver.harness.ProblemFixture;
 import de.legoshi.parkourcalc.core.anglesolver.solver.Angles;
 import de.legoshi.parkourcalc.core.anglesolver.solver.ClosedFormSolve;
@@ -11,6 +12,7 @@ import de.legoshi.parkourcalc.core.anglesolver.solver.JumpPhysicsInputs;
 import de.legoshi.parkourcalc.core.anglesolver.solver.JumpSpec;
 import de.legoshi.parkourcalc.core.anglesolver.solver.Objective;
 import de.legoshi.parkourcalc.core.anglesolver.solver.SolveCore;
+import org.junit.experimental.categories.Category;
 import org.junit.Test;
 
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -18,6 +20,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+@Category(SlowSolverTests.class)
 public class IlsPolishTest {
 
     @Test

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/J008VelocityFieldGoldenTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/J008VelocityFieldGoldenTest.java
@@ -1,5 +1,6 @@
 package de.legoshi.parkourcalc.anglesolver;
 
+import de.legoshi.parkourcalc.SlowSolverTests;
 import de.legoshi.parkourcalc.anglesolver.harness.ProblemFixture;
 import de.legoshi.parkourcalc.core.anglesolver.AngleSolverState;
 import de.legoshi.parkourcalc.core.anglesolver.velocity.VelocityFinder;
@@ -7,6 +8,7 @@ import de.legoshi.parkourcalc.core.save.SaveFile;
 import de.legoshi.parkourcalc.core.save.SaveIO;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.InputData;
+import org.junit.experimental.categories.Category;
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
@@ -20,6 +22,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.Assert.assertArrayEquals;
 
+@Category(SlowSolverTests.class)
 public class J008VelocityFieldGoldenTest {
 
     private static final String GOLDEN_RESOURCE = "/golden/j008-velfield-9.bin";

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/J008VelocityFieldTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/J008VelocityFieldTest.java
@@ -1,5 +1,6 @@
 package de.legoshi.parkourcalc.anglesolver;
 
+import de.legoshi.parkourcalc.SlowSolverTests;
 import de.legoshi.parkourcalc.anglesolver.harness.ProblemFixture;
 import de.legoshi.parkourcalc.core.anglesolver.AngleSolverState;
 import de.legoshi.parkourcalc.core.anglesolver.velocity.VelocityFinder;
@@ -7,10 +8,12 @@ import de.legoshi.parkourcalc.core.save.SaveFile;
 import de.legoshi.parkourcalc.core.save.SaveIO;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.InputData;
+import org.junit.experimental.categories.Category;
 import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
 
+@Category(SlowSolverTests.class)
 public class J008VelocityFieldTest {
 
     @Test

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/J008VelocityFinderTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/J008VelocityFinderTest.java
@@ -1,5 +1,6 @@
 package de.legoshi.parkourcalc.anglesolver;
 
+import de.legoshi.parkourcalc.SlowSolverTests;
 import de.legoshi.parkourcalc.anglesolver.harness.ProblemFixture;
 import de.legoshi.parkourcalc.core.anglesolver.AngleSolverState;
 import de.legoshi.parkourcalc.core.anglesolver.velocity.VelocityFinder;
@@ -8,6 +9,7 @@ import de.legoshi.parkourcalc.core.save.SaveIO;
 import de.legoshi.parkourcalc.core.sim.TickState;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.InputData;
+import org.junit.experimental.categories.Category;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -19,6 +21,7 @@ import static org.junit.Assert.assertTrue;
 
 /** Exercises the core {@link VelocityFinder} on j008-bfneo: it must reproduce the recorded jump
  *  (recorded v0 lands at the recorded spot) and return a ranked set of landing initial velocities. */
+@Category(SlowSolverTests.class)
 public class J008VelocityFinderTest {
 
     @Test

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/ProblemsTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/ProblemsTest.java
@@ -1,5 +1,6 @@
 package de.legoshi.parkourcalc.anglesolver;
 
+import de.legoshi.parkourcalc.SlowSolverTests;
 import de.legoshi.parkourcalc.anglesolver.harness.ProblemCatalog;
 import de.legoshi.parkourcalc.anglesolver.harness.ProblemFixture;
 import de.legoshi.parkourcalc.core.anglesolver.AngleSolverState;
@@ -12,6 +13,7 @@ import de.legoshi.parkourcalc.core.anglesolver.solver.JumpConstraintCompiler;
 import de.legoshi.parkourcalc.core.anglesolver.solver.JumpPhysicsInputs;
 import de.legoshi.parkourcalc.core.anglesolver.solver.JumpSpec;
 import de.legoshi.parkourcalc.core.anglesolver.solver.Objective;
+import org.junit.experimental.categories.Category;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -41,6 +43,7 @@ import static org.junit.Assert.fail;
  * </ul>
  */
 @RunWith(Parameterized.class)
+@Category(SlowSolverTests.class)
 public class ProblemsTest {
 
     @Parameters(name = "{0}/{1}")

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/TESTS.md
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/TESTS.md
@@ -3,6 +3,10 @@
 A saved jump (capture) lives in a check folder, and `ProblemsTest` validates it for that check. To add
 coverage you drop a capture (or a tiny sidecar) into a folder. No Java change, no capture name in any test.
 
+`ProblemsTest` and the other engine-driving suites are tagged `@Category(SlowSolverTests.class)` and
+excluded from the default `:core:test` run; pass `-PslowTests` to run them (CI always does). See
+AGENTS.md "Tests" for the full slow list and when a full run is required.
+
 ```
 anglesolver/
   ProblemsTest.java        every capture under resources/problems/<check>/ is validated for that check

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/TranslationEliminationTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/TranslationEliminationTest.java
@@ -1,5 +1,6 @@
 package de.legoshi.parkourcalc.anglesolver;
 
+import de.legoshi.parkourcalc.SlowSolverTests;
 import de.legoshi.parkourcalc.anglesolver.harness.ProblemFixture;
 import de.legoshi.parkourcalc.anglesolver.harness.RazorFixtures;
 import de.legoshi.parkourcalc.core.anglesolver.solver.Angles;
@@ -11,6 +12,7 @@ import de.legoshi.parkourcalc.core.anglesolver.solver.JumpPhysicsInputs;
 import de.legoshi.parkourcalc.core.anglesolver.solver.JumpSpec;
 import de.legoshi.parkourcalc.core.anglesolver.solver.SmoothJumpProblem;
 import de.legoshi.parkourcalc.core.anglesolver.solver.SnapRepairPolish;
+import org.junit.experimental.categories.Category;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -20,6 +22,7 @@ import java.util.Random;
 
 import static org.junit.Assert.assertTrue;
 
+@Category(SlowSolverTests.class)
 public class TranslationEliminationTest {
 
     private static final int DRAWS = 16;

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/VelocityFinderConstraintTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/VelocityFinderConstraintTest.java
@@ -1,5 +1,6 @@
 package de.legoshi.parkourcalc.anglesolver;
 
+import de.legoshi.parkourcalc.SlowSolverTests;
 import de.legoshi.parkourcalc.anglesolver.harness.Fixtures;
 import de.legoshi.parkourcalc.core.anglesolver.AngleSolverState;
 import de.legoshi.parkourcalc.core.anglesolver.solver.ExactJumpModel;
@@ -8,6 +9,7 @@ import de.legoshi.parkourcalc.core.save.SaveFile;
 import de.legoshi.parkourcalc.core.save.SaveIO;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.InputData;
+import org.junit.experimental.categories.Category;
 import org.junit.Test;
 
 import java.util.List;
@@ -18,6 +20,7 @@ import static org.junit.Assert.assertTrue;
  *  velocity counts as a hit iff every constraint is met, wherever the jump lands. bfsetup2 is a pure
  *  constraint + objective jump (no land block) whose solution travels ~2 blocks from the start; the old
  *  pad-walls rejected every such velocity. */
+@Category(SlowSolverTests.class)
 public class VelocityFinderConstraintTest {
 
     private static VelocityFinder build(SaveFile file, VelocityFinder.Accuracy acc) {

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/WrapWindowIlsTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/WrapWindowIlsTest.java
@@ -1,5 +1,6 @@
 package de.legoshi.parkourcalc.anglesolver;
 
+import de.legoshi.parkourcalc.SlowSolverTests;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
@@ -14,6 +15,7 @@ import de.legoshi.parkourcalc.core.anglesolver.solver.JumpSpec;
 import de.legoshi.parkourcalc.core.anglesolver.solver.StartBox;
 import de.legoshi.parkourcalc.core.anglesolver.solver.WrapWindowIls;
 import de.legoshi.parkourcalc.core.save.SaveFile;
+import org.junit.experimental.categories.Category;
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
@@ -29,6 +31,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+@Category(SlowSolverTests.class)
 public class WrapWindowIlsTest {
 
     private static final class Rung {

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/graph/GraphPresetSolveTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/graph/GraphPresetSolveTest.java
@@ -1,5 +1,6 @@
 package de.legoshi.parkourcalc.anglesolver.graph;
 
+import de.legoshi.parkourcalc.SlowSolverTests;
 import de.legoshi.parkourcalc.anglesolver.harness.Fixtures;
 import de.legoshi.parkourcalc.core.anglesolver.AngleSolverEngine;
 import de.legoshi.parkourcalc.core.anglesolver.AngleSolverState;
@@ -14,6 +15,7 @@ import de.legoshi.parkourcalc.core.save.Result;
 import de.legoshi.parkourcalc.core.save.SaveFile;
 import de.legoshi.parkourcalc.core.save.SaveIO;
 import de.legoshi.parkourcalc.core.ui.InputData;
+import org.junit.experimental.categories.Category;
 import org.junit.Test;
 
 import java.nio.file.Files;
@@ -22,6 +24,7 @@ import java.nio.file.Path;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+@Category(SlowSolverTests.class)
 public class GraphPresetSolveTest {
 
     @Test

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/graph/GraphRunnerTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/graph/GraphRunnerTest.java
@@ -1,5 +1,6 @@
 package de.legoshi.parkourcalc.anglesolver.graph;
 
+import de.legoshi.parkourcalc.SlowSolverTests;
 import de.legoshi.parkourcalc.core.anglesolver.graph.Branch;
 import de.legoshi.parkourcalc.core.anglesolver.graph.GraphContext;
 import de.legoshi.parkourcalc.core.anglesolver.graph.GraphEdge;
@@ -16,6 +17,7 @@ import de.legoshi.parkourcalc.core.anglesolver.graph.NodeStatus;
 import de.legoshi.parkourcalc.core.anglesolver.graph.NodeType;
 import de.legoshi.parkourcalc.core.anglesolver.graph.ParamSpec;
 import de.legoshi.parkourcalc.core.anglesolver.graph.SolverGraph;
+import org.junit.experimental.categories.Category;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -29,6 +31,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+@Category(SlowSolverTests.class)
 public class GraphRunnerTest {
 
     private static GraphNode marker(String id, String typeId) {

--- a/core/src/test/java/de/legoshi/parkourcalc/core/anglesolver/velocity/VelocityFieldReuseEquivalenceTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/anglesolver/velocity/VelocityFieldReuseEquivalenceTest.java
@@ -1,11 +1,13 @@
 package de.legoshi.parkourcalc.core.anglesolver.velocity;
 
+import de.legoshi.parkourcalc.SlowSolverTests;
 import de.legoshi.parkourcalc.anglesolver.harness.ProblemFixture;
 import de.legoshi.parkourcalc.core.anglesolver.AngleSolverState;
 import de.legoshi.parkourcalc.core.save.SaveFile;
 import de.legoshi.parkourcalc.core.save.SaveIO;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.InputData;
+import org.junit.experimental.categories.Category;
 import org.junit.Test;
 
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -13,6 +15,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+@Category(SlowSolverTests.class)
 public class VelocityFieldReuseEquivalenceTest {
 
     private static final int N = 9;


### PR DESCRIPTION
Closes #269.

`:core:test` was ~3.5 min wall, 167 s of it `ProblemsTest` alone. The 13 engine-driving solver suites are now tagged with a JUnit category (`de.legoshi.parkourcalc.SlowSolverTests`) and excluded from the default run; `-PslowTests` includes them.

- default `:core:test`: 513 tests, ~7 s test execution (~17 s wall including Gradle overhead)
- `:core:test -PslowTests`: full 655 tests, ~4 min, green
- CI (`build.yml`, `release.yml`) now passes `-PslowTests`, so PRs and releases still gate on the full suite
- AGENTS.md and `anglesolver/TESTS.md` document the flag and when a full local run is required (any solver/model/capture change)