### PR TITLE
fix(forge): survive transient Windows clipboard contention on ImGui copy

### DIFF
--- a/forge-core/src/main/java/de/legoshi/parkourcalc/forge/core/lwjgl2/AwtClipboard.java
+++ b/forge-core/src/main/java/de/legoshi/parkourcalc/forge/core/lwjgl2/AwtClipboard.java
@@ -1,0 +1,33 @@
+package de.legoshi.parkourcalc.forge.core.lwjgl2;
+
+import java.awt.Toolkit;
+import java.awt.datatransfer.StringSelection;
+
+final class AwtClipboard {
+
+    private static final int MAX_ATTEMPTS = 3;
+    private static final long RETRY_DELAY_MS = 5;
+
+    private AwtClipboard() {
+    }
+
+    static void setString(String text) {
+        for (int attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+            try {
+                Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(text), null);
+                return;
+            } catch (Exception e) {
+                if (attempt == MAX_ATTEMPTS) {
+                    System.err.println("[ParkourCalculator] clipboard copy skipped: " + e.getMessage());
+                    return;
+                }
+                try {
+                    Thread.sleep(RETRY_DELAY_MS);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/forge-core/src/main/java/de/legoshi/parkourcalc/forge/core/lwjgl2/Lwjgl2ImGuiHost.java
+++ b/forge-core/src/main/java/de/legoshi/parkourcalc/forge/core/lwjgl2/Lwjgl2ImGuiHost.java
@@ -10,6 +10,7 @@ import imgui.ImFontConfig;
 import imgui.ImFontGlyphRangesBuilder;
 import imgui.ImGui;
 import imgui.ImGuiIO;
+import imgui.callback.ImStrConsumer;
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
 
@@ -130,11 +131,21 @@ public final class Lwjgl2ImGuiHost {
         if (initialized) return;
         ImGui.createContext();
         imguiLwjgl2.init();
+        installGuardedClipboardCopy();
         configurePresetFonts();
         imguiGl3.init();
         applyScale(settings.scaleIndex);
         lastFrameNanos = System.nanoTime();
         initialized = true;
+    }
+
+    private static void installGuardedClipboardCopy() {
+        ImGui.getIO().setSetClipboardTextFn(new ImStrConsumer() {
+            @Override
+            public void accept(String text) {
+                AwtClipboard.setString(text);
+            }
+        });
     }
 
     private void applyPendingScale() {


### PR DESCRIPTION
## Summary
Crash on 1.8.9 (equally reachable on 1.12.2): pressing Ctrl+C/Ctrl+X in an ImGui text field while another process momentarily held the Win32 clipboard threw IllegalStateException "cannot open system clipboard" from AWT. The exception escaped through the native inputText frame into the render tick and killed the client.

## Root cause
The koxx12 shim's SetClipboardTextFn (ImGuiLwjgl2$2) calls AWT Clipboard.setContents with no guard. The Windows clipboard is a global lock; clipboard history ingestion and clipboard managers hold it for a few milliseconds at a time, and any copy landing in that window crashed the game.

## Fix
- Lwjgl2ImGuiHost reinstalls a guarded SetClipboardTextFn right after imguiLwjgl2.init(); the shim installs its own inside init, so the post-init override wins.
- New AwtClipboard.setString: 3 attempts with 5 ms sleeps, then drops the copy with a stderr note, matching vanilla GuiScreen.setClipboardString's swallow-not-crash policy.

Paste cannot crash this way: the shim guards getData, and the flavor availability check does not open the clipboard (verified under contention on JDK 8 and 21).

## Verification
- :forge-core:build green.
- Harness holding the Win32 clipboard from a second process (P/Invoke OpenClipboard): raw AWT setContents reproduces the exact crash exception; the guarded setter survives with no throw; with a free clipboard the copy lands and reads back correctly.
- No CI regression seam: forge-core has no test task and the repro needs a second Windows process holding the clipboard. In-game QA pending.
