### PR TITLE
fix(constraints): generalize hotkey B over multi-box block shapes

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/ConstraintDeriver.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/ConstraintDeriver.java
@@ -48,10 +48,14 @@ public final class ConstraintDeriver {
     private static double faceFromBoxes(Constraint.Field field, int sign, List<AABB> boxes, Vec3dCore hitVec) {
         double fallback = (field == Constraint.Field.X) ? hitVec.x : hitVec.z;
         if (boxes == null || boxes.isEmpty()) return fallback;
+        double nearest = Double.POSITIVE_INFINITY;
+        for (AABB b : boxes) {
+            nearest = Math.min(nearest, tangentialGap(field, b, hitVec));
+        }
         boolean found = false;
         double best = 0;
         for (AABB b : boxes) {
-            if (!spansTangential(field, b, hitVec)) continue;
+            if (tangentialGap(field, b, hitVec) > nearest + SPAN_EPS) continue;
             double faceCoord;
             if (field == Constraint.Field.X) {
                 faceCoord = sign > 0 ? b.max.x : b.min.x;
@@ -68,12 +72,18 @@ public final class ConstraintDeriver {
         return found ? best : fallback;
     }
 
-    private static boolean spansTangential(Constraint.Field field, AABB b, Vec3dCore hitVec) {
-        boolean spansY = b.min.y <= hitVec.y + SPAN_EPS && b.max.y >= hitVec.y - SPAN_EPS;
-        if (field == Constraint.Field.X) {
-            return spansY && b.min.z <= hitVec.z + SPAN_EPS && b.max.z >= hitVec.z - SPAN_EPS;
-        }
-        return spansY && b.min.x <= hitVec.x + SPAN_EPS && b.max.x >= hitVec.x - SPAN_EPS;
+    private static double tangentialGap(Constraint.Field field, AABB b, Vec3dCore hitVec) {
+        double gapY = axisGap(hitVec.y, b.min.y, b.max.y);
+        double gapT = (field == Constraint.Field.X)
+                ? axisGap(hitVec.z, b.min.z, b.max.z)
+                : axisGap(hitVec.x, b.min.x, b.max.x);
+        return Math.max(gapY, gapT);
+    }
+
+    private static double axisGap(double v, double lo, double hi) {
+        if (v < lo) return lo - v;
+        if (v > hi) return v - hi;
+        return 0.0;
     }
 
     public static Constraint.Op opposite(Constraint.Op op) {
@@ -89,6 +99,37 @@ public final class ConstraintDeriver {
             default:
                 return op;
         }
+    }
+
+    public static AABB mergeCoplanarSupport(AABB seed, List<AABB> boxes) {
+        double top = seed.max.y;
+        double xLo = seed.min.x, xHi = seed.max.x;
+        double zLo = seed.min.z, zHi = seed.max.z;
+        double yLo = seed.min.y;
+        double bodyWidth = 2.0 * HALF;
+        boolean grew = true;
+        while (grew) {
+            grew = false;
+            for (AABB b : boxes) {
+                if (Math.abs(b.max.y - top) > EPS) continue;
+                boolean sameX = Math.abs(b.min.x - xLo) <= EPS && Math.abs(b.max.x - xHi) <= EPS;
+                boolean sameZ = Math.abs(b.min.z - zLo) <= EPS && Math.abs(b.max.z - zHi) <= EPS;
+                if (sameX && (b.min.z < zLo - EPS || b.max.z > zHi + EPS)
+                        && b.min.z - zHi < bodyWidth && zLo - b.max.z < bodyWidth) {
+                    zLo = Math.min(zLo, b.min.z);
+                    zHi = Math.max(zHi, b.max.z);
+                    yLo = Math.min(yLo, b.min.y);
+                    grew = true;
+                } else if (sameZ && (b.min.x < xLo - EPS || b.max.x > xHi + EPS)
+                        && b.min.x - xHi < bodyWidth && xLo - b.max.x < bodyWidth) {
+                    xLo = Math.min(xLo, b.min.x);
+                    xHi = Math.max(xHi, b.max.x);
+                    yLo = Math.min(yLo, b.min.y);
+                    grew = true;
+                }
+            }
+        }
+        return new AABB(new Vec3dCore(xLo, yLo, zLo), new Vec3dCore(xHi, top, zHi));
     }
 
     public static double[] deriveFootprint(AABB support, double clickX, double clickZ, List<AABB> obstacles,

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/ConstraintKeyController.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/ConstraintKeyController.java
@@ -67,7 +67,7 @@ public final class ConstraintKeyController {
                 Vec3dCore hit = mc.getLookedAtHitVec();
                 if (hit == null) return;
                 AABB support = supportBox(bx, by, bz, hit);
-                List<AABB> obstacles = mc.getCollisionBoxes(bx - 1, by + 1, bz - 1, bx + 1, by + 2, bz + 1);
+                List<AABB> obstacles = mc.getCollisionBoxes(bx - 1, by, bz - 1, bx + 1, by + 2, bz + 1);
                 double[] r = ConstraintDeriver.deriveFootprint(support, hit.x, hit.z, obstacles, modernCollision);
                 state.setFootprint(tick, r[0], r[1], r[2], r[3]);
             }
@@ -114,7 +114,7 @@ public final class ConstraintKeyController {
                 best = b;
             }
         }
-        if (best != null) return best;
+        if (best != null) return ConstraintDeriver.mergeCoplanarSupport(best, boxes);
         return new AABB(new Vec3dCore(bx, by, bz), new Vec3dCore(bx + 1.0, by + 1.0, bz + 1.0));
     }
 

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/ConstraintDeriverTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/ConstraintDeriverTest.java
@@ -72,6 +72,35 @@ public class ConstraintDeriverTest {
     }
 
     @Test
+    public void wallSnapsToTheCollisionFaceWhenTheHitLandsOffTheBoxes() {
+        AABB honey = box(5.0625, 64.0, 5.0625, 5.9375, 64.9375, 5.9375);
+        Vec3dCore outlineHit = new Vec3dCore(6.0, 64.97, 5.5);
+        Constraint c = ConstraintDeriver.deriveWall(Face.POS_X, Arrays.asList(honey), outlineHit, false);
+        assertEquals("hit above the inset collision still snaps to the collision face, not the outline",
+                5.9375 + HALF, c.getValue(), EPS);
+    }
+
+    @Test
+    public void wallPicksTheNearestBoxWhenNoneSpansTheHit() {
+        AABB bottomPlate = box(5.0, 64.0, 5.0, 6.0, 64.2, 6.0);
+        AABB insetTopPlate = box(5.0, 64.9, 5.0, 5.8, 65.0, 6.0);
+        Vec3dCore hit = new Vec3dCore(6.0, 64.85, 5.5);
+        Constraint c = ConstraintDeriver.deriveWall(Face.POS_X, Arrays.asList(bottomPlate, insetTopPlate), hit, false);
+        assertEquals("the nearest box wins over a farther box with a more extreme face",
+                5.8 + HALF, c.getValue(), EPS);
+    }
+
+    @Test
+    public void wallKeepsTheOutermostFaceAmongBoxesSpanningTheHit() {
+        AABB backPanel = box(5.8125, 64.0, 5.0, 6.0, 65.0, 6.0);
+        AABB topLip = box(5.6875, 64.75, 5.0, 5.8125, 65.0, 6.0);
+        Vec3dCore hit = new Vec3dCore(5.6875, 64.8, 5.5);
+        Constraint c = ConstraintDeriver.deriveWall(Face.NEG_X, Arrays.asList(backPanel, topLip), hit, false);
+        assertEquals("the lip in front of the panel sets the wall plane at the clicked height",
+                5.6875 - HALF, c.getValue(), EPS);
+    }
+
+    @Test
     public void wallReturnsNullForTopFace() {
         assertNull(ConstraintDeriver.deriveWall(Face.POS_Y, Collections.<AABB>emptyList(), new Vec3dCore(5.5, 65.0, 5.5), false));
     }
@@ -128,6 +157,40 @@ public class ConstraintDeriverTest {
         double[] r = ConstraintDeriver.deriveFootprint(cube(5, 64, 8), 5.5, 8.5, obstacles, false);
         assertEquals(6 + HALF, r[1], EPS);
         assertEquals(9 + HALF, r[3], EPS);
+    }
+
+    @Test
+    public void ownCellRiserAboveTheStandSurfaceClipsTheFootprint() {
+        AABB slab = box(5.0, 64.0, 8.0, 6.0, 64.5, 9.0);
+        AABB riser = box(5.5, 64.5, 8.0, 6.0, 65.0, 9.0);
+        double[] r = ConstraintDeriver.deriveFootprint(slab, 5.25, 8.5, Arrays.asList(riser), false);
+        assertEquals("the stair riser in the same cell blocks the body above the lower step", 5.5 - HALF, r[1], EPS);
+        assertEquals(5 - HALF, r[0], EPS);
+        assertEquals(8 - HALF, r[2], EPS);
+        assertEquals(9 + HALF, r[3], EPS);
+    }
+
+    @Test
+    public void coplanarCollinearBoxesMergeIntoOneSupport() {
+        AABB topLip = box(5.0, 64.75, 8.6875, 6.0, 65.0, 8.8125);
+        AABB backPanel = box(5.0, 64.0, 8.8125, 6.0, 65.0, 9.0);
+        AABB bottomLip = box(5.0, 64.0, 8.6875, 6.0, 64.25, 8.8125);
+        AABB merged = ConstraintDeriver.mergeCoplanarSupport(topLip, Arrays.asList(topLip, backPanel, bottomLip));
+        assertEquals(8.6875, merged.min.z, 0.0);
+        assertEquals("the flush back panel extends the standing surface", 9.0, merged.max.z, 0.0);
+        assertEquals(5.0, merged.min.x, 0.0);
+        assertEquals(6.0, merged.max.x, 0.0);
+        assertEquals(65.0, merged.max.y, 0.0);
+    }
+
+    @Test
+    public void ringWallsWithDifferentSpansStayUnmerged() {
+        AABB north = box(5.0, 64.0, 8.0, 6.0, 65.0, 8.125);
+        AABB east = box(5.875, 64.0, 8.0, 6.0, 65.0, 9.0);
+        AABB merged = ConstraintDeriver.mergeCoplanarSupport(north, Arrays.asList(north, east));
+        assertEquals("a rim wall keeps only the clicked strip", 8.125, merged.max.z, 0.0);
+        assertEquals(5.0, merged.min.x, 0.0);
+        assertEquals(6.0, merged.max.x, 0.0);
     }
 
     @Test

--- a/core/src/test/java/de/legoshi/parkourcalc/core/FakeMinecraftAccess.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/FakeMinecraftAccess.java
@@ -1,0 +1,50 @@
+package de.legoshi.parkourcalc.core;
+
+import de.legoshi.parkourcalc.core.ports.MinecraftAccess;
+import de.legoshi.parkourcalc.core.sim.AABB;
+import de.legoshi.parkourcalc.core.sim.Face;
+import de.legoshi.parkourcalc.core.sim.Vec3dCore;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+public class FakeMinecraftAccess implements MinecraftAccess {
+
+    public final List<AABB> worldBoxes = new ArrayList<>();
+    public int[] lookedAtBlock;
+    public Face lookedAtFace;
+    public Vec3dCore lookedAtHitVec;
+    public boolean ready = true;
+
+    @Override public Vec3dCore getPlayerPosition() { return Vec3dCore.ZERO; }
+    @Override public float getPlayerYaw() { return 0f; }
+    @Override public Vec3dCore getEyePosition() { return Vec3dCore.ZERO; }
+    @Override public Vec3dCore getLookDirection() { return Vec3dCore.ZERO; }
+    @Override public int[] getLookedAtBlock() { return lookedAtBlock; }
+    @Override public Face getLookedAtFace() { return lookedAtFace; }
+    @Override public Vec3dCore getLookedAtHitVec() { return lookedAtHitVec; }
+
+    @Override
+    public List<AABB> getCollisionBoxes(int minX, int minY, int minZ, int maxX, int maxY, int maxZ) {
+        List<AABB> out = new ArrayList<>();
+        for (AABB b : worldBoxes) {
+            if (b.max.x > minX && b.min.x < maxX + 1.0
+                    && b.max.y > minY && b.min.y < maxY + 1.0
+                    && b.max.z > minZ && b.min.z < maxZ + 1.0) {
+                out.add(b);
+            }
+        }
+        return out;
+    }
+
+    @Override public boolean isMousePressedLeft() { return false; }
+    @Override public boolean isMousePressedRight() { return false; }
+    @Override public double getCursorScreenX() { return 0; }
+    @Override public double getCursorScreenY() { return 0; }
+    @Override public boolean isCtrlDown() { return false; }
+    @Override public boolean isShiftDown() { return false; }
+    @Override public boolean isReady() { return ready; }
+    @Override public boolean isSinglePlayer() { return true; }
+    @Override public <T> T runOnServerThread(Supplier<T> task) { return task.get(); }
+}

--- a/core/src/test/java/de/legoshi/parkourcalc/ui/ConstraintKeyControllerTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/ui/ConstraintKeyControllerTest.java
@@ -1,0 +1,110 @@
+package de.legoshi.parkourcalc.ui;
+
+import de.legoshi.parkourcalc.core.FakeMinecraftAccess;
+import de.legoshi.parkourcalc.core.anglesolver.AngleSolverState;
+import de.legoshi.parkourcalc.core.anglesolver.Constraint;
+import de.legoshi.parkourcalc.core.anglesolver.ConstraintDeriver;
+import de.legoshi.parkourcalc.core.sim.AABB;
+import de.legoshi.parkourcalc.core.sim.Face;
+import de.legoshi.parkourcalc.core.sim.Vec3dCore;
+import de.legoshi.parkourcalc.core.ui.ConstraintKeyController;
+import de.legoshi.parkourcalc.core.ui.ConstraintSelection;
+import de.legoshi.parkourcalc.core.ui.SelectionManager;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class ConstraintKeyControllerTest {
+
+    private static final double HALF = ConstraintDeriver.HALF;
+    private static final double EPS = 1.0e-9;
+    private static final int TICK = 3;
+
+    private FakeMinecraftAccess mc;
+    private AngleSolverState state;
+    private ConstraintKeyController controller;
+
+    private static AABB box(double x0, double y0, double z0, double x1, double y1, double z1) {
+        return new AABB(new Vec3dCore(x0, y0, z0), new Vec3dCore(x1, y1, z1));
+    }
+
+    @Before
+    public void setUp() {
+        mc = new FakeMinecraftAccess();
+        state = new AngleSolverState();
+        state.setLandingTick(TICK);
+        controller = new ConstraintKeyController(
+                mc, state, new SelectionManager(mc), new ConstraintSelection(), () -> { }, false);
+    }
+
+    private List<Constraint> constraints() {
+        assertNotNull(state.tickConstraintsOrNull(TICK));
+        return state.tickConstraintsOrNull(TICK).getConstraints();
+    }
+
+    private Constraint range(Constraint.Field field) {
+        for (Constraint c : constraints()) {
+            if (c.isRange() && c.getField() == field) return c;
+        }
+        throw new AssertionError("no range constraint for " + field);
+    }
+
+    @Test
+    public void footprintOnTheLowerStepIsClippedByTheRiserInTheSameCell() {
+        mc.worldBoxes.add(box(5.0, 64.0, 8.0, 6.0, 64.5, 9.0));
+        mc.worldBoxes.add(box(5.5, 64.5, 8.0, 6.0, 65.0, 9.0));
+        mc.lookedAtBlock = new int[] {5, 64, 8};
+        mc.lookedAtFace = Face.POS_Y;
+        mc.lookedAtHitVec = new Vec3dCore(5.25, 64.5, 8.5);
+
+        controller.onKey(false, false);
+
+        Constraint x = range(Constraint.Field.X);
+        assertEquals(5 - HALF, x.getLo(), EPS);
+        assertEquals("riser above the step surface pulls the high X in", 5.5 - HALF, x.getHi(), EPS);
+        Constraint z = range(Constraint.Field.Z);
+        assertEquals(8 - HALF, z.getLo(), EPS);
+        assertEquals(9 + HALF, z.getHi(), EPS);
+    }
+
+    @Test
+    public void footprintOnAShelfTopSpansTheMergedCoplanarBoards() {
+        mc.worldBoxes.add(box(5.0, 64.75, 8.6875, 6.0, 65.0, 8.8125));
+        mc.worldBoxes.add(box(5.0, 64.0, 8.8125, 6.0, 65.0, 9.0));
+        mc.worldBoxes.add(box(5.0, 64.0, 8.6875, 6.0, 64.25, 8.8125));
+        mc.lookedAtBlock = new int[] {5, 64, 8};
+        mc.lookedAtFace = Face.POS_Y;
+        mc.lookedAtHitVec = new Vec3dCore(5.5, 65.0, 8.75);
+
+        controller.onKey(false, false);
+
+        Constraint z = range(Constraint.Field.Z);
+        assertEquals("front lip edge", 8.6875 - HALF, z.getLo(), EPS);
+        assertEquals("flush back panel extends the surface", 9 + HALF, z.getHi(), EPS);
+        Constraint x = range(Constraint.Field.X);
+        assertEquals(5 - HALF, x.getLo(), EPS);
+        assertEquals(6 + HALF, x.getHi(), EPS);
+    }
+
+    @Test
+    public void wallOnAnInsetCollisionBlockUsesTheCollisionFace() {
+        mc.worldBoxes.add(box(5.0625, 64.0, 5.0625, 5.9375, 64.9375, 5.9375));
+        mc.lookedAtBlock = new int[] {5, 64, 5};
+        mc.lookedAtFace = Face.POS_X;
+        mc.lookedAtHitVec = new Vec3dCore(6.0, 64.97, 5.5);
+
+        controller.onKey(false, false);
+
+        Constraint wall = null;
+        for (Constraint c : constraints()) {
+            if (!c.isRange() && c.getField() == Constraint.Field.X) wall = c;
+        }
+        assertNotNull(wall);
+        assertEquals(Constraint.Op.GE, wall.getOp());
+        assertEquals("wall sits on the inset collision face, not the outline hit", 5.9375 + HALF, wall.getValue(), EPS);
+    }
+}

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8MinecraftAccess.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8MinecraftAccess.java
@@ -151,9 +151,9 @@ public final class Forge8MinecraftAccess implements MinecraftAccess {
         if (world == null) return out;
         AxisAlignedBB mask = new AxisAlignedBB(minX, minY, minZ, maxX + 1.0, maxY + 1.0, maxZ + 1.0);
         List<AxisAlignedBB> boxes = new ArrayList<>();
-        for (int x = minX; x <= maxX; x++) {
-            for (int y = minY; y <= maxY; y++) {
-                for (int z = minZ; z <= maxZ; z++) {
+        for (int x = minX - 1; x <= maxX + 1; x++) {
+            for (int y = minY - 1; y <= maxY + 1; y++) {
+                for (int z = minZ - 1; z <= maxZ + 1; z++) {
                     BlockPos pos = new BlockPos(x, y, z);
                     IBlockState state = world.getBlockState(pos);
                     state.getBlock().addCollisionBoxesToList(world, pos, state, mask, boxes, null);


### PR DESCRIPTION
Closes #253

Hotkey B constraints now handle blocks whose collision is built from multiple voxel boxes or differs from the outline shape, without hardcoding any block:

- Wall constraints pick the collision box nearest the ray hit in the face-tangential plane (outermost face among ties) instead of falling back to the outline surface. Fixes honey, lectern desks, snow layers, cactus, and gap regions of shelves.
- Footprint obstacle queries start at the support's own Y level, so same-cell higher sub-boxes (stair risers, shelf lips) and taller same-level neighbors clip the footprint.
- The clicked support merges coplanar, collinear sub-boxes (shelf lip + back panel stand as one surface). Only exact rectangle unions merge, so cauldron/composter rims keep the clicked strip.
- The 1.8.9 collision query scans one cell outward like the 1.12.2/26.2 vanilla helpers, catching shapes that protrude from neighboring cells (1.5-tall fences).

Known limitation kept on purpose: the pick ray still uses the outline shape, so the collision-only band of fences/walls/gates (y 1.0 to 1.5) is not directly clickable; switching to collider raycasts would break ctrl+B on vines (#245).

Tested with the full `-PslowTests` suite plus new deriver and controller tests (shared `FakeMinecraftAccess` fake). In-game QA pending: stairs, shelf front and top, honey side, lectern on 26.2; fence-neighbor footprint on 1.8.9.