### PR TITLE
fix: keep the gizmo tail patch alive while constraint plates are shown

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/render/PathRenderPlan.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/render/PathRenderPlan.java
@@ -22,8 +22,12 @@ import java.util.function.IntSupplier;
  * one box; other constraints add a front box and a back box), so
  * {@link #constraintFaceVerts}/{@link #constraintLineVerts} are counted by replaying the exact constraint
  * emit through a {@link CountingBoxRenderer} ({@code BoxController.constraintFaceVertexCount}/
- * {@code constraintLineVertexCount}). Each loader draws the region as the trailing slice
- * {@code [faceTotal - constraintFaceVerts, faceTotal)} (and the line equivalent); the region is
+ * {@code constraintLineVertexCount}). Hit-distance reach lines bake just before the constraint region in
+ * the lines buffer and are tracked separately as {@link #reachLineVerts}, so a count-stable constraint
+ * region can be re-emitted in place ({@link #constraintFaceEmitter}/{@link #constraintLineEmitter})
+ * while reach lines, whose re-emit would raycast the world per tick, still force a rebuild. Each loader
+ * draws the trailing slice {@code [faceTotal - constraintFaceVerts, faceTotal)} (lines:
+ * {@code [lineTotal - reachLineVerts - constraintLineVerts, lineTotal)}); the region is
  * camera-run-independent, so it is drawn once, not per run.
  */
 public final class PathRenderPlan {
@@ -87,18 +91,26 @@ public final class PathRenderPlan {
     public final Set<Integer> selection;
     public final Consumer<BoxRenderer> faceEmitter;
     public final Consumer<BoxRenderer> lineEmitter;
+    public final Consumer<BoxRenderer> constraintFaceEmitter;
+    public final Consumer<BoxRenderer> constraintLineEmitter;
     public final SelectionPatchSpec patch;
     public final int constraintFaceVerts;
     public final int constraintLineVerts;
+    public final int reachLineVerts;
 
-    private PathRenderPlan(int structuralHash, Set<Integer> selection, Consumer<BoxRenderer> faceEmitter, Consumer<BoxRenderer> lineEmitter, SelectionPatchSpec patch, int constraintFaceVerts, int constraintLineVerts) {
+    private PathRenderPlan(int structuralHash, Set<Integer> selection, Consumer<BoxRenderer> faceEmitter, Consumer<BoxRenderer> lineEmitter,
+                           Consumer<BoxRenderer> constraintFaceEmitter, Consumer<BoxRenderer> constraintLineEmitter,
+                           SelectionPatchSpec patch, int constraintFaceVerts, int constraintLineVerts, int reachLineVerts) {
         this.structuralHash = structuralHash;
         this.selection = selection;
         this.faceEmitter = faceEmitter;
         this.lineEmitter = lineEmitter;
+        this.constraintFaceEmitter = constraintFaceEmitter;
+        this.constraintLineEmitter = constraintLineEmitter;
         this.patch = patch;
         this.constraintFaceVerts = constraintFaceVerts;
         this.constraintLineVerts = constraintLineVerts;
+        this.reachLineVerts = reachLineVerts;
     }
 
     public static PathRenderPlan build(BoxController boxController, Settings settings, SelectionManager selection) {
@@ -163,6 +175,16 @@ public final class PathRenderPlan {
             if (drawLive) boxController.renderConstraints(lines, live, palette, true, 0, 0, 0, ALL);
         };
 
+        Consumer<BoxRenderer> constraintFaceEmitter = faces -> {
+            if (drawConstraints) boxController.renderConstraints(faces, source, palette, false, 0, 0, 0, ALL);
+            if (drawLive) boxController.renderConstraints(faces, live, palette, false, 0, 0, 0, ALL);
+        };
+
+        Consumer<BoxRenderer> constraintLineEmitter = lines -> {
+            if (drawConstraints) boxController.renderConstraints(lines, source, palette, true, 0, 0, 0, ALL);
+            if (drawLive) boxController.renderConstraints(lines, live, palette, true, 0, 0, 0, ALL);
+        };
+
         SelectionPatchSpec patch = new SelectionPatchSpec(face, line, hitbox, drawHitbox, full, settings.showSubtick, arrowsPerBox,
                 drawYawArrows, drawCombinedArrows, BoxStyle.yawArrowArgb(settings), BoxStyle.pitchArrowArgb(settings));
 
@@ -197,8 +219,8 @@ public final class PathRenderPlan {
             constraintLineVerts = countedLineVerts;
         }
         return new PathRenderPlan(structuralHash(settings, constraintRevision, liveRevision, deviationTick, solverStartTick, solverGoalTick),
-                selectedBoxes, faceEmitter, lineEmitter, patch,
-                constraintFaceVerts, constraintLineVerts + reachLineVerts);
+                selectedBoxes, faceEmitter, lineEmitter, constraintFaceEmitter, constraintLineEmitter, patch,
+                constraintFaceVerts, constraintLineVerts, reachLineVerts);
     }
 
     /** Colors and overlay toggles, but NOT selection (which is patched in place). The constraint

--- a/core/src/main/java/de/legoshi/parkourcalc/core/render/TailPatchGate.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/render/TailPatchGate.java
@@ -1,0 +1,17 @@
+package de.legoshi.parkourcalc.core.render;
+
+public final class TailPatchGate {
+
+    private TailPatchGate() {
+    }
+
+    public static boolean canPatch(boolean built, boolean structuralHashSame, boolean boxCountSame,
+                                   int hitboxEdges, boolean useSubtick, PathRenderPlan plan,
+                                   int bakedConstraintFaceVerts, int bakedConstraintLineVerts) {
+        return built && structuralHashSame && boxCountSame
+                && hitboxEdges == 0 && !useSubtick
+                && plan.reachLineVerts == 0
+                && plan.constraintFaceVerts == bakedConstraintFaceVerts
+                && plan.constraintLineVerts == bakedConstraintLineVerts;
+    }
+}

--- a/core/src/test/java/de/legoshi/parkourcalc/render/ByteSinkRenderer.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/render/ByteSinkRenderer.java
@@ -1,0 +1,97 @@
+package de.legoshi.parkourcalc.render;
+
+import de.legoshi.parkourcalc.core.ports.BoxRenderer;
+import de.legoshi.parkourcalc.core.sim.AABB;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+final class ByteSinkRenderer implements BoxRenderer {
+    final ByteBuffer buf = ByteBuffer.allocateDirect(1 << 24).order(ByteOrder.nativeOrder());
+    final Mode mode;
+    final double ax;
+    final double ay;
+    final double az;
+    long vertices;
+
+    ByteSinkRenderer(Mode mode, double ax, double ay, double az) {
+        this.mode = mode;
+        this.ax = ax;
+        this.ay = ay;
+        this.az = az;
+    }
+
+    void reset() {
+        buf.clear();
+        vertices = 0;
+    }
+
+    private void vertex(double x, double y, double z, int argb) {
+        if (buf.remaining() < 16) buf.clear();
+        buf.putFloat((float) (x - ax));
+        buf.putFloat((float) (y - ay));
+        buf.putFloat((float) (z - az));
+        buf.putInt(argb);
+        vertices++;
+    }
+
+    @Override
+    public void drawBox(AABB b, int argb) {
+        double x0 = b.min.x;
+        double y0 = b.min.y;
+        double z0 = b.min.z;
+        double x1 = b.max.x;
+        double y1 = b.max.y;
+        double z1 = b.max.z;
+        if (mode == Mode.LINES) {
+            line(x0, y0, z0, x1, y0, z0, argb);
+            line(x1, y0, z0, x1, y0, z1, argb);
+            line(x1, y0, z1, x0, y0, z1, argb);
+            line(x0, y0, z1, x0, y0, z0, argb);
+            line(x0, y1, z0, x1, y1, z0, argb);
+            line(x1, y1, z0, x1, y1, z1, argb);
+            line(x1, y1, z1, x0, y1, z1, argb);
+            line(x0, y1, z1, x0, y1, z0, argb);
+            line(x0, y0, z0, x0, y1, z0, argb);
+            line(x1, y0, z0, x1, y1, z0, argb);
+            line(x1, y0, z1, x1, y1, z1, argb);
+            line(x0, y0, z1, x0, y1, z1, argb);
+        } else {
+            tri(x0, y0, z0, x1, y0, z0, x1, y0, z1, argb);
+            tri(x0, y0, z0, x1, y0, z1, x0, y0, z1, argb);
+            tri(x0, y1, z0, x0, y1, z1, x1, y1, z1, argb);
+            tri(x0, y1, z0, x1, y1, z1, x1, y1, z0, argb);
+            tri(x0, y0, z0, x0, y1, z0, x1, y1, z0, argb);
+            tri(x0, y0, z0, x1, y1, z0, x1, y0, z0, argb);
+            tri(x0, y0, z1, x1, y0, z1, x1, y1, z1, argb);
+            tri(x0, y0, z1, x1, y1, z1, x0, y1, z1, argb);
+            tri(x0, y0, z0, x0, y0, z1, x0, y1, z1, argb);
+            tri(x0, y0, z0, x0, y1, z1, x0, y1, z0, argb);
+            tri(x1, y0, z0, x1, y1, z0, x1, y1, z1, argb);
+            tri(x1, y0, z0, x1, y1, z1, x1, y0, z1, argb);
+        }
+    }
+
+    private void line(double x1, double y1, double z1, double x2, double y2, double z2, int argb) {
+        vertex(x1, y1, z1, argb);
+        vertex(x2, y2, z2, argb);
+    }
+
+    private void tri(double x1, double y1, double z1, double x2, double y2, double z2, double x3, double y3, double z3, int argb) {
+        vertex(x1, y1, z1, argb);
+        vertex(x2, y2, z2, argb);
+        vertex(x3, y3, z3, argb);
+    }
+
+    @Override
+    public void drawLine(double x1, double y1, double z1, double x2, double y2, double z2, int argb) {
+        if (mode != Mode.LINES) return;
+        line(x1, y1, z1, x2, y2, z2, argb);
+    }
+
+    @Override
+    public void drawTriangle(double x1, double y1, double z1, double x2, double y2, double z2, double x3, double y3, double z3, int argb) {
+        if (mode != Mode.FACES) return;
+        tri(x1, y1, z1, x2, y2, z2, x3, y3, z3, argb);
+    }
+}

--- a/core/src/test/java/de/legoshi/parkourcalc/render/GizmoDragConstraintBench.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/render/GizmoDragConstraintBench.java
@@ -1,0 +1,198 @@
+package de.legoshi.parkourcalc.render;
+
+import de.legoshi.parkourcalc.core.anglesolver.AngleSolverState;
+import de.legoshi.parkourcalc.core.anglesolver.Constraint;
+import de.legoshi.parkourcalc.core.ports.BoxRenderer;
+import de.legoshi.parkourcalc.core.render.CountingBoxRenderer;
+import de.legoshi.parkourcalc.core.render.PathRenderPlan;
+import de.legoshi.parkourcalc.core.render.PathVertexLayout;
+import de.legoshi.parkourcalc.core.render.TailPatchGate;
+import de.legoshi.parkourcalc.core.sim.TickState;
+import de.legoshi.parkourcalc.core.sim.Vec3dCore;
+import de.legoshi.parkourcalc.core.ui.BoxController;
+import de.legoshi.parkourcalc.core.ui.ConstraintSelection;
+import de.legoshi.parkourcalc.core.ui.SelectionManager;
+import de.legoshi.parkourcalc.core.ui.Settings;
+import de.legoshi.parkourcalc.core.ui.anglesolver.AngleSolverConstraintSource;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assume.assumeTrue;
+
+public class GizmoDragConstraintBench {
+
+    private static final int N = 5001;
+    private static final int CONSTRAINT_SPACING = 12;
+    private static final int WARMUP_FRAMES = 30;
+    private static final int FRAMES = 200;
+
+    private static TickState state(double x, double y, double z, float yaw) {
+        return new TickState(new Vec3dCore(x, y, z), true, false, false, yaw,
+                Collections.<Vec3dCore>emptyList(), Vec3dCore.ZERO, false, Double.NaN);
+    }
+
+    private static List<TickState> path(int n, int seed) {
+        List<TickState> list = new ArrayList<TickState>();
+        for (int i = 0; i < n; i++) {
+            list.add(state(i * 0.28 + seed * 0.013, 64.0 + (i % 7) * 0.1, seed * 0.4 + i * 0.04,
+                    (i * 11 + seed * 5) % 360 - 180));
+        }
+        return list;
+    }
+
+    private static BoxController controllerWith(List<TickState> states) {
+        BoxController bc = new BoxController();
+        for (TickState s : states) {
+            bc.add(s);
+        }
+        bc.setPitches(new float[states.size()]);
+        return bc;
+    }
+
+    private static final class LoaderCacheReplica {
+        boolean built;
+        long lastGeometryRev = -1;
+        int lastStructuralHash;
+        int boxCount;
+        int hitboxEdges;
+        boolean useSubtick;
+        int constraintFaceVerts;
+        int constraintLineVerts;
+
+        boolean fastPathTaken(BoxController bc, PathRenderPlan plan) {
+            if (!TailPatchGate.canPatch(built, plan.structuralHash == lastStructuralHash,
+                    bc.size() == boxCount, hitboxEdges, useSubtick, plan,
+                    constraintFaceVerts, constraintLineVerts)) {
+                return false;
+            }
+            return bc.takeDirtyFrom(lastGeometryRev) > 0;
+        }
+
+        void adopt(BoxController bc, PathRenderPlan plan) {
+            built = true;
+            lastGeometryRev = bc.getGeometryRev();
+            lastStructuralHash = plan.structuralHash;
+            boxCount = bc.size();
+            hitboxEdges = plan.patch.hitboxEdges();
+            useSubtick = plan.patch.showSubtick;
+            constraintFaceVerts = plan.constraintFaceVerts;
+            constraintLineVerts = plan.constraintLineVerts;
+        }
+    }
+
+    private static long rebuildEmission(BoxController bc, PathRenderPlan plan,
+                                        ByteSinkRenderer faces, ByteSinkRenderer lines) {
+        long t0 = System.nanoTime();
+        CountingBoxRenderer faceCounter = new CountingBoxRenderer(BoxRenderer.Mode.FACES);
+        plan.faceEmitter.accept(faceCounter);
+        CountingBoxRenderer lineCounter = new CountingBoxRenderer(BoxRenderer.Mode.LINES);
+        plan.lineEmitter.accept(lineCounter);
+        PathVertexLayout.hitboxVertexStarts(bc, plan.patch.hitboxEdges(), plan.patch.showSubtick);
+        faces.reset();
+        plan.faceEmitter.accept(faces);
+        lines.reset();
+        plan.lineEmitter.accept(lines);
+        return System.nanoTime() - t0;
+    }
+
+    private static long patchEmission(BoxController bc, PathRenderPlan plan, int from,
+                                      ByteSinkRenderer faces, ByteSinkRenderer lines) {
+        long t0 = System.nanoTime();
+        int n = bc.size();
+        faces.reset();
+        bc.render(faces, plan.patch.facePicker, from, n);
+        bc.renderFacingArrows(faces, plan.patch.drawYawArrows, plan.patch.drawCombinedArrows,
+                plan.patch.yawArrowArgb, plan.patch.combinedArrowArgb, from, Math.max(from, n - 1));
+        plan.constraintFaceEmitter.accept(faces);
+        lines.reset();
+        bc.render(lines, plan.patch.linePicker, from, n);
+        plan.constraintLineEmitter.accept(lines);
+        return System.nanoTime() - t0;
+    }
+
+    private long[] driveFrames(BoxController bc, Settings settings, SelectionManager sel, int frames, int[] pathCounts) {
+        ByteSinkRenderer faces = new ByteSinkRenderer(BoxRenderer.Mode.FACES, 0, 64, 0);
+        ByteSinkRenderer lines = new ByteSinkRenderer(BoxRenderer.Mode.LINES, 0, 64, 0);
+        LoaderCacheReplica cache = new LoaderCacheReplica();
+
+        PathRenderPlan initial = PathRenderPlan.build(bc, settings, sel);
+        rebuildEmission(bc, initial, faces, lines);
+        bc.takeDirtyFrom(bc.getGeometryRev());
+        cache.adopt(bc, initial);
+
+        int dirtyTick = N - 3;
+        long rebuildNanos = 0;
+        long patchNanos = 0;
+        long planNanos = 0;
+        for (int f = 0; f < frames; f++) {
+            List<TickState> tail = new ArrayList<TickState>();
+            tail.add(state(dirtyTick * 0.28 + f * 0.001, 64.0, f * 0.002, (f * 17) % 360 - 180));
+            tail.add(state(dirtyTick * 0.28 + f * 0.0015, 64.0, f * 0.003, (f * 19) % 360 - 180));
+            bc.replaceFrom(dirtyTick + 1, tail);
+            bc.setPitches(new float[bc.size()]);
+
+            long p0 = System.nanoTime();
+            PathRenderPlan plan = PathRenderPlan.build(bc, settings, sel);
+            planNanos += System.nanoTime() - p0;
+
+            if (cache.fastPathTaken(bc, plan)) {
+                pathCounts[0]++;
+                patchNanos += patchEmission(bc, plan, Math.max(0, dirtyTick), faces, lines);
+            } else {
+                pathCounts[1]++;
+                rebuildNanos += rebuildEmission(bc, plan, faces, lines);
+                bc.takeDirtyFrom(bc.getGeometryRev());
+            }
+            cache.adopt(bc, plan);
+        }
+        return new long[]{patchNanos, rebuildNanos, planNanos, faces.vertices + lines.vertices};
+    }
+
+    @Test
+    public void measure() {
+        assumeTrue("1".equals(System.getenv("PKC_BENCH")));
+        Settings settings = new Settings();
+        SelectionManager sel = new SelectionManager(null);
+        try {
+            StringBuilder out = new StringBuilder();
+            for (int withConstraints = 0; withConstraints < 2; withConstraints++) {
+                BoxController bc = controllerWith(path(N, 1));
+                AngleSolverState solver = new AngleSolverState();
+                if (withConstraints == 1) {
+                    for (int t = CONSTRAINT_SPACING; t < N; t += CONSTRAINT_SPACING) {
+                        double x = t * 0.28;
+                        double z = t * 0.04;
+                        solver.tickConstraints(t).getConstraints().add(
+                                Constraint.range(Constraint.Field.X, x - 0.8, x + 0.8, true, true));
+                        solver.tickConstraints(t).getConstraints().add(
+                                Constraint.range(Constraint.Field.Z, z - 0.8, z + 0.8, true, true));
+                    }
+                }
+                PathRenderPlan.setConstraintSource(new AngleSolverConstraintSource(
+                        solver, bc, () -> true, settings, sel, new ConstraintSelection()));
+                PathRenderPlan.setLiveSource(null);
+                PathRenderPlan.setReachProbe(null);
+
+                int[] warmCounts = new int[2];
+                driveFrames(bc, settings, sel, WARMUP_FRAMES, warmCounts);
+                int[] pathCounts = new int[2];
+                long[] r = driveFrames(bc, settings, sel, FRAMES, pathCounts);
+
+                out.append(String.format(
+                        "n=%d constraints=%s: patch frames %d (avg %.3f ms), rebuild frames %d (avg %.3f ms), plan avg %.3f ms, last verts %d%n",
+                        N, withConstraints == 1 ? ("every " + CONSTRAINT_SPACING + " ticks") : "none",
+                        pathCounts[0], pathCounts[0] == 0 ? 0 : r[0] / 1e6 / pathCounts[0],
+                        pathCounts[1], pathCounts[1] == 0 ? 0 : r[1] / 1e6 / pathCounts[1],
+                        r[2] / 1e6 / FRAMES, r[3]));
+            }
+            System.out.print(out);
+        } finally {
+            PathRenderPlan.setConstraintSource(null);
+            PathRenderPlan.setLiveSource(null);
+            PathRenderPlan.setReachProbe(null);
+        }
+    }
+}

--- a/core/src/test/java/de/legoshi/parkourcalc/render/PathRebuildBenchmark.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/render/PathRebuildBenchmark.java
@@ -3,7 +3,6 @@ package de.legoshi.parkourcalc.render;
 import de.legoshi.parkourcalc.core.ports.BoxRenderer;
 import de.legoshi.parkourcalc.core.render.PathRenderPlan;
 import de.legoshi.parkourcalc.core.render.PathVertexLayout;
-import de.legoshi.parkourcalc.core.sim.AABB;
 import de.legoshi.parkourcalc.core.sim.TickState;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.BoxController;
@@ -12,8 +11,6 @@ import de.legoshi.parkourcalc.core.ui.SelectionManager;
 import de.legoshi.parkourcalc.core.ui.Settings;
 import org.junit.Test;
 
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -22,96 +19,6 @@ import java.util.List;
 import static org.junit.Assume.assumeTrue;
 
 public class PathRebuildBenchmark {
-
-    private static final class ByteSink implements BoxRenderer {
-        final ByteBuffer buf = ByteBuffer.allocateDirect(1 << 24).order(ByteOrder.nativeOrder());
-        final Mode mode;
-        final double ax;
-        final double ay;
-        final double az;
-        long vertices;
-
-        ByteSink(Mode mode, double ax, double ay, double az) {
-            this.mode = mode;
-            this.ax = ax;
-            this.ay = ay;
-            this.az = az;
-        }
-
-        void reset() {
-            buf.clear();
-            vertices = 0;
-        }
-
-        private void vertex(double x, double y, double z, int argb) {
-            if (buf.remaining() < 16) buf.clear();
-            buf.putFloat((float) (x - ax));
-            buf.putFloat((float) (y - ay));
-            buf.putFloat((float) (z - az));
-            buf.putInt(argb);
-            vertices++;
-        }
-
-        @Override
-        public void drawBox(AABB b, int argb) {
-            double x0 = b.min.x;
-            double y0 = b.min.y;
-            double z0 = b.min.z;
-            double x1 = b.max.x;
-            double y1 = b.max.y;
-            double z1 = b.max.z;
-            if (mode == Mode.LINES) {
-                line(x0, y0, z0, x1, y0, z0, argb);
-                line(x1, y0, z0, x1, y0, z1, argb);
-                line(x1, y0, z1, x0, y0, z1, argb);
-                line(x0, y0, z1, x0, y0, z0, argb);
-                line(x0, y1, z0, x1, y1, z0, argb);
-                line(x1, y1, z0, x1, y1, z1, argb);
-                line(x1, y1, z1, x0, y1, z1, argb);
-                line(x0, y1, z1, x0, y1, z0, argb);
-                line(x0, y0, z0, x0, y1, z0, argb);
-                line(x1, y0, z0, x1, y1, z0, argb);
-                line(x1, y0, z1, x1, y1, z1, argb);
-                line(x0, y0, z1, x0, y1, z1, argb);
-            } else {
-                tri(x0, y0, z0, x1, y0, z0, x1, y0, z1, argb);
-                tri(x0, y0, z0, x1, y0, z1, x0, y0, z1, argb);
-                tri(x0, y1, z0, x0, y1, z1, x1, y1, z1, argb);
-                tri(x0, y1, z0, x1, y1, z1, x1, y1, z0, argb);
-                tri(x0, y0, z0, x0, y1, z0, x1, y1, z0, argb);
-                tri(x0, y0, z0, x1, y1, z0, x1, y0, z0, argb);
-                tri(x0, y0, z1, x1, y0, z1, x1, y1, z1, argb);
-                tri(x0, y0, z1, x1, y1, z1, x0, y1, z1, argb);
-                tri(x0, y0, z0, x0, y0, z1, x0, y1, z1, argb);
-                tri(x0, y0, z0, x0, y1, z1, x0, y1, z0, argb);
-                tri(x1, y0, z0, x1, y1, z0, x1, y1, z1, argb);
-                tri(x1, y0, z0, x1, y1, z1, x1, y0, z1, argb);
-            }
-        }
-
-        private void line(double x1, double y1, double z1, double x2, double y2, double z2, int argb) {
-            vertex(x1, y1, z1, argb);
-            vertex(x2, y2, z2, argb);
-        }
-
-        private void tri(double x1, double y1, double z1, double x2, double y2, double z2, double x3, double y3, double z3, int argb) {
-            vertex(x1, y1, z1, argb);
-            vertex(x2, y2, z2, argb);
-            vertex(x3, y3, z3, argb);
-        }
-
-        @Override
-        public void drawLine(double x1, double y1, double z1, double x2, double y2, double z2, int argb) {
-            if (mode != Mode.LINES) return;
-            line(x1, y1, z1, x2, y2, z2, argb);
-        }
-
-        @Override
-        public void drawTriangle(double x1, double y1, double z1, double x2, double y2, double z2, double x3, double y3, double z3, int argb) {
-            if (mode != Mode.FACES) return;
-            tri(x1, y1, z1, x2, y2, z2, x3, y3, z3, argb);
-        }
-    }
 
     private static List<TickState> syntheticPath(int n) {
         List<TickState> states = new ArrayList<TickState>(n);
@@ -124,7 +31,7 @@ public class PathRebuildBenchmark {
     }
 
     private static long fullEmission(BoxController bc, List<TickState> states, Settings settings,
-                                     SelectionManager sel, ByteSink faces, ByteSink lines, long[] splits) {
+                                     SelectionManager sel, ByteSinkRenderer faces, ByteSinkRenderer lines, long[] splits) {
         long t0 = System.nanoTime();
         bc.clearAll();
         for (int i = 0; i < states.size(); i++) {
@@ -154,7 +61,7 @@ public class PathRebuildBenchmark {
     }
 
     private static long incrementalEmission(BoxController bc, List<TickState> path, int dirtyTick, Settings settings,
-                                            ByteSink faces, ByteSink lines) {
+                                            ByteSinkRenderer faces, ByteSinkRenderer lines) {
         long t0 = System.nanoTime();
         bc.replaceFrom(dirtyTick + 1, path.subList(dirtyTick + 1, path.size()));
         int n = bc.size();
@@ -177,8 +84,8 @@ public class PathRebuildBenchmark {
 
         Settings settings = new Settings();
         SelectionManager sel = new SelectionManager(null);
-        ByteSink faces = new ByteSink(BoxRenderer.Mode.FACES, 0, 64, 0);
-        ByteSink lines = new ByteSink(BoxRenderer.Mode.LINES, 0, 64, 0);
+        ByteSinkRenderer faces = new ByteSinkRenderer(BoxRenderer.Mode.FACES, 0, 64, 0);
+        ByteSinkRenderer lines = new ByteSinkRenderer(BoxRenderer.Mode.LINES, 0, 64, 0);
 
         int big = 100_000;
         int small = 80;

--- a/core/src/test/java/de/legoshi/parkourcalc/render/TailPatchEquivalenceTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/render/TailPatchEquivalenceTest.java
@@ -1,21 +1,31 @@
 package de.legoshi.parkourcalc.render;
 
+import de.legoshi.parkourcalc.core.anglesolver.AngleSolverState;
+import de.legoshi.parkourcalc.core.anglesolver.Constraint;
 import de.legoshi.parkourcalc.core.ports.BoxRenderer;
+import de.legoshi.parkourcalc.core.render.PathRenderPlan;
 import de.legoshi.parkourcalc.core.render.PathVertexLayout;
+import de.legoshi.parkourcalc.core.render.TailPatchGate;
 import de.legoshi.parkourcalc.core.sim.AABB;
 import de.legoshi.parkourcalc.core.sim.TickState;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.BoxColorPicker;
 import de.legoshi.parkourcalc.core.ui.BoxController;
 import de.legoshi.parkourcalc.core.ui.BoxStyle;
+import de.legoshi.parkourcalc.core.ui.ConstraintSelection;
+import de.legoshi.parkourcalc.core.ui.SelectionManager;
 import de.legoshi.parkourcalc.core.ui.Settings;
+import de.legoshi.parkourcalc.core.ui.anglesolver.AngleSolverConstraintSource;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Consumer;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 public class TailPatchEquivalenceTest {
 
@@ -179,6 +189,97 @@ public class TailPatchEquivalenceTest {
         int from = firstChangedPitch - 1;
         BoxController expected = controllerWith(states, after);
         assertEquals(fullFaces(expected, true, true), patchedFaces(baseFaces, bc, from, true, true));
+    }
+
+    @Test
+    public void constraintRegionPatchMatchesFullRebake() {
+        int n = 40;
+        int dirtyTick = 25;
+        List<TickState> before = path(n, 1);
+        List<TickState> after = new ArrayList<TickState>(before.subList(0, dirtyTick + 1));
+        for (int i = dirtyTick + 1; i < n; i++) {
+            TickState b = before.get(i);
+            after.add(state(b.position.x + 3.0, b.position.y, b.position.z + 3.0, b.yaw));
+        }
+
+        BoxController bc = controllerWith(before, new float[n]);
+        AngleSolverState solver =
+                new AngleSolverState();
+        solver.tickConstraints(10).getConstraints().add(Constraint.range(
+                Constraint.Field.X,
+                before.get(10).position.x - 0.5, before.get(10).position.x + 0.5, true, true));
+        solver.tickConstraints(30).getConstraints().add(Constraint.range(
+                Constraint.Field.X,
+                before.get(30).position.x - 0.5, before.get(30).position.x + 0.5, true, true));
+        PathRenderPlan.setConstraintSource(
+                new AngleSolverConstraintSource(
+                        solver, bc, () -> true, settings, new SelectionManager(null),
+                        new ConstraintSelection()));
+        PathRenderPlan.setLiveSource(null);
+        PathRenderPlan.setReachProbe(null);
+        try {
+            SelectionManager sel = new SelectionManager(null);
+            PathRenderPlan planBefore =
+                    PathRenderPlan.build(bc, settings, sel);
+            List<String> baseFaces = emit(planBefore.faceEmitter, BoxRenderer.Mode.FACES);
+            List<String> baseLines = emit(planBefore.lineEmitter, BoxRenderer.Mode.LINES);
+
+            long revBefore = bc.getGeometryRev();
+            bc.takeDirtyFrom(revBefore);
+            bc.replaceFrom(dirtyTick + 1, after.subList(dirtyTick + 1, n));
+            bc.setPitches(new float[n]);
+            assertEquals(dirtyTick + 1, bc.takeDirtyFrom(revBefore));
+
+            PathRenderPlan planAfter =
+                    PathRenderPlan.build(bc, settings, sel);
+            assertEquals(planBefore.structuralHash, planAfter.structuralHash);
+            assertEquals(planBefore.constraintFaceVerts, planAfter.constraintFaceVerts);
+            assertEquals(planBefore.constraintLineVerts, planAfter.constraintLineVerts);
+            assertTrue(planAfter.constraintFaceVerts > 0);
+            assertTrue(TailPatchGate.canPatch(
+                    true, true, true, planAfter.patch.hitboxEdges(), planAfter.patch.showSubtick,
+                    planAfter, planBefore.constraintFaceVerts, planBefore.constraintLineVerts));
+
+            int from = dirtyTick;
+            List<String> patchedFaces = new ArrayList<String>(baseFaces);
+            Rec fr = new Rec(BoxRenderer.Mode.FACES);
+            bc.render(fr, planAfter.patch.facePicker, from, n);
+            splice(patchedFaces, from * FACE_VERTS, n * FACE_VERTS, fr.verts);
+            int arrowsPerBox = planAfter.patch.arrowsPerBox;
+            if (arrowsPerBox > 0) {
+                Rec ar = new Rec(BoxRenderer.Mode.FACES);
+                bc.renderFacingArrows(ar, planAfter.patch.drawYawArrows, planAfter.patch.drawCombinedArrows,
+                        planAfter.patch.yawArrowArgb, planAfter.patch.combinedArrowArgb, from, n - 1);
+                int arrowBase = n * FACE_VERTS;
+                int stride = arrowsPerBox * ARROW_VERTS;
+                splice(patchedFaces, arrowBase + from * stride, arrowBase + (n - 1) * stride, ar.verts);
+            }
+            splice(patchedFaces, patchedFaces.size() - planAfter.constraintFaceVerts, patchedFaces.size(),
+                    emit(planAfter.constraintFaceEmitter, BoxRenderer.Mode.FACES));
+
+            List<String> patchedLines = new ArrayList<String>(baseLines);
+            Rec lr = new Rec(BoxRenderer.Mode.LINES);
+            bc.render(lr, planAfter.patch.linePicker, from, n);
+            splice(patchedLines, from * 24, n * 24, lr.verts);
+            splice(patchedLines, patchedLines.size() - planAfter.constraintLineVerts, patchedLines.size(),
+                    emit(planAfter.constraintLineEmitter, BoxRenderer.Mode.LINES));
+
+            assertEquals(emit(planAfter.faceEmitter, BoxRenderer.Mode.FACES), patchedFaces);
+            assertEquals(emit(planAfter.lineEmitter, BoxRenderer.Mode.LINES), patchedLines);
+            assertNotEquals(
+                    baseFaces.subList(baseFaces.size() - planAfter.constraintFaceVerts, baseFaces.size()),
+                    patchedFaces.subList(patchedFaces.size() - planAfter.constraintFaceVerts, patchedFaces.size()));
+        } finally {
+            PathRenderPlan.setConstraintSource(null);
+            PathRenderPlan.setLiveSource(null);
+            PathRenderPlan.setReachProbe(null);
+        }
+    }
+
+    private static List<String> emit(Consumer<BoxRenderer> emitter, BoxRenderer.Mode mode) {
+        Rec r = new Rec(mode);
+        emitter.accept(r);
+        return r.verts;
     }
 
     @Test

--- a/core/src/test/java/de/legoshi/parkourcalc/render/TailPatchGateTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/render/TailPatchGateTest.java
@@ -1,0 +1,99 @@
+package de.legoshi.parkourcalc.render;
+
+import de.legoshi.parkourcalc.core.anglesolver.AngleSolverState;
+import de.legoshi.parkourcalc.core.anglesolver.Constraint;
+import de.legoshi.parkourcalc.core.render.PathRenderPlan;
+import de.legoshi.parkourcalc.core.render.ReachProbe;
+import de.legoshi.parkourcalc.core.render.TailPatchGate;
+import de.legoshi.parkourcalc.core.sim.TickState;
+import de.legoshi.parkourcalc.core.sim.Vec3dCore;
+import de.legoshi.parkourcalc.core.ui.BoxController;
+import de.legoshi.parkourcalc.core.ui.ConstraintSelection;
+import de.legoshi.parkourcalc.core.ui.SelectionManager;
+import de.legoshi.parkourcalc.core.ui.Settings;
+import de.legoshi.parkourcalc.core.ui.anglesolver.AngleSolverConstraintSource;
+import org.junit.After;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TailPatchGateTest {
+
+    @After
+    public void resetSources() {
+        PathRenderPlan.setConstraintSource(null);
+        PathRenderPlan.setLiveSource(null);
+        PathRenderPlan.setReachProbe(null);
+    }
+
+    private static BoxController boxes(int n) {
+        BoxController bc = new BoxController();
+        for (int i = 0; i < n; i++) {
+            bc.add(new TickState(new Vec3dCore(i * 0.3, 64.0, 0.0), true, false, false, 0f,
+                    Collections.<Vec3dCore>emptyList(), Vec3dCore.ZERO, false, Double.NaN));
+        }
+        bc.setPitches(new float[n]);
+        return bc;
+    }
+
+    private static PathRenderPlan planWithConstraints(BoxController bc, Settings settings) {
+        AngleSolverState state = new AngleSolverState();
+        state.tickConstraints(1).getConstraints().add(
+                Constraint.range(Constraint.Field.X, 0.0, 1.0, true, true));
+        PathRenderPlan.setConstraintSource(new AngleSolverConstraintSource(
+                state, bc, () -> true, settings, new SelectionManager(null), new ConstraintSelection()));
+        return PathRenderPlan.build(bc, settings, new SelectionManager(null));
+    }
+
+    @Test
+    public void countStableConstraintsAllowPatch() {
+        Settings settings = new Settings();
+        BoxController bc = boxes(4);
+        PathRenderPlan plan = planWithConstraints(bc, settings);
+        assertTrue(plan.constraintFaceVerts > 0);
+        assertTrue(TailPatchGate.canPatch(true, true, true, 0, false, plan,
+                plan.constraintFaceVerts, plan.constraintLineVerts));
+    }
+
+    @Test
+    public void changedConstraintCountsForceRebuild() {
+        Settings settings = new Settings();
+        BoxController bc = boxes(4);
+        PathRenderPlan plan = planWithConstraints(bc, settings);
+        assertFalse(TailPatchGate.canPatch(true, true, true, 0, false, plan,
+                plan.constraintFaceVerts + 36, plan.constraintLineVerts));
+        assertFalse(TailPatchGate.canPatch(true, true, true, 0, false, plan,
+                plan.constraintFaceVerts, plan.constraintLineVerts + 24));
+    }
+
+    @Test
+    public void reachLinesForceRebuild() {
+        Settings settings = new Settings();
+        settings.showHitDistanceLines = true;
+        settings.hitDistanceSelectedOnly = false;
+        BoxController bc = boxes(4);
+        PathRenderPlan.setReachProbe(ReachProbe.NONE);
+        PathRenderPlan plan = PathRenderPlan.build(bc, settings, new SelectionManager(null));
+        assertTrue(plan.reachLineVerts > 0);
+        assertEquals(0, plan.constraintLineVerts);
+        assertFalse(TailPatchGate.canPatch(true, true, true, 0, false, plan,
+                plan.constraintFaceVerts, plan.constraintLineVerts));
+    }
+
+    @Test
+    public void overlayAndStalenessConditionsForceRebuild() {
+        Settings settings = new Settings();
+        BoxController bc = boxes(4);
+        PathRenderPlan plan = PathRenderPlan.build(bc, settings, new SelectionManager(null));
+        assertFalse(TailPatchGate.canPatch(false, true, true, 0, false, plan, 0, 0));
+        assertFalse(TailPatchGate.canPatch(true, false, true, 0, false, plan, 0, 0));
+        assertFalse(TailPatchGate.canPatch(true, true, false, 0, false, plan, 0, 0));
+        assertFalse(TailPatchGate.canPatch(true, true, true, 4, false, plan, 0, 0));
+        assertFalse(TailPatchGate.canPatch(true, true, true, 0, true, plan, 0, 0));
+        assertTrue(TailPatchGate.canPatch(true, true, true, 0, false, plan, 0, 0));
+    }
+}

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/render/CachedBoxGeometry.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/render/CachedBoxGeometry.java
@@ -9,8 +9,10 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.textures.GpuTextureView;
 import de.legoshi.parkourcalc.core.perf.Perf;
 import de.legoshi.parkourcalc.core.ports.BoxRenderer;
+import de.legoshi.parkourcalc.core.render.PathRenderPlan;
 import de.legoshi.parkourcalc.core.render.PathVertexLayout;
 import de.legoshi.parkourcalc.core.render.SelectionPatchSpec;
+import de.legoshi.parkourcalc.core.render.TailPatchGate;
 import de.legoshi.parkourcalc.core.sim.TickState;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.BoxController;
@@ -65,41 +67,58 @@ public final class CachedBoxGeometry implements AutoCloseable {
     private int lineTotal;      // total line vertices (subtick occupies [lineMainTotal, lineTotal))
     private int constraintFaceVerts;
     private int constraintLineVerts;
+    private int reachLineVerts;
     private Set<Integer> bakedSelection = new HashSet<>();
 
     private record Segment(GpuBuffer buffer, int vertexCount) {
     }
 
-    public void ensureBuilt(BoxController boxController, int structuralHash, Set<Integer> selection, Consumer<BoxRenderer> faceEmitter, Consumer<BoxRenderer> lineEmitter, SelectionPatchSpec patch, int constraintFaceVerts, int constraintLineVerts) {
-        this.constraintFaceVerts = constraintFaceVerts;
-        this.constraintLineVerts = constraintLineVerts;
+    public void ensureBuilt(BoxController boxController, PathRenderPlan plan) {
         long rev = boxController.getGeometryRev();
-        if (built && rev == lastGeometryRev && structuralHash == lastStructuralHash) {
-            if (!selection.equals(bakedSelection)) {
-                patchSelection(boxController, selection, patch);
+        if (built && rev == lastGeometryRev && plan.structuralHash == lastStructuralHash) {
+            if (!plan.selection.equals(bakedSelection)) {
+                patchSelection(boxController, plan.selection, plan.patch);
             }
             return;
         }
         long buildStart = Perf.now();
-        if (built && structuralHash == lastStructuralHash && boxController.size() == boxCount
-                && hitboxEdges == 0 && !useSubtick && constraintFaceVerts == 0 && constraintLineVerts == 0) {
+        if (TailPatchGate.canPatch(built, plan.structuralHash == lastStructuralHash,
+                boxController.size() == boxCount, hitboxEdges, useSubtick, plan,
+                constraintFaceVerts, constraintLineVerts)) {
             int dirty = boxController.takeDirtyFrom(lastGeometryRev);
-            if (dirty > 0 && patchTail(boxController, Math.max(0, dirty - 1), patch)) {
+            if (dirty > 0 && patchTail(boxController, Math.max(0, dirty - 1), plan.patch) && patchConstraintRegion(plan)) {
                 lastGeometryRev = rev;
-                if (!selection.equals(bakedSelection)) {
-                    patchSelection(boxController, selection, patch);
+                if (!plan.selection.equals(bakedSelection)) {
+                    patchSelection(boxController, plan.selection, plan.patch);
                 }
                 Perf.stop("geomPatchTail", buildStart);
                 return;
             }
         }
-        rebuild(boxController, faceEmitter, lineEmitter, patch);
+        this.constraintFaceVerts = plan.constraintFaceVerts;
+        this.constraintLineVerts = plan.constraintLineVerts;
+        this.reachLineVerts = plan.reachLineVerts;
+        rebuild(boxController, plan.faceEmitter, plan.lineEmitter, plan.patch);
         boxController.takeDirtyFrom(rev);
         Perf.stop("geomRebuild", buildStart);
-        bakedSelection = new HashSet<>(selection);
+        bakedSelection = new HashSet<>(plan.selection);
         lastGeometryRev = rev;
-        lastStructuralHash = structuralHash;
+        lastStructuralHash = plan.structuralHash;
         built = true;
+    }
+
+    private boolean patchConstraintRegion(PathRenderPlan plan) {
+        boolean ok = true;
+        if (constraintFaceVerts > 0) {
+            ok = writeVerts(faceSegments, faceTotal - constraintFaceVerts, PrimitiveTopology.TRIANGLES,
+                    BoxRenderer.Mode.FACES, plan.constraintFaceEmitter);
+        }
+        if (ok && constraintLineVerts > 0) {
+            ok = writeVerts(lineSegments, lineTotal - constraintLineVerts, PrimitiveTopology.DEBUG_LINES,
+                    BoxRenderer.Mode.LINES, plan.constraintLineEmitter);
+        }
+        if (!ok) close();
+        return ok;
     }
 
     private boolean patchTail(BoxController boxController, int from, SelectionPatchSpec patch) {
@@ -292,8 +311,9 @@ public final class CachedBoxGeometry implements AutoCloseable {
 
     public void drawLines(Matrix4f modelView, int[] runs) {
         RenderPipeline pipeline = FabricRenderLayers.thinLinesPipeline();
-        int constraintLineBase = lineTotal - constraintLineVerts;
-        boolean hasSubtick = lineMainTotal < constraintLineBase;
+        int trailingLineVerts = constraintLineVerts + reachLineVerts;
+        int trailingLineBase = lineTotal - trailingLineVerts;
+        boolean hasSubtick = lineMainTotal < trailingLineBase;
         for (int k = 0; k + 1 < runs.length; k += 2) {
             int a = runs[k];
             int b = runs[k + 1];
@@ -302,8 +322,8 @@ public final class CachedBoxGeometry implements AutoCloseable {
                 drawRange(lineSegments, pipeline, PrimitiveTopology.DEBUG_LINES, modelView,lineMainTotal + subtickStarts[a], subtickStarts[b] - subtickStarts[a]);
             }
         }
-        if (constraintLineVerts > 0) {
-            drawRange(lineSegments, pipeline, PrimitiveTopology.DEBUG_LINES, modelView, constraintLineBase, constraintLineVerts);
+        if (trailingLineVerts > 0) {
+            drawRange(lineSegments, pipeline, PrimitiveTopology.DEBUG_LINES, modelView, trailingLineBase, trailingLineVerts);
         }
     }
 

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/render/FabricWorldOverlayRenderer.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/render/FabricWorldOverlayRenderer.java
@@ -59,7 +59,7 @@ public final class FabricWorldOverlayRenderer {
         Vec3 cameraPos = camera.pos;
 
         PathRenderPlan plan = PathRenderPlan.build(boxController, settings, selection);
-        cached.ensureBuilt(boxController, plan.structuralHash, plan.selection, plan.faceEmitter, plan.lineEmitter, plan.patch, plan.constraintFaceVerts, plan.constraintLineVerts);
+        cached.ensureBuilt(boxController, plan);
 
         Matrix4f modelView = new Matrix4f(camera.viewRotationMatrix).translate(
                 (float) (cached.anchorX() - cameraPos.x),

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/render/Forge12CachedBoxGeometry.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/render/Forge12CachedBoxGeometry.java
@@ -2,8 +2,10 @@ package de.legoshi.parkourcalc.forge12.render;
 
 import de.legoshi.parkourcalc.core.perf.Perf;
 import de.legoshi.parkourcalc.core.ports.BoxRenderer;
+import de.legoshi.parkourcalc.core.render.PathRenderPlan;
 import de.legoshi.parkourcalc.core.render.PathVertexLayout;
 import de.legoshi.parkourcalc.core.render.SelectionPatchSpec;
+import de.legoshi.parkourcalc.core.render.TailPatchGate;
 import de.legoshi.parkourcalc.core.sim.TickState;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.BoxController;
@@ -49,42 +51,55 @@ public final class Forge12CachedBoxGeometry {
     private int lineTotal;
     private int constraintFaceVerts;
     private int constraintLineVerts;
+    private int reachLineVerts;
     private int lastBakeVertices;
     private Set<Integer> bakedSelection = new HashSet<Integer>();
 
-    public void ensureBuilt(BoxController boxController, int structuralHash, Set<Integer> selection,
-                            Consumer<BoxRenderer> faceEmitter, Consumer<BoxRenderer> lineEmitter, SelectionPatchSpec patch,
-                            int constraintFaceVerts, int constraintLineVerts) {
-        this.constraintFaceVerts = constraintFaceVerts;
-        this.constraintLineVerts = constraintLineVerts;
+    public void ensureBuilt(BoxController boxController, PathRenderPlan plan) {
         long rev = boxController.getGeometryRev();
-        if (built && rev == lastGeometryRev && structuralHash == lastStructuralHash) {
-            if (!selection.equals(bakedSelection)) {
-                patchSelection(boxController, selection, patch);
+        if (built && rev == lastGeometryRev && plan.structuralHash == lastStructuralHash) {
+            if (!plan.selection.equals(bakedSelection)) {
+                patchSelection(boxController, plan.selection, plan.patch);
             }
             return;
         }
         long buildStart = Perf.now();
-        if (built && structuralHash == lastStructuralHash && boxController.size() == boxCount
-                && hitboxEdges == 0 && !useSubtick && constraintFaceVerts == 0 && constraintLineVerts == 0) {
+        if (TailPatchGate.canPatch(built, plan.structuralHash == lastStructuralHash,
+                boxController.size() == boxCount, hitboxEdges, useSubtick, plan,
+                constraintFaceVerts, constraintLineVerts)) {
             int dirty = boxController.takeDirtyFrom(lastGeometryRev);
             if (dirty > 0) {
-                patchTail(boxController, Math.max(0, dirty - 1), patch);
+                patchTail(boxController, Math.max(0, dirty - 1), plan.patch);
+                patchConstraintRegion(plan);
                 lastGeometryRev = rev;
-                if (!selection.equals(bakedSelection)) {
-                    patchSelection(boxController, selection, patch);
+                if (!plan.selection.equals(bakedSelection)) {
+                    patchSelection(boxController, plan.selection, plan.patch);
                 }
                 Perf.stop("geomPatchTail", buildStart);
                 return;
             }
         }
-        rebuild(boxController, faceEmitter, lineEmitter, patch);
+        this.constraintFaceVerts = plan.constraintFaceVerts;
+        this.constraintLineVerts = plan.constraintLineVerts;
+        this.reachLineVerts = plan.reachLineVerts;
+        rebuild(boxController, plan.faceEmitter, plan.lineEmitter, plan.patch);
         boxController.takeDirtyFrom(rev);
         Perf.stop("geomRebuild", buildStart);
-        bakedSelection = new HashSet<Integer>(selection);
+        bakedSelection = new HashSet<Integer>(plan.selection);
         lastGeometryRev = rev;
-        lastStructuralHash = structuralHash;
+        lastStructuralHash = plan.structuralHash;
         built = true;
+    }
+
+    private void patchConstraintRegion(PathRenderPlan plan) {
+        if (constraintFaceVerts > 0) {
+            writeVerts(faceVbo, faceTotal - constraintFaceVerts, GL11.GL_TRIANGLES, BoxRenderer.Mode.FACES,
+                    constraintFaceVerts, plan.constraintFaceEmitter);
+        }
+        if (constraintLineVerts > 0) {
+            writeVerts(lineVbo, lineTotal - constraintLineVerts, GL11.GL_LINES, BoxRenderer.Mode.LINES,
+                    constraintLineVerts, plan.constraintLineEmitter);
+        }
     }
 
     private void patchTail(final BoxController boxController, final int from, final SelectionPatchSpec patch) {
@@ -249,8 +264,9 @@ public final class Forge12CachedBoxGeometry {
 
     public void drawLines(int[] runs) {
         if (lineVbo == null) return;
-        int constraintLineBase = lineTotal - constraintLineVerts;
-        boolean hasSubtick = lineMainTotal < constraintLineBase;
+        int trailingLineVerts = constraintLineVerts + reachLineVerts;
+        int trailingLineBase = lineTotal - trailingLineVerts;
+        boolean hasSubtick = lineMainTotal < trailingLineBase;
         beginArrays(lineVbo);
         for (int k = 0; k + 1 < runs.length; k += 2) {
             int a = runs[k];
@@ -262,8 +278,8 @@ public final class Forge12CachedBoxGeometry {
                         subtickStarts[b] - subtickStarts[a]);
             }
         }
-        if (constraintLineVerts > 0) {
-            GL11.glDrawArrays(GL11.GL_LINES, constraintLineBase, constraintLineVerts);
+        if (trailingLineVerts > 0) {
+            GL11.glDrawArrays(GL11.GL_LINES, trailingLineBase, trailingLineVerts);
         }
         endArrays(lineVbo);
     }

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/render/Forge12WorldOverlayRenderer.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/render/Forge12WorldOverlayRenderer.java
@@ -78,7 +78,7 @@ public final class Forge12WorldOverlayRenderer {
         GlStateManager.glLineWidth(BoxStyle.LINE_WIDTH);
 
         PathRenderPlan plan = PathRenderPlan.build(boxController, settings, selection);
-        cached.ensureBuilt(boxController, plan.structuralHash, plan.selection, plan.faceEmitter, plan.lineEmitter, plan.patch, plan.constraintFaceVerts, plan.constraintLineVerts);
+        cached.ensureBuilt(boxController, plan);
 
         int[] runs = boxController.inRangeRuns(camX, camY, camZ, BoxStyle.pathMaxDistanceSq(settings));
         GlStateManager.pushMatrix();

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/render/Forge8CachedBoxGeometry.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/render/Forge8CachedBoxGeometry.java
@@ -2,8 +2,10 @@ package de.legoshi.parkourcalc.forge8.render;
 
 import de.legoshi.parkourcalc.core.perf.Perf;
 import de.legoshi.parkourcalc.core.ports.BoxRenderer;
+import de.legoshi.parkourcalc.core.render.PathRenderPlan;
 import de.legoshi.parkourcalc.core.render.PathVertexLayout;
 import de.legoshi.parkourcalc.core.render.SelectionPatchSpec;
+import de.legoshi.parkourcalc.core.render.TailPatchGate;
 import de.legoshi.parkourcalc.core.sim.TickState;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.BoxController;
@@ -49,40 +51,55 @@ public final class Forge8CachedBoxGeometry {
     private int lineTotal;
     private int constraintFaceVerts;
     private int constraintLineVerts;
+    private int reachLineVerts;
     private int lastBakeVertices;
     private Set<Integer> bakedSelection = new HashSet<Integer>();
 
-    public void ensureBuilt(BoxController boxController, int structuralHash, Set<Integer> selection, Consumer<BoxRenderer> faceEmitter, Consumer<BoxRenderer> lineEmitter, SelectionPatchSpec patch, int constraintFaceVerts, int constraintLineVerts) {
-        this.constraintFaceVerts = constraintFaceVerts;
-        this.constraintLineVerts = constraintLineVerts;
+    public void ensureBuilt(BoxController boxController, PathRenderPlan plan) {
         long rev = boxController.getGeometryRev();
-        if (built && rev == lastGeometryRev && structuralHash == lastStructuralHash) {
-            if (!selection.equals(bakedSelection)) {
-                patchSelection(boxController, selection, patch);
+        if (built && rev == lastGeometryRev && plan.structuralHash == lastStructuralHash) {
+            if (!plan.selection.equals(bakedSelection)) {
+                patchSelection(boxController, plan.selection, plan.patch);
             }
             return;
         }
         long buildStart = Perf.now();
-        if (built && structuralHash == lastStructuralHash && boxController.size() == boxCount
-                && hitboxEdges == 0 && !useSubtick && constraintFaceVerts == 0 && constraintLineVerts == 0) {
+        if (TailPatchGate.canPatch(built, plan.structuralHash == lastStructuralHash,
+                boxController.size() == boxCount, hitboxEdges, useSubtick, plan,
+                constraintFaceVerts, constraintLineVerts)) {
             int dirty = boxController.takeDirtyFrom(lastGeometryRev);
             if (dirty > 0) {
-                patchTail(boxController, Math.max(0, dirty - 1), patch);
+                patchTail(boxController, Math.max(0, dirty - 1), plan.patch);
+                patchConstraintRegion(plan);
                 lastGeometryRev = rev;
-                if (!selection.equals(bakedSelection)) {
-                    patchSelection(boxController, selection, patch);
+                if (!plan.selection.equals(bakedSelection)) {
+                    patchSelection(boxController, plan.selection, plan.patch);
                 }
                 Perf.stop("geomPatchTail", buildStart);
                 return;
             }
         }
-        rebuild(boxController, faceEmitter, lineEmitter, patch);
+        this.constraintFaceVerts = plan.constraintFaceVerts;
+        this.constraintLineVerts = plan.constraintLineVerts;
+        this.reachLineVerts = plan.reachLineVerts;
+        rebuild(boxController, plan.faceEmitter, plan.lineEmitter, plan.patch);
         boxController.takeDirtyFrom(rev);
         Perf.stop("geomRebuild", buildStart);
-        bakedSelection = new HashSet<Integer>(selection);
+        bakedSelection = new HashSet<Integer>(plan.selection);
         lastGeometryRev = rev;
-        lastStructuralHash = structuralHash;
+        lastStructuralHash = plan.structuralHash;
         built = true;
+    }
+
+    private void patchConstraintRegion(PathRenderPlan plan) {
+        if (constraintFaceVerts > 0) {
+            writeVerts(faceVbo, faceTotal - constraintFaceVerts, GL11.GL_TRIANGLES, BoxRenderer.Mode.FACES,
+                    constraintFaceVerts, plan.constraintFaceEmitter);
+        }
+        if (constraintLineVerts > 0) {
+            writeVerts(lineVbo, lineTotal - constraintLineVerts, GL11.GL_LINES, BoxRenderer.Mode.LINES,
+                    constraintLineVerts, plan.constraintLineEmitter);
+        }
     }
 
     private void patchTail(final BoxController boxController, final int from, final SelectionPatchSpec patch) {
@@ -241,8 +258,9 @@ public final class Forge8CachedBoxGeometry {
 
     public void drawLines(int[] runs) {
         if (lineVbo == null) return;
-        int constraintLineBase = lineTotal - constraintLineVerts;
-        boolean hasSubtick = lineMainTotal < constraintLineBase;
+        int trailingLineVerts = constraintLineVerts + reachLineVerts;
+        int trailingLineBase = lineTotal - trailingLineVerts;
+        boolean hasSubtick = lineMainTotal < trailingLineBase;
         beginArrays(lineVbo);
         for (int k = 0; k + 1 < runs.length; k += 2) {
             int a = runs[k];
@@ -252,8 +270,8 @@ public final class Forge8CachedBoxGeometry {
                 GL11.glDrawArrays(GL11.GL_LINES, lineMainTotal + subtickStarts[a], subtickStarts[b] - subtickStarts[a]);
             }
         }
-        if (constraintLineVerts > 0) {
-            GL11.glDrawArrays(GL11.GL_LINES, constraintLineBase, constraintLineVerts);
+        if (trailingLineVerts > 0) {
+            GL11.glDrawArrays(GL11.GL_LINES, trailingLineBase, trailingLineVerts);
         }
         endArrays(lineVbo);
     }

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/render/Forge8WorldOverlayRenderer.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/render/Forge8WorldOverlayRenderer.java
@@ -78,7 +78,7 @@ public final class Forge8WorldOverlayRenderer {
         GL11.glLineWidth(BoxStyle.LINE_WIDTH);
 
         PathRenderPlan plan = PathRenderPlan.build(boxController, settings, selection);
-        cached.ensureBuilt(boxController, plan.structuralHash, plan.selection, plan.faceEmitter, plan.lineEmitter, plan.patch, plan.constraintFaceVerts, plan.constraintLineVerts);
+        cached.ensureBuilt(boxController, plan);
 
         int[] runs = boxController.inRangeRuns(camX, camY, camZ, BoxStyle.pathMaxDistanceSq(settings));
         GlStateManager.pushMatrix();


### PR DESCRIPTION
## Problem

Dragging the yaw gizmo on a long TAS (reported at 5k ticks, tail-only drag) drops the game to ~10fps on dev.

Root cause: the gh-215 tail patch requires `constraintFaceVerts == 0 && constraintLineVerts == 0`. With the solver view open and any drawable constraint (or live-path marker) present, the counts are nonzero, so every gizmo frame falls back to a full rebake plus a full VBO delete/realloc/re-upload. The reporting setup (viewAngleSolver on, X/Z range constraints on dozens of ticks) hits this permanently.

Measured headless at n=5001 with that constraint density (`GizmoDragConstraintBench`, `PKC_BENCH=1`):

| | patch frames | rebuild frames | CPU emission / frame | verts re-emitted |
|---|---|---|---|---|
| before | 0/200 | 200/200 | 16.1 ms | 625,020 (~10 MB re-upload) |
| after | 200/200 | 0/200 | 0.8 ms | 25,260 (region write only) |

The in-game cost on 1.8.9 is higher than the CPU number: each rebuild also deletes and reallocates both STATIC_DRAW VBOs and re-uploads ~10 MB, which stalls the driver.

## Fix

- Tail patch also runs when the constraint region is count-stable: the trailing constraint slice of both buffers is re-emitted in place through the existing `writeVerts` machinery, so plate positions and satisfied/violated recolors stay correct while the path buffers persist.
- Reach lines still force a rebuild (re-emitting them raycasts the world per tick); `PathRenderPlan` now tracks `reachLineVerts` separately from `constraintLineVerts` and exposes constraint-only emitters.
- The patch-vs-rebuild decision moved to core (`TailPatchGate`), shared by all three loaders instead of three drifting copies; `ensureBuilt` now takes the plan directly.
- Any constraint edit, selection of a constrained tick, live-solve revision bump, or count change still structural-hashes to a full rebuild, same as before.

## Tests

- `TailPatchEquivalenceTest.constraintRegionPatchMatchesFullRebake`: spliced tail + re-emitted constraint region equals a full rebake, including a satisfied-to-violated plate recolor.
- `TailPatchGateTest`: count-stable constraints allow the patch (the regression), reach lines and count changes force rebuild, overlay/staleness conditions unchanged.
- `GizmoDragConstraintBench` (env-gated) reproduces the numbers above.
- `:core:build` (full default suite + tableStyleCheck) and all three loader builds green.

## QA

In-game verify pending: with the solver view open and constraints on the TAS, dragging the yaw gizmo should tick up the `geomPatchTail` perf row (viewPerf) instead of `geomRebuild`, on all three loaders.