### PR TITLE
feat: copy ticks to a new TAS and copy/paste table rows

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
@@ -55,6 +55,7 @@ import de.legoshi.parkourcalc.core.anglesolver.solver.ExactJumpModel;
 import de.legoshi.parkourcalc.core.undo.UndoController;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -141,6 +142,24 @@ public final class Application {
         return new PlaybackController.StartRange(first, stopExclusive, pos, vel, yaw, runner.getCheckpoint(first));
     }
 
+    private void promptSaveSelectionAsTas(FileMenu fileMenu) {
+        Set<Integer> rows = selection.getSelectedRows();
+        if (rows.isEmpty()) return;
+        int first = Collections.min(rows);
+        List<InputRow> copied = new ArrayList<>(rows.size());
+        for (int idx : rows) {
+            if (idx >= 0 && idx < inputData.size()) copied.add(inputData.get(idx).copy());
+        }
+        if (copied.isEmpty()) return;
+
+        TickState pre = boxController.getState(first);
+        Vec3dCore pos = pre != null ? pre.position : runner.getStartPosition();
+        Vec3dCore vel = pre != null ? pre.velocity : runner.getStartVelocity();
+        float yaw = pre != null ? pre.yaw : runner.getStartYaw();
+        float pitch = pre != null ? boxController.getPitch(first) : runner.getStartPitch();
+        fileMenu.promptSaveSelectionAsTas(copied, pos, vel, yaw, pitch);
+    }
+
     public void setModVersion(String modVersion) {
         this.modVersion = modVersion;
     }
@@ -220,6 +239,7 @@ public final class Application {
         TickInfoPanel tickInfoPanel = new TickInfoPanel(boxController, inputData, selection, settings, runner, this::pushHudMessage);
         PerfOverlay perfOverlay = new PerfOverlay();
         FileMenu fileMenu = new FileMenu(saveController, filePicker, settings, this::saveSettings);
+        inputOverlay.setSaveSelectionAsTasHandler(() -> promptSaveSelectionAsTas(fileMenu));
         SettingsModal settingsModal = new SettingsModal(settings, this::saveSettings);
         HudMessagesPanel hudMessagesPanel = new HudMessagesPanel(hudMessages, settings);
         MainWindowOverlay mainWindow = new MainWindowOverlay(

--- a/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
@@ -11,6 +11,7 @@ import de.legoshi.parkourcalc.core.perf.Perf;
 import de.legoshi.parkourcalc.core.save.FileSystemSaveStore;
 import de.legoshi.parkourcalc.core.save.SaveIO;
 import de.legoshi.parkourcalc.core.sim.SimulationRunner;
+import de.legoshi.parkourcalc.core.sim.StartResumeState;
 import de.legoshi.parkourcalc.core.sim.TickState;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.BoxController;
@@ -147,8 +148,12 @@ public final class Application {
         if (rows.isEmpty()) return;
         int first = Collections.min(rows);
         List<InputRow> copied = new ArrayList<>(rows.size());
+        List<Integer> sourceRows = new ArrayList<>(rows.size());
         for (int idx : rows) {
-            if (idx >= 0 && idx < inputData.size()) copied.add(inputData.get(idx).copy());
+            if (idx >= 0 && idx < inputData.size()) {
+                copied.add(inputData.get(idx).copy());
+                sourceRows.add(idx);
+            }
         }
         if (copied.isEmpty()) return;
 
@@ -157,7 +162,8 @@ public final class Application {
         Vec3dCore vel = pre != null ? pre.velocity : runner.getStartVelocity();
         float yaw = pre != null ? pre.yaw : runner.getStartYaw();
         float pitch = pre != null ? boxController.getPitch(first) : runner.getStartPitch();
-        fileMenu.promptSaveSelectionAsTas(copied, pos, vel, yaw, pitch);
+        StartResumeState resume = pre != null ? runner.describeResumeAt(first) : runner.getStartResumeState();
+        fileMenu.promptSaveSelectionAsTas(copied, sourceRows, pos, vel, yaw, pitch, resume);
     }
 
     public void setModVersion(String modVersion) {
@@ -194,14 +200,14 @@ public final class Application {
                     saveStore.getModVersion(), saveStore.getMcVersion()));
             angleSolverEngine.setProblemSnapshotSource(() -> SaveIO.snapshotJson(saveStore, inputData,
                     runner.getStartPosition(), runner.getStartVelocity(), runner.getStartYaw(), runner.getStartPitch(),
-                    angleSolverState, boxController.getStates()));
+                    runner.getStartResumeState(), angleSolverState, boxController.getStates()));
         }
         saveController.setSolverEngine(angleSolverEngine);
         undoController = new UndoController<>(
                 () -> SaveIO.undoSignature(inputData, runner.getStartPosition(), runner.getStartVelocity(),
-                        runner.getStartYaw(), runner.getStartPitch(), angleSolverState),
+                        runner.getStartYaw(), runner.getStartPitch(), runner.getStartResumeState(), angleSolverState),
                 () -> SaveIO.buildUndoSnapshot(inputData, runner.getStartPosition(), runner.getStartVelocity(),
-                        runner.getStartYaw(), runner.getStartPitch(), angleSolverState),
+                        runner.getStartYaw(), runner.getStartPitch(), runner.getStartResumeState(), angleSolverState),
                 SaveIO::undoJson,
                 saveController::applySnapshotJson);
         saveController.setUndoController(undoController);

--- a/core/src/main/java/de/legoshi/parkourcalc/core/SaveController.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/SaveController.java
@@ -9,6 +9,7 @@ import de.legoshi.parkourcalc.core.save.SaveIO;
 import de.legoshi.parkourcalc.core.save.SaveInfo;
 import de.legoshi.parkourcalc.core.save.WorldDescriptor;
 import de.legoshi.parkourcalc.core.sim.SimulationRunner;
+import de.legoshi.parkourcalc.core.sim.StartResumeState;
 import de.legoshi.parkourcalc.core.sim.TickState;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.BoxController;
@@ -112,7 +113,8 @@ public final class SaveController {
         if (tempActive) return;
         List<TickState> states = boxController != null ? boxController.getStates() : null;
         preTempSnapshotJson = SaveIO.snapshotJson(store, inputData, runner.getStartPosition(),
-                runner.getStartVelocity(), runner.getStartYaw(), runner.getStartPitch(), angleSolver, states);
+                runner.getStartVelocity(), runner.getStartYaw(), runner.getStartPitch(),
+                runner.getStartResumeState(), angleSolver, states);
         tempActive = true;
     }
 
@@ -139,6 +141,7 @@ public final class SaveController {
             runner.setStartVelocity(SaveIO.velOf(f.start));
             runner.setStartYaw(f.start.yaw);
             runner.setStartPitch(f.start.pitch != null ? f.start.pitch : PlaybackController.DEFAULT_PITCH);
+            runner.setStartResumeState(SaveIO.resumeOf(f.start));
             retriggerSimulation.run();
         } else if (dirtyTick >= 0) {
             retriggerFrom.accept(dirtyTick);
@@ -154,7 +157,8 @@ public final class SaveController {
         return pos.x == curPos.x && pos.y == curPos.y && pos.z == curPos.z
                 && vel.x == curVel.x && vel.y == curVel.y && vel.z == curVel.z
                 && s.yaw == runner.getStartYaw()
-                && pitch == runner.getStartPitch();
+                && pitch == runner.getStartPitch()
+                && StartResumeState.sameAs(SaveIO.resumeOf(s), runner.getStartResumeState());
     }
 
     private int firstChangedRow(List<SaveFile.Row> restored) {
@@ -177,16 +181,18 @@ public final class SaveController {
         List<TickState> states = boxController != null ? boxController.getStates() : null;
         boolean fullDebug = settings != null && settings.saveDebugValues;
         return SaveIO.save(store, rawName, inputData, runner.getStartPosition(), runner.getStartVelocity(),
-                runner.getStartYaw(), runner.getStartPitch(), angleSolver, states, fullDebug);
+                runner.getStartYaw(), runner.getStartPitch(), runner.getStartResumeState(), angleSolver, states, fullDebug);
     }
 
-    public Result<String> saveSelectionAsNewTas(String rawName, List<InputRow> rows, Vec3dCore startPos,
-                                                Vec3dCore startVel, float startYaw, float startPitch) {
+    public Result<String> saveSelectionAsNewTas(String rawName, List<InputRow> rows, List<Integer> sourceRows,
+                                                Vec3dCore startPos, Vec3dCore startVel, float startYaw,
+                                                float startPitch, StartResumeState resume) {
         if (store == null) return Result.failure("Save store not initialized.");
         if (rows == null || rows.isEmpty()) return Result.failure("No ticks selected.");
         InputData slice = new InputData();
         for (InputRow row : rows) slice.getRows().add(row);
-        return SaveIO.save(store, rawName, slice, startPos, startVel, startYaw, startPitch, null, null, false);
+        AngleSolverState sliceSolver = SaveIO.sliceAngleSolverState(angleSolver, sourceRows);
+        return SaveIO.save(store, rawName, slice, startPos, startVel, startYaw, startPitch, resume, sliceSolver, null, false);
     }
 
     public Result<String> save(String name) {
@@ -198,7 +204,7 @@ public final class SaveController {
         List<TickState> states = boxController != null ? boxController.getStates() : null;
         boolean fullDebug = settings != null && settings.saveDebugValues;
         SaveFile file = SaveIO.buildSaveFile(store, inputData, runner.getStartPosition(), runner.getStartVelocity(),
-                runner.getStartYaw(), runner.getStartPitch(), angleSolver, states, fullDebug);
+                runner.getStartYaw(), runner.getStartPitch(), runner.getStartResumeState(), angleSolver, states, fullDebug);
         FileSystemSaveStore target = store;
         writeExecutor().execute(() -> {
             try {
@@ -267,6 +273,7 @@ public final class SaveController {
         runner.setStartVelocity(SaveIO.velOf(s));
         runner.setStartYaw(s.yaw);
         runner.setStartPitch(s.pitch != null ? s.pitch : PlaybackController.DEFAULT_PITCH);
+        runner.setStartResumeState(SaveIO.resumeOf(s));
         retriggerSimulation.run();
         currentName = name;
         dirty = false;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/SaveController.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/SaveController.java
@@ -180,6 +180,15 @@ public final class SaveController {
                 runner.getStartYaw(), runner.getStartPitch(), angleSolver, states, fullDebug);
     }
 
+    public Result<String> saveSelectionAsNewTas(String rawName, List<InputRow> rows, Vec3dCore startPos,
+                                                Vec3dCore startVel, float startYaw, float startPitch) {
+        if (store == null) return Result.failure("Save store not initialized.");
+        if (rows == null || rows.isEmpty()) return Result.failure("No ticks selected.");
+        InputData slice = new InputData();
+        for (InputRow row : rows) slice.getRows().add(row);
+        return SaveIO.save(store, rawName, slice, startPos, startVel, startYaw, startPitch, null, null, false);
+    }
+
     public Result<String> save(String name) {
         if (store == null) return Result.failure("Save store not initialized.");
         String sanitized = SaveIO.sanitizeRelative(name);

--- a/core/src/main/java/de/legoshi/parkourcalc/core/VelocityMapController.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/VelocityMapController.java
@@ -63,7 +63,8 @@ public final class VelocityMapController {
         if (seed == null || store == null) return null;
 
         final String json = SaveIO.snapshotJson(store, inputData, runner.getStartPosition(),
-                runner.getStartVelocity(), runner.getStartYaw(), runner.getStartPitch(), angleSolverState, boxController.getStates());
+                runner.getStartVelocity(), runner.getStartYaw(), runner.getStartPitch(),
+                runner.getStartResumeState(), angleSolverState, boxController.getStates());
         this.velocitySnapshotJson = json;
         VelocityFinder.ProblemFactory factory = new VelocityFinder.ProblemFactory() {
             public AngleSolverState newState() {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/TickConstraints.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/TickConstraints.java
@@ -16,4 +16,13 @@ public final class TickConstraints {
     public StateOverride getOverride() {
         return override;
     }
+
+    public TickConstraints copy() {
+        TickConstraints c = new TickConstraints();
+        for (Constraint constraint : constraints) {
+            c.constraints.add(constraint.copy());
+        }
+        c.override.copyFrom(override);
+        return c;
+    }
 }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ports/MinecraftAccess.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ports/MinecraftAccess.java
@@ -99,6 +99,14 @@ public interface MinecraftAccess {
         return false;
     }
 
+    default boolean isCopyChordDown() {
+        return false;
+    }
+
+    default boolean isPasteChordDown() {
+        return false;
+    }
+
     /** Either shift key currently held. Polled directly, not via ImGui IO. */
     boolean isShiftDown();
 

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ports/Simulator.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ports/Simulator.java
@@ -2,6 +2,7 @@ package de.legoshi.parkourcalc.core.ports;
 
 import de.legoshi.parkourcalc.core.anglesolver.Medium;
 import de.legoshi.parkourcalc.core.sim.Checkpoint;
+import de.legoshi.parkourcalc.core.sim.StartResumeState;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.InputRow;
 
@@ -63,6 +64,17 @@ public interface Simulator {
     float getStartYaw();
 
     void setStartYaw(float yaw);
+
+    default StartResumeState getStartResumeState() {
+        return null;
+    }
+
+    default void setStartResumeState(StartResumeState resume) {
+    }
+
+    default StartResumeState describeCheckpoint(Checkpoint checkpoint) {
+        return null;
+    }
 
     Checkpoint saveCheckpoint();
 

--- a/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveFile.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveFile.java
@@ -28,6 +28,20 @@ public final class SaveFile {
         public double[] vel;
         public float yaw;
         public Float pitch;
+        public Resume resume;
+    }
+
+    public static final class Resume {
+        public boolean onGround;
+        public boolean wall;
+        public boolean softWall;
+        public boolean sprinting;
+        public int sprintWindow;
+        public int sprintTicksLeft;
+        public int jumpCooldown;
+        public Float airSprintFactor;
+        public double[] stuck;
+        public List<String> heldLastTick;
     }
 
     public static final class Row {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveIO.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveIO.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 import de.legoshi.parkourcalc.core.sim.AABB;
+import de.legoshi.parkourcalc.core.sim.StartResumeState;
 import de.legoshi.parkourcalc.core.sim.TickState;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.InputData;
@@ -23,8 +24,10 @@ import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.TimeZone;
 
@@ -32,12 +35,16 @@ import java.util.TimeZone;
 public final class SaveIO {
 
     public static Result<String> save(FileSystemSaveStore store, String rawName, InputData inputData, Vec3dCore startPos, Vec3dCore startVel, float startYaw, float startPitch, AngleSolverState angleSolver, List<TickState> states, boolean fullDebug) {
+        return save(store, rawName, inputData, startPos, startVel, startYaw, startPitch, null, angleSolver, states, fullDebug);
+    }
+
+    public static Result<String> save(FileSystemSaveStore store, String rawName, InputData inputData, Vec3dCore startPos, Vec3dCore startVel, float startYaw, float startPitch, StartResumeState resume, AngleSolverState angleSolver, List<TickState> states, boolean fullDebug) {
         String name = sanitizeRelative(rawName);
         if (name == null) {
             return Result.failure("Invalid save name. Use letters, numbers, dashes, or underscores.");
         }
 
-        SaveFile file = buildFile(store, inputData, startPos, startVel, startYaw, startPitch, angleSolver, states, fullDebug);
+        SaveFile file = buildFile(store, inputData, startPos, startVel, startYaw, startPitch, resume, angleSolver, states, fullDebug);
 
         try {
             store.write(name, saveJson(file));
@@ -48,7 +55,11 @@ public final class SaveIO {
     }
 
     public static SaveFile buildSaveFile(FileSystemSaveStore store, InputData inputData, Vec3dCore startPos, Vec3dCore startVel, float startYaw, float startPitch, AngleSolverState angleSolver, List<TickState> states, boolean fullDebug) {
-        return buildFile(store, inputData, startPos, startVel, startYaw, startPitch, angleSolver, states, fullDebug);
+        return buildFile(store, inputData, startPos, startVel, startYaw, startPitch, null, angleSolver, states, fullDebug);
+    }
+
+    public static SaveFile buildSaveFile(FileSystemSaveStore store, InputData inputData, Vec3dCore startPos, Vec3dCore startVel, float startYaw, float startPitch, StartResumeState resume, AngleSolverState angleSolver, List<TickState> states, boolean fullDebug) {
+        return buildFile(store, inputData, startPos, startVel, startYaw, startPitch, resume, angleSolver, states, fullDebug);
     }
 
     public static String saveJson(SaveFile file) {
@@ -58,17 +69,23 @@ public final class SaveIO {
     public static String snapshotJson(FileSystemSaveStore store, InputData inputData, Vec3dCore startPos,
                                       Vec3dCore startVel, float startYaw, float startPitch,
                                       AngleSolverState angleSolver, List<TickState> states) {
-        SaveFile file = buildFile(store, inputData, startPos, startVel, startYaw, startPitch, angleSolver, states, false);
+        return snapshotJson(store, inputData, startPos, startVel, startYaw, startPitch, null, angleSolver, states);
+    }
+
+    public static String snapshotJson(FileSystemSaveStore store, InputData inputData, Vec3dCore startPos,
+                                      Vec3dCore startVel, float startYaw, float startPitch,
+                                      StartResumeState resume, AngleSolverState angleSolver, List<TickState> states) {
+        SaveFile file = buildFile(store, inputData, startPos, startVel, startYaw, startPitch, resume, angleSolver, states, false);
         return new GsonBuilder().setPrettyPrinting().create().toJson(file);
     }
 
     public static String undoSnapshotJson(InputData inputData, Vec3dCore startPos, Vec3dCore startVel,
-                                          float startYaw, float startPitch, AngleSolverState angleSolver) {
-        return undoJson(buildUndoSnapshot(inputData, startPos, startVel, startYaw, startPitch, angleSolver));
+                                          float startYaw, float startPitch, StartResumeState resume, AngleSolverState angleSolver) {
+        return undoJson(buildUndoSnapshot(inputData, startPos, startVel, startYaw, startPitch, resume, angleSolver));
     }
 
     public static SaveFile buildUndoSnapshot(InputData inputData, Vec3dCore startPos, Vec3dCore startVel,
-                                             float startYaw, float startPitch, AngleSolverState angleSolver) {
+                                             float startYaw, float startPitch, StartResumeState resume, AngleSolverState angleSolver) {
         SaveFile file = new SaveFile();
         file.version = SaveFile.FORMAT_VERSION;
         SaveFile.Start start = new SaveFile.Start();
@@ -76,6 +93,7 @@ public final class SaveIO {
         start.vel = new double[] { startVel.x, startVel.y, startVel.z };
         start.yaw = startYaw;
         start.pitch = startPitch;
+        start.resume = toSaveResume(resume);
         file.start = start;
         List<SaveFile.Row> rows = new ArrayList<>(inputData.size());
         for (InputRow row : inputData.getRows()) {
@@ -91,7 +109,7 @@ public final class SaveIO {
     }
 
     public static String undoSignature(InputData inputData, Vec3dCore startPos, Vec3dCore startVel,
-                                       float startYaw, float startPitch, AngleSolverState angleSolver) {
+                                       float startYaw, float startPitch, StartResumeState resume, AngleSolverState angleSolver) {
         List<InputRow> rows = inputData.getRows();
         long h = 1125899906842597L;
         for (int i = 0; i < rows.size(); i++) {
@@ -104,6 +122,9 @@ public final class SaveIO {
                 .append('#').append(startPos.x).append(',').append(startPos.y).append(',').append(startPos.z)
                 .append('#').append(startVel.x).append(',').append(startVel.y).append(',').append(startVel.z)
                 .append('#').append(startYaw).append('#').append(startPitch).append('#');
+        SaveFile.Resume res = toSaveResume(resume);
+        if (res != null) sb.append(COMPACT_GSON.toJson(res));
+        sb.append('#');
         SaveFile.AngleSolver solver = toSaveAngleSolver(angleSolver);
         if (solver != null) sb.append(COMPACT_GSON.toJson(solver));
         return sb.toString();
@@ -205,6 +226,48 @@ public final class SaveIO {
                 parseEnum(AngleSolverState.DeviationKind.class, a.deviationKind, AngleSolverState.DeviationKind.OTHER));
     }
 
+    public static AngleSolverState sliceAngleSolverState(AngleSolverState source, List<Integer> sourceRows) {
+        if (source == null || sourceRows == null || sourceRows.isEmpty()) return null;
+        SaveFile.AngleSolver a = toSaveAngleSolver(source);
+        if (a == null) return null;
+
+        Map<Integer, Integer> remap = new HashMap<>();
+        int maxRow = Integer.MIN_VALUE;
+        for (int j = 0; j < sourceRows.size(); j++) {
+            remap.put(sourceRows.get(j), j);
+            maxRow = Math.max(maxRow, sourceRows.get(j));
+        }
+        remap.put(maxRow + 1, sourceRows.size());
+
+        List<SaveFile.Tick> kept = new ArrayList<>();
+        if (a.ticks != null) {
+            for (SaveFile.Tick t : a.ticks) {
+                if (t == null) continue;
+                Integer mapped = remap.get(t.tick);
+                if (mapped != null) {
+                    t.tick = mapped;
+                    kept.add(t);
+                }
+            }
+        }
+        a.ticks = kept;
+
+        Integer start = remap.get(a.startTick);
+        Integer landing = remap.get(a.landingTick);
+        a.startTick = start != null ? start : 0;
+        a.landingTick = start != null && landing != null ? landing : 0;
+        a.result = null;
+        a.deviation = null;
+        a.deviationKind = null;
+        a.seed = null;
+
+        SaveFile holder = new SaveFile();
+        holder.angleSolver = a;
+        AngleSolverState out = new AngleSolverState();
+        applyAngleSolverTo(holder, out);
+        return out;
+    }
+
     public static Vec3dCore posOf(SaveFile.Start s) {
         return new Vec3dCore(s.pos[0], s.pos[1], s.pos[2]);
     }
@@ -212,7 +275,56 @@ public final class SaveIO {
     public static Vec3dCore velOf(SaveFile.Start s) {
         if (s.vel == null || s.vel.length < 3) return Vec3dCore.GROUND_REST_VELOCITY;
         Vec3dCore v = new Vec3dCore(s.vel[0], s.vel[1], s.vel[2]);
+        if (s.resume != null) return v;
         return v.equals(Vec3dCore.ZERO) ? Vec3dCore.GROUND_REST_VELOCITY : v;
+    }
+
+    public static StartResumeState resumeOf(SaveFile.Start s) {
+        SaveFile.Resume r = s != null ? s.resume : null;
+        if (r == null) return null;
+        StartResumeState resume = new StartResumeState();
+        resume.onGround = r.onGround;
+        resume.wallContact = r.wall;
+        resume.softWallContact = r.softWall;
+        resume.sprinting = r.sprinting;
+        resume.sprintWindow = r.sprintWindow;
+        resume.sprintTicksLeft = r.sprintTicksLeft;
+        resume.jumpCooldown = r.jumpCooldown;
+        resume.airSprintFactor = r.airSprintFactor != null ? r.airSprintFactor : Float.NaN;
+        if (r.stuck != null && r.stuck.length >= 3) {
+            resume.stuckMultiplier = new Vec3dCore(r.stuck[0], r.stuck[1], r.stuck[2]);
+        }
+        if (r.heldLastTick != null) {
+            for (String key : r.heldLastTick) {
+                try {
+                    resume.heldLastTick.add(InputRow.Key.valueOf(key));
+                } catch (IllegalArgumentException ignored) {
+                }
+            }
+        }
+        return resume;
+    }
+
+    public static SaveFile.Resume toSaveResume(StartResumeState resume) {
+        if (resume == null) return null;
+        SaveFile.Resume r = new SaveFile.Resume();
+        r.onGround = resume.onGround;
+        r.wall = resume.wallContact;
+        r.softWall = resume.softWallContact;
+        r.sprinting = resume.sprinting;
+        r.sprintWindow = resume.sprintWindow;
+        r.sprintTicksLeft = resume.sprintTicksLeft;
+        r.jumpCooldown = resume.jumpCooldown;
+        r.airSprintFactor = Float.isNaN(resume.airSprintFactor) ? null : resume.airSprintFactor;
+        if (resume.stuckMultiplier != null) {
+            r.stuck = new double[] { resume.stuckMultiplier.x, resume.stuckMultiplier.y, resume.stuckMultiplier.z };
+        }
+        if (!resume.heldLastTick.isEmpty()) {
+            List<String> held = new ArrayList<>(resume.heldLastTick.size());
+            for (InputRow.Key key : resume.heldLastTick) held.add(key.name());
+            r.heldLastTick = held;
+        }
+        return r;
     }
 
     public static SaveFile parseSafe(String contents) {
@@ -262,7 +374,7 @@ public final class SaveIO {
         return out.length() == 0 ? null : out.toString();
     }
 
-    private static SaveFile buildFile(FileSystemSaveStore store, InputData inputData, Vec3dCore startPos, Vec3dCore startVel, float startYaw, float startPitch, AngleSolverState angleSolver, List<TickState> states, boolean fullDebug) {
+    private static SaveFile buildFile(FileSystemSaveStore store, InputData inputData, Vec3dCore startPos, Vec3dCore startVel, float startYaw, float startPitch, StartResumeState resume, AngleSolverState angleSolver, List<TickState> states, boolean fullDebug) {
         SaveFile file = new SaveFile();
         file.version = SaveFile.FORMAT_VERSION;
         file.createdAt = nowIso8601();
@@ -275,6 +387,7 @@ public final class SaveIO {
         start.vel = new double[] { startVel.x, startVel.y, startVel.z };
         start.yaw = startYaw;
         start.pitch = startPitch;
+        start.resume = toSaveResume(resume);
         file.start = start;
 
         List<SaveFile.Row> rows = new ArrayList<>(inputData.size());

--- a/core/src/main/java/de/legoshi/parkourcalc/core/sim/LazyEntitySimulator.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/sim/LazyEntitySimulator.java
@@ -19,11 +19,12 @@ public abstract class LazyEntitySimulator<E> implements Simulator {
     private Vec3dCore pendingStart;
     private Vec3dCore pendingVelocity;
     private Float pendingYaw;
+    private StartResumeState startResume;
     private int debugTickIndex;
 
     @Override
     public final void resetToStart() {
-        resetEntity(ensureEntity());
+        resetEntity(ensureEntity(), startResume);
         debugTickIndex = 0;
     }
 
@@ -180,6 +181,21 @@ public abstract class LazyEntitySimulator<E> implements Simulator {
     }
 
     @Override
+    public final StartResumeState getStartResumeState() {
+        return startResume;
+    }
+
+    @Override
+    public final void setStartResumeState(StartResumeState resume) {
+        startResume = resume;
+    }
+
+    @Override
+    public final StartResumeState describeCheckpoint(Checkpoint checkpoint) {
+        return checkpoint == null ? null : describeResume(checkpoint);
+    }
+
+    @Override
     public final Checkpoint saveCheckpoint() {
         return saveCheckpoint(ensureEntity());
     }
@@ -195,6 +211,7 @@ public abstract class LazyEntitySimulator<E> implements Simulator {
         pendingStart = null;
         pendingVelocity = null;
         pendingYaw = null;
+        startResume = null;
     }
 
     private E ensureEntity() {
@@ -207,7 +224,9 @@ public abstract class LazyEntitySimulator<E> implements Simulator {
     /** Any of pendingStart/pendingVelocity/pendingYaw may be null; subclass falls back to defaults. */
     protected abstract E createEntity(Vec3dCore pendingStart, Vec3dCore pendingVelocity, Float pendingYaw);
 
-    protected abstract void resetEntity(E entity);
+    protected abstract void resetEntity(E entity, StartResumeState resume);
+
+    protected abstract StartResumeState describeResume(Checkpoint checkpoint);
 
     protected abstract void setInput(E entity, InputRow row);
 

--- a/core/src/main/java/de/legoshi/parkourcalc/core/sim/SimulationRunner.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/sim/SimulationRunner.java
@@ -197,6 +197,19 @@ public final class SimulationRunner {
         simulator.setStartYaw(yaw);
     }
 
+    public StartResumeState getStartResumeState() {
+        return simulator.getStartResumeState();
+    }
+
+    public void setStartResumeState(StartResumeState resume) {
+        simulator.setStartResumeState(resume);
+    }
+
+    public StartResumeState describeResumeAt(int index) {
+        Checkpoint c = getCheckpoint(index);
+        return c == null ? null : simulator.describeCheckpoint(c);
+    }
+
     public float getStartPitch() {
         return startPitch;
     }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/sim/StartResumeState.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/sim/StartResumeState.java
@@ -1,0 +1,54 @@
+package de.legoshi.parkourcalc.core.sim;
+
+import de.legoshi.parkourcalc.core.ui.InputRow;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+public final class StartResumeState {
+
+    public boolean onGround;
+    public boolean wallContact;
+    public boolean softWallContact;
+    public boolean sprinting;
+    public int sprintWindow;
+    public int sprintTicksLeft;
+    public int jumpCooldown;
+    public float airSprintFactor = Float.NaN;
+    public Vec3dCore stuckMultiplier;
+    public final Set<InputRow.Key> heldLastTick = EnumSet.noneOf(InputRow.Key.class);
+
+    public StartResumeState copy() {
+        StartResumeState c = new StartResumeState();
+        c.onGround = onGround;
+        c.wallContact = wallContact;
+        c.softWallContact = softWallContact;
+        c.sprinting = sprinting;
+        c.sprintWindow = sprintWindow;
+        c.sprintTicksLeft = sprintTicksLeft;
+        c.jumpCooldown = jumpCooldown;
+        c.airSprintFactor = airSprintFactor;
+        c.stuckMultiplier = stuckMultiplier;
+        c.heldLastTick.addAll(heldLastTick);
+        return c;
+    }
+
+    public boolean sameAs(StartResumeState o) {
+        if (o == null) return false;
+        return onGround == o.onGround
+                && wallContact == o.wallContact
+                && softWallContact == o.softWallContact
+                && sprinting == o.sprinting
+                && sprintWindow == o.sprintWindow
+                && sprintTicksLeft == o.sprintTicksLeft
+                && jumpCooldown == o.jumpCooldown
+                && Float.floatToIntBits(airSprintFactor) == Float.floatToIntBits(o.airSprintFactor)
+                && (stuckMultiplier == null ? o.stuckMultiplier == null
+                        : o.stuckMultiplier != null && stuckMultiplier.equals(o.stuckMultiplier))
+                && heldLastTick.equals(o.heldLastTick);
+    }
+
+    public static boolean sameAs(StartResumeState a, StartResumeState b) {
+        return a == null ? b == null : a.sameAs(b);
+    }
+}

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/FileMenu.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/FileMenu.java
@@ -6,6 +6,7 @@ import de.legoshi.parkourcalc.core.save.Result;
 import de.legoshi.parkourcalc.core.save.SaveBrowseResult;
 import de.legoshi.parkourcalc.core.save.SaveFile;
 import de.legoshi.parkourcalc.core.save.SaveInfo;
+import de.legoshi.parkourcalc.core.sim.StartResumeState;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.theme.Controls;
 import de.legoshi.parkourcalc.core.ui.theme.Fonts;
@@ -391,29 +392,29 @@ public final class FileMenu {
         applyResult(r, "Saved as '%s'");
     }
 
-    public void promptSaveSelectionAsTas(List<InputRow> rows, Vec3dCore pos, Vec3dCore vel, float yaw, float pitch) {
+    public void promptSaveSelectionAsTas(List<InputRow> rows, List<Integer> sourceRows, Vec3dCore pos, Vec3dCore vel, float yaw, float pitch, StartResumeState resume) {
         if (rows == null || rows.isEmpty()) return;
         nameInput.set("");
         nameModalError = null;
         lastNameInputSeen = "";
-        nameModalConfirm = name -> doSaveSelectionAsTas(name, rows, pos, vel, yaw, pitch);
+        nameModalConfirm = name -> doSaveSelectionAsTas(name, rows, sourceRows, pos, vel, yaw, pitch, resume);
         pendingNamePopupId = POPUP_NAME_SLICE;
         pendingNameTitle = TITLE_NAME_SLICE;
     }
 
-    private void doSaveSelectionAsTas(String name, List<InputRow> rows, Vec3dCore pos, Vec3dCore vel, float yaw, float pitch) {
+    private void doSaveSelectionAsTas(String name, List<InputRow> rows, List<Integer> sourceRows, Vec3dCore pos, Vec3dCore vel, float yaw, float pitch, StartResumeState resume) {
         if (name.isEmpty()) { nameModalError = "Name cannot be empty."; return; }
         if (controller.exists(name)) {
             overwriteCandidateName = name;
-            overwriteModalConfirm = () -> finalizeSaveSelectionAsTas(name, rows, pos, vel, yaw, pitch);
+            overwriteModalConfirm = () -> finalizeSaveSelectionAsTas(name, rows, sourceRows, pos, vel, yaw, pitch, resume);
             openOverwriteModal = true;
             return;
         }
-        finalizeSaveSelectionAsTas(name, rows, pos, vel, yaw, pitch);
+        finalizeSaveSelectionAsTas(name, rows, sourceRows, pos, vel, yaw, pitch, resume);
     }
 
-    private void finalizeSaveSelectionAsTas(String name, List<InputRow> rows, Vec3dCore pos, Vec3dCore vel, float yaw, float pitch) {
-        Result<String> r = controller.saveSelectionAsNewTas(name, rows, pos, vel, yaw, pitch);
+    private void finalizeSaveSelectionAsTas(String name, List<InputRow> rows, List<Integer> sourceRows, Vec3dCore pos, Vec3dCore vel, float yaw, float pitch, StartResumeState resume) {
+        Result<String> r = controller.saveSelectionAsNewTas(name, rows, sourceRows, pos, vel, yaw, pitch, resume);
         if (r.ok) {
             setStatus("Created '" + r.value + "' from selected ticks.", false);
             cacheStale = true;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/FileMenu.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/FileMenu.java
@@ -6,6 +6,7 @@ import de.legoshi.parkourcalc.core.save.Result;
 import de.legoshi.parkourcalc.core.save.SaveBrowseResult;
 import de.legoshi.parkourcalc.core.save.SaveFile;
 import de.legoshi.parkourcalc.core.save.SaveInfo;
+import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.theme.Controls;
 import de.legoshi.parkourcalc.core.ui.theme.Fonts;
 import de.legoshi.parkourcalc.core.ui.theme.Modal;
@@ -36,9 +37,11 @@ public final class FileMenu {
 
     private static final String POPUP_NAME_NEW = "###name_modal_new";
     private static final String POPUP_NAME_SAVEAS = "###name_modal_saveas";
+    private static final String POPUP_NAME_SLICE = "###name_modal_slice";
     private static final String POPUP_OPEN = "###open_modal";
     private static final String TITLE_NAME_NEW = "New TAS";
     private static final String TITLE_NAME_SAVEAS = "Save TAS As";
+    private static final String TITLE_NAME_SLICE = "Save Ticks as New TAS";
     private static final String TITLE_OPEN = "Open TAS";
     private static final String POPUP_DISCARD = "###discard";
     private static final String POPUP_OVERWRITE = "###overwrite";
@@ -386,6 +389,37 @@ public final class FileMenu {
     private void finalizeSaveAs(String name) {
         Result<String> r = controller.save(name);
         applyResult(r, "Saved as '%s'");
+    }
+
+    public void promptSaveSelectionAsTas(List<InputRow> rows, Vec3dCore pos, Vec3dCore vel, float yaw, float pitch) {
+        if (rows == null || rows.isEmpty()) return;
+        nameInput.set("");
+        nameModalError = null;
+        lastNameInputSeen = "";
+        nameModalConfirm = name -> doSaveSelectionAsTas(name, rows, pos, vel, yaw, pitch);
+        pendingNamePopupId = POPUP_NAME_SLICE;
+        pendingNameTitle = TITLE_NAME_SLICE;
+    }
+
+    private void doSaveSelectionAsTas(String name, List<InputRow> rows, Vec3dCore pos, Vec3dCore vel, float yaw, float pitch) {
+        if (name.isEmpty()) { nameModalError = "Name cannot be empty."; return; }
+        if (controller.exists(name)) {
+            overwriteCandidateName = name;
+            overwriteModalConfirm = () -> finalizeSaveSelectionAsTas(name, rows, pos, vel, yaw, pitch);
+            openOverwriteModal = true;
+            return;
+        }
+        finalizeSaveSelectionAsTas(name, rows, pos, vel, yaw, pitch);
+    }
+
+    private void finalizeSaveSelectionAsTas(String name, List<InputRow> rows, Vec3dCore pos, Vec3dCore vel, float yaw, float pitch) {
+        Result<String> r = controller.saveSelectionAsNewTas(name, rows, pos, vel, yaw, pitch);
+        if (r.ok) {
+            setStatus("Created '" + r.value + "' from selected ticks.", false);
+            cacheStale = true;
+        } else {
+            setStatus(r.error, true);
+        }
     }
 
     private void doLoad(String name) {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputOverlay.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputOverlay.java
@@ -21,6 +21,8 @@ import imgui.flag.*;
 import imgui.type.ImInt;
 import imgui.type.ImString;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -75,6 +77,7 @@ public final class InputOverlay {
     private static final String MENU_DELETE_SHORTCUT = "Del";
 
     private static final String MENU_DUPLICATE = "Duplicate selected";
+    private static final String MENU_SAVE_AS_NEW_TAS = "Save selected as new TAS";
 
     private static final String MENU_LOCK_YAW = "Lock yaw value";
     private static final String MENU_UNLOCK_YAW = "Unlock yaw value";
@@ -110,6 +113,9 @@ public final class InputOverlay {
     private final ImString pitchInput = new ImString(32);
     private final ImInt rowsToAdd = new ImInt(1);
     private final ImInt ampBuf = new ImInt();
+
+    private final List<InputRow> clipboard = new ArrayList<>();
+    private Runnable onSaveSelectionAsTas;
 
     private int draggingRowIndex = -1;
     private int editingYawRow = -1;
@@ -206,6 +212,10 @@ public final class InputOverlay {
 
     public void setStartState(StartStateTable startState) {
         this.startState = startState;
+    }
+
+    public void setSaveSelectionAsTasHandler(Runnable handler) {
+        this.onSaveSelectionAsTas = handler;
     }
 
     private void solverRowsInserted(int index, int count) {
@@ -1265,6 +1275,28 @@ public final class InputOverlay {
         notifyChange(dirtyTick == Integer.MAX_VALUE ? -1 : dirtyTick);
     }
 
+    public void copySelectedRows() {
+        Set<Integer> rows = selection.getSelectedRows();
+        if (rows.isEmpty()) return;
+        clipboard.clear();
+        for (int idx : rows) {
+            if (idx >= 0 && idx < data.size()) clipboard.add(data.get(idx).copy());
+        }
+    }
+
+    public void pasteRows() {
+        if (clipboard.isEmpty()) return;
+        Set<Integer> selected = selection.getSelectedRows();
+        int insertAt = selected.isEmpty() ? data.size() : Collections.max(selected) + 1;
+        insertAt = Math.min(insertAt, data.size());
+        for (int i = 0; i < clipboard.size(); i++) {
+            data.insertRow(insertAt + i, clipboard.get(i).copy());
+        }
+        solverRowsInserted(insertAt, clipboard.size());
+        selection.selectRows(insertAt, clipboard.size());
+        notifyChange(insertAt);
+    }
+
     private void renderContextMenu() {
 
         boolean blockedByOtherPopup = ImGui.isPopupOpen("", ImGuiPopupFlags.AnyPopup) && !ImGui.isPopupOpen(ID_CONTEXT_MENU);
@@ -1282,6 +1314,7 @@ public final class InputOverlay {
         renderRowCountInput();
         renderAddRowOptions();
         renderDuplicateOption();
+        renderSaveAsNewTasOption();
 
         // Segment 2: position / yaw state for the current rows.
         ThemeManager.paddedSeparator();
@@ -1366,6 +1399,14 @@ public final class InputOverlay {
 
         if (contextButton(MENU_DUPLICATE)) {
             duplicateSelectedRows();
+        }
+    }
+
+    private void renderSaveAsNewTasOption() {
+        if (onSaveSelectionAsTas == null || selection.getSelectedRows().isEmpty()) return;
+
+        if (contextButton(MENU_SAVE_AS_NEW_TAS)) {
+            onSaveSelectionAsTas.run();
         }
     }
 

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputOverlay.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputOverlay.java
@@ -1,6 +1,7 @@
 package de.legoshi.parkourcalc.core.ui;
 
 import de.legoshi.parkourcalc.core.PlaybackController;
+import de.legoshi.parkourcalc.core.anglesolver.TickConstraints;
 import de.legoshi.parkourcalc.core.perf.Perf;
 import de.legoshi.parkourcalc.core.ports.MinecraftAccess;
 import de.legoshi.parkourcalc.core.sim.TickState;
@@ -115,6 +116,7 @@ public final class InputOverlay {
     private final ImInt ampBuf = new ImInt();
 
     private final List<InputRow> clipboard = new ArrayList<>();
+    private final List<TickConstraints> clipboardTicks = new ArrayList<>();
     private Runnable onSaveSelectionAsTas;
 
     private int draggingRowIndex = -1;
@@ -1279,8 +1281,12 @@ public final class InputOverlay {
         Set<Integer> rows = selection.getSelectedRows();
         if (rows.isEmpty()) return;
         clipboard.clear();
+        clipboardTicks.clear();
         for (int idx : rows) {
-            if (idx >= 0 && idx < data.size()) clipboard.add(data.get(idx).copy());
+            if (idx >= 0 && idx < data.size()) {
+                clipboard.add(data.get(idx).copy());
+                clipboardTicks.add(angleSolver != null ? angleSolver.snapshotTick(idx) : null);
+            }
         }
     }
 
@@ -1293,6 +1299,11 @@ public final class InputOverlay {
             data.insertRow(insertAt + i, clipboard.get(i).copy());
         }
         solverRowsInserted(insertAt, clipboard.size());
+        if (angleSolver != null) {
+            for (int i = 0; i < clipboard.size() && i < clipboardTicks.size(); i++) {
+                angleSolver.applyTickSnapshot(insertAt + i, clipboardTicks.get(i));
+            }
+        }
         selection.selectRows(insertAt, clipboard.size());
         notifyChange(insertAt);
     }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/MainWindowOverlay.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/MainWindowOverlay.java
@@ -57,6 +57,8 @@ public final class MainWindowOverlay implements RenderInterface {
     private boolean saveChordWasDown;
     private boolean undoChordWasDown;
     private boolean redoChordWasDown;
+    private boolean copyChordWasDown;
+    private boolean pasteChordWasDown;
 
     private boolean openAboutRequested;
     private float lastHeaderHeight;
@@ -97,6 +99,7 @@ public final class MainWindowOverlay implements RenderInterface {
     public void render(ImGuiIO io) {
         handleQuickSaveChord();
         handleUndoRedoChords(io);
+        handleCopyPasteChords(io);
         fileMenu.tickAutoSave();
         renderMainWindow(io, true);
         if (settings.viewTickInfo) tickInfoPanel.render(io);
@@ -121,6 +124,19 @@ public final class MainWindowOverlay implements RenderInterface {
         }
         undoChordWasDown = undoDown;
         redoChordWasDown = redoDown;
+    }
+
+    private void handleCopyPasteChords(ImGuiIO io) {
+        boolean ready = mc != null && mc.isReady();
+        boolean copyDown = ready && mc.isCopyChordDown();
+        boolean pasteDown = ready && mc.isPasteChordDown();
+        boolean typing = io != null && io.getWantTextInput();
+        if (fileMenu.hasOpenTas() && !typing) {
+            if (copyDown && !copyChordWasDown) inputOverlay.copySelectedRows();
+            if (pasteDown && !pasteChordWasDown) inputOverlay.pasteRows();
+        }
+        copyChordWasDown = copyDown;
+        pasteChordWasDown = pasteDown;
     }
 
     /** Display-only panels kept visible while the main UI is closed. ImGui receives no input here, so they don't edit. */

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/SelectionManager.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/SelectionManager.java
@@ -110,6 +110,18 @@ public class SelectionManager {
         selectSingle(rowIndex);
     }
 
+    public void selectRows(int firstRow, int count) {
+        selectedRows.clear();
+        if (count <= 0 || firstRow < 0) {
+            lastClickedRow = -1;
+            return;
+        }
+        for (int i = 0; i < count; i++) {
+            selectedRows.add(firstRow + 1 + i);
+        }
+        lastClickedRow = firstRow + count;
+    }
+
     private void selectRange(int fromRow, int toRow, boolean addToExisting) {
         if (!addToExisting) {
             selectedRows.clear();

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/StartStateTable.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/StartStateTable.java
@@ -1,6 +1,7 @@
 package de.legoshi.parkourcalc.core.ui;
 
 import de.legoshi.parkourcalc.core.sim.SimulationRunner;
+import de.legoshi.parkourcalc.core.sim.StartResumeState;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.theme.Controls;
 import de.legoshi.parkourcalc.core.ui.theme.ThemeManager;
@@ -27,6 +28,7 @@ public final class StartStateTable {
 
     private boolean expanded;
     private float measuredContentH = -1f;
+    private StartResumeState shownResume;
 
     private final Map<String, ImString> fieldBufs = new HashMap<>();
     private String activeField;
@@ -64,6 +66,7 @@ public final class StartStateTable {
                 + sectionHead + 3f * inputRow
                 + sectionHead + 3f * inputRow
                 + sectionHead + 2f * inputRow
+                + sectionHead + 9f * inputRow
                 + fhs;
     }
 
@@ -98,6 +101,10 @@ public final class StartStateTable {
         ThemeManager.sectionSpacing();
         sectionHeader("Rotation");
         rotationEditor(runner.getStartYaw(), runner.getStartPitch());
+
+        ThemeManager.sectionSpacing();
+        sectionHeader("Resume state");
+        resumeEditor();
 
         float spacingY = ImGui.getStyle().getItemSpacing().y;
         float bodyH = ImGui.getCursorPosY() - spacingY;
@@ -148,6 +155,136 @@ public final class StartStateTable {
         });
         Controls.popInputFrameHeight();
         ThemeManager.endStandardFormTable();
+    }
+
+    private void resumeEditor() {
+        StartResumeState pinned = runner.getStartResumeState();
+        if (pinned != null) {
+            shownResume = pinned;
+        } else {
+            StartResumeState derived = runner.describeResumeAt(0);
+            shownResume = derived != null ? derived : new StartResumeState();
+        }
+        StartResumeState resume = shownResume;
+
+        if (!ThemeManager.beginStandardFormTable("##resume", 2)) return;
+        ImGui.tableSetupColumn("l", ImGuiTableColumnFlags.WidthFixed, resumeLabelWidth());
+        ImGui.tableSetupColumn("v", ImGuiTableColumnFlags.WidthStretch);
+        Controls.pushInputFrameHeight();
+        boolRow("On ground", "##res_ground", resume.onGround, v -> resume.onGround = v);
+        boolRow("Sprinting", "##res_sprinting", resume.sprinting, v -> resume.sprinting = v);
+        boolRow("Wall contact", "##res_wall", resume.wallContact, v -> resume.wallContact = v);
+        boolRow("Grazing contact", "##res_soft", resume.softWallContact, v -> resume.softWallContact = v);
+        boolRow("Cobweb slow", "##res_web", resume.stuckMultiplier != null,
+                v -> resume.stuckMultiplier = v ? new Vec3dCore(0.25, 0.05, 0.25) : null);
+        intRow("Jump cooldown", "##res_jumpcd", resume.jumpCooldown, v -> resume.jumpCooldown = clampInt(v, 0, 10));
+        intRow("Sprint window", "##res_window", resume.sprintWindow, v -> resume.sprintWindow = clampInt(v, 0, 7));
+        heldKeysRows(resume);
+        Controls.popInputFrameHeight();
+        ThemeManager.endStandardFormTable();
+    }
+
+    private void pinShownResume() {
+        if (runner.getStartResumeState() == null) {
+            runner.setStartResumeState(shownResume);
+        }
+        reSimulate.run();
+    }
+
+    private interface BoolApply {
+        void apply(boolean value);
+    }
+
+    private interface IntApply {
+        void apply(int value);
+    }
+
+    private void boolRow(String label, String id, boolean value, BoolApply apply) {
+        ImGui.tableNextRow();
+        ImGui.tableNextColumn();
+        Controls.labelCell(label);
+        ImGui.tableNextColumn();
+        if (ImGui.checkbox(id, value)) {
+            apply.apply(!value);
+            pinShownResume();
+        }
+    }
+
+    private void intRow(String label, String id, int value, IntApply apply) {
+        ImGui.tableNextRow();
+        ImGui.tableNextColumn();
+        Controls.labelCell(label);
+        ImGui.tableNextColumn();
+        ImGui.setNextItemWidth(ImGui.getContentRegionAvail().x);
+        ImString buf = fieldBufs.get(id);
+        if (buf == null) {
+            buf = new ImString(8);
+            fieldBufs.put(id, buf);
+        }
+        if (!id.equals(activeField)) {
+            buf.set(Integer.toString(value));
+        }
+        ImGui.inputText(id, buf, ImGuiInputTextFlags.CharsDecimal);
+        if (ImGui.isItemActivated()) {
+            activeField = id;
+        }
+        if (ImGui.isItemDeactivatedAfterEdit()) {
+            try {
+                apply.apply(Integer.parseInt(buf.get().trim()));
+                pinShownResume();
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        if (ImGui.isItemDeactivated() && id.equals(activeField)) {
+            activeField = null;
+        }
+    }
+
+    private void heldKeysRows(StartResumeState resume) {
+        ImGui.tableNextRow();
+        ImGui.tableNextColumn();
+        Controls.labelCell("Held last tick");
+        ImGui.tableNextColumn();
+        keyToggle(resume, InputRow.Key.W, "W");
+        ImGui.sameLine();
+        keyToggle(resume, InputRow.Key.A, "A");
+        ImGui.sameLine();
+        keyToggle(resume, InputRow.Key.S, "S");
+        ImGui.sameLine();
+        keyToggle(resume, InputRow.Key.D, "D");
+        ImGui.tableNextRow();
+        ImGui.tableNextColumn();
+        ImGui.tableNextColumn();
+        keyToggle(resume, InputRow.Key.JUMP, "Jump");
+        ImGui.sameLine();
+        keyToggle(resume, InputRow.Key.SNEAK, "Sneak");
+        ImGui.sameLine();
+        keyToggle(resume, InputRow.Key.SPRINT, "Sprint");
+    }
+
+    private void keyToggle(StartResumeState resume, InputRow.Key key, String label) {
+        boolean held = resume.heldLastTick.contains(key);
+        if (ImGui.checkbox(label + "##res_held_" + key.name(), held)) {
+            if (held) {
+                resume.heldLastTick.remove(key);
+            } else {
+                resume.heldLastTick.add(key);
+            }
+            pinShownResume();
+        }
+    }
+
+    private static int clampInt(int value, int lo, int hi) {
+        return Math.max(lo, Math.min(hi, value));
+    }
+
+    private float resumeLabelWidth() {
+        float max = 0f;
+        for (String l : new String[]{"On ground", "Sprinting", "Wall contact", "Grazing contact",
+                "Cobweb slow", "Jump cooldown", "Sprint window", "Held last tick"}) {
+            max = Math.max(max, ImGui.calcTextSize(l).x);
+        }
+        return max + ThemeManager.SM * ThemeManager.uiScale();
     }
 
     private void axisRow(String group, String label, double value, DoubleConsumer apply) {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverTable.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverTable.java
@@ -140,6 +140,20 @@ public final class AngleSolverTable {
         state.onRowsInserted(index, count);
     }
 
+    public TickConstraints snapshotTick(int row) {
+        TickConstraints tc = state.tickConstraintsOrNull(row);
+        return tc != null ? tc.copy() : null;
+    }
+
+    public void applyTickSnapshot(int row, TickConstraints snapshot) {
+        if (snapshot == null) return;
+        TickConstraints dst = state.tickConstraints(row);
+        for (Constraint c : snapshot.getConstraints()) {
+            dst.getConstraints().add(c.copy());
+        }
+        dst.getOverride().copyFrom(snapshot.getOverride());
+    }
+
     public void onRowsRemoved(java.util.List<Integer> descendingIndices) {
         state.onRowsRemoved(descendingIndices);
     }

--- a/core/src/test/java/de/legoshi/parkourcalc/core/MediumWorldFakeSimulator.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/MediumWorldFakeSimulator.java
@@ -1,0 +1,437 @@
+package de.legoshi.parkourcalc.core;
+
+import de.legoshi.parkourcalc.core.sim.Checkpoint;
+import de.legoshi.parkourcalc.core.sim.LazyEntitySimulator;
+import de.legoshi.parkourcalc.core.sim.StartResumeState;
+import de.legoshi.parkourcalc.core.sim.Vec3dCore;
+import de.legoshi.parkourcalc.core.ui.InputRow;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+public class MediumWorldFakeSimulator extends LazyEntitySimulator<MediumWorldFakeSimulator.FakeEntity> {
+
+    public enum Cell { SOLID, WATER, LAVA, WEB }
+
+    public static final class World {
+
+        private static final class Box {
+            final Cell cell;
+            final double x0, y0, z0, x1, y1, z1;
+
+            Box(Cell cell, double x0, double y0, double z0, double x1, double y1, double z1) {
+                this.cell = cell;
+                this.x0 = x0;
+                this.y0 = y0;
+                this.z0 = z0;
+                this.x1 = x1;
+                this.y1 = y1;
+                this.z1 = z1;
+            }
+
+            boolean column(double x, double z) {
+                return x >= x0 && x < x1 && z >= z0 && z < z1;
+            }
+
+            boolean containsFeet(double x, double y, double z) {
+                return column(x, z) && y >= y0 && y < y1;
+            }
+
+            boolean overlapsBody(double x, double y, double z) {
+                return column(x, z) && y < y1 && y + FakeEntity.HEIGHT > y0;
+            }
+        }
+
+        private final List<Box> boxes = new ArrayList<>();
+
+        public World add(Cell cell, double x0, double y0, double z0, double x1, double y1, double z1) {
+            boxes.add(new Box(cell, x0, y0, z0, x1, y1, z1));
+            return this;
+        }
+
+        public Set<Cell> statesAt(double x, double y, double z) {
+            Set<Cell> cells = EnumSet.noneOf(Cell.class);
+            for (Box b : boxes) {
+                if (b.cell == Cell.WEB && b.overlapsBody(x, y, z)) cells.add(Cell.WEB);
+                if ((b.cell == Cell.WATER || b.cell == Cell.LAVA) && b.containsFeet(x, y, z)) cells.add(b.cell);
+            }
+            return cells;
+        }
+
+        boolean webAt(double x, double y, double z) {
+            for (Box b : boxes) {
+                if (b.cell == Cell.WEB && b.overlapsBody(x, y, z)) return true;
+            }
+            return false;
+        }
+
+        double floorPlane(double x, double z, double yFrom, double yTo) {
+            double best = Double.NaN;
+            for (Box b : boxes) {
+                if (b.cell != Cell.SOLID || !b.column(x, z)) continue;
+                if (yFrom >= b.y1 && yTo < b.y1 && (Double.isNaN(best) || b.y1 > best)) best = b.y1;
+            }
+            return best;
+        }
+
+        double ceilingPlane(double x, double z, double headFrom, double headTo) {
+            double best = Double.NaN;
+            for (Box b : boxes) {
+                if (b.cell != Cell.SOLID || !b.column(x, z)) continue;
+                if (headFrom <= b.y0 && headTo > b.y0 && (Double.isNaN(best) || b.y0 < best)) best = b.y0;
+            }
+            return best;
+        }
+
+        double wallPlaneX(double xFrom, double xTo, double y, double z) {
+            double best = Double.NaN;
+            for (Box b : boxes) {
+                if (b.cell != Cell.SOLID) continue;
+                if (z < b.z0 || z >= b.z1 || y >= b.y1 || y + FakeEntity.HEIGHT <= b.y0) continue;
+                if (xTo > xFrom && xFrom <= b.x0 && xTo > b.x0 && (Double.isNaN(best) || b.x0 < best)) best = b.x0;
+                if (xTo < xFrom && xFrom >= b.x1 && xTo < b.x1 && (Double.isNaN(best) || b.x1 > best)) best = b.x1;
+            }
+            return best;
+        }
+
+        double wallPlaneZ(double zFrom, double zTo, double x, double y) {
+            double best = Double.NaN;
+            for (Box b : boxes) {
+                if (b.cell != Cell.SOLID) continue;
+                if (x < b.x0 || x >= b.x1 || y >= b.y1 || y + FakeEntity.HEIGHT <= b.y0) continue;
+                if (zTo > zFrom && zFrom <= b.z0 && zTo > b.z0 && (Double.isNaN(best) || b.z0 < best)) best = b.z0;
+                if (zTo < zFrom && zFrom >= b.z1 && zTo < b.z1 && (Double.isNaN(best) || b.z1 > best)) best = b.z1;
+            }
+            return best;
+        }
+    }
+
+    public static final class FakeEntity {
+
+        static final double HEIGHT = 1.8;
+
+        final World world;
+        Vec3dCore startPos;
+        Vec3dCore startVel;
+        float startYaw;
+
+        double x, y, z;
+        double vx, vy, vz;
+        float yaw;
+        boolean onGround;
+        boolean horizontalCollision;
+        boolean pendingStuck;
+        boolean sprinting;
+        int noJumpDelay;
+        InputRow row = new InputRow();
+
+        FakeEntity(World world, Vec3dCore startPos, Vec3dCore startVel, float startYaw) {
+            this.world = world;
+            this.startPos = startPos;
+            this.startVel = startVel;
+            this.startYaw = startYaw;
+            reset(null);
+        }
+
+        void reset(StartResumeState resume) {
+            x = startPos.x;
+            y = startPos.y;
+            z = startPos.z;
+            vx = 0;
+            vy = 0;
+            vz = 0;
+            yaw = startYaw;
+            onGround = false;
+            horizontalCollision = false;
+            pendingStuck = false;
+            sprinting = false;
+            noJumpDelay = 0;
+            row = new InputRow();
+            tick();
+            tick();
+            x = startPos.x;
+            y = startPos.y;
+            z = startPos.z;
+            vx = startVel.x;
+            vy = startVel.y;
+            vz = startVel.z;
+            if (resume != null) {
+                onGround = resume.onGround;
+                horizontalCollision = resume.wallContact;
+                sprinting = resume.sprinting;
+                noJumpDelay = resume.jumpCooldown;
+                pendingStuck = resume.stuckMultiplier != null;
+            }
+        }
+
+        void tick() {
+            if (noJumpDelay > 0) noJumpDelay--;
+            boolean w = row.isKeyActive(InputRow.Key.W);
+            boolean s = row.isKeyActive(InputRow.Key.S);
+            boolean a = row.isKeyActive(InputRow.Key.A);
+            boolean d = row.isKeyActive(InputRow.Key.D);
+            boolean jump = row.isKeyActive(InputRow.Key.JUMP);
+            boolean sneak = row.isKeyActive(InputRow.Key.SNEAK);
+            boolean sprintKey = row.isKeyActive(InputRow.Key.SPRINT);
+
+            Set<Cell> media = world.statesAt(x, y, z);
+            boolean inWater = media.contains(Cell.WATER);
+            boolean inLava = media.contains(Cell.LAVA);
+
+            if (!sprinting && w && sprintKey && !sneak) sprinting = true;
+            if (sprinting && (!w || sneak || horizontalCollision)) sprinting = false;
+
+            if (jump) {
+                if (inWater || inLava) {
+                    vy += 0.04;
+                } else if (onGround && noJumpDelay == 0) {
+                    vy = 0.42;
+                    noJumpDelay = 10;
+                }
+            } else {
+                noJumpDelay = 0;
+            }
+
+            double forward = (w ? 1.0 : 0.0) - (s ? 1.0 : 0.0);
+            double strafe = (a ? 1.0 : 0.0) - (d ? 1.0 : 0.0);
+            double len = Math.sqrt(forward * forward + strafe * strafe);
+            if (len > 1.0E-4) {
+                if (len > 1.0) {
+                    forward /= len;
+                    strafe /= len;
+                }
+                double speed;
+                if (inWater) {
+                    speed = 0.04;
+                } else if (inLava) {
+                    speed = 0.04;
+                } else if (onGround) {
+                    speed = sprinting ? 0.13 : 0.1;
+                } else {
+                    speed = sprinting ? 0.026 : 0.02;
+                }
+                if (sneak) speed *= 0.3;
+                double rad = Math.toRadians(yaw);
+                double sin = Math.sin(rad);
+                double cos = Math.cos(rad);
+                vx += speed * (strafe * cos - forward * sin);
+                vz += speed * (forward * cos + strafe * sin);
+            }
+
+            double mx = vx;
+            double my = vy;
+            double mz = vz;
+            if (pendingStuck) {
+                mx *= 0.25;
+                my *= 0.05;
+                mz *= 0.25;
+                vx = 0;
+                vy = 0;
+                vz = 0;
+                pendingStuck = false;
+            }
+
+            move(mx, my, mz);
+
+            if (world.webAt(x, y, z)) pendingStuck = true;
+
+            if (inWater) {
+                vx *= 0.8;
+                vz *= 0.8;
+                vy = vy * 0.8 - 0.02;
+            } else if (inLava) {
+                vx *= 0.5;
+                vz *= 0.5;
+                vy = vy * 0.5 - 0.02;
+            } else {
+                double f = onGround ? 0.546 : 0.91;
+                vx *= f;
+                vz *= f;
+                vy = (vy - 0.08) * 0.98;
+            }
+        }
+
+        private void move(double mx, double my, double mz) {
+            double ny = y + my;
+            boolean landed = false;
+            if (my < 0) {
+                double floor = world.floorPlane(x, z, y, ny);
+                if (!Double.isNaN(floor)) {
+                    ny = floor;
+                    landed = true;
+                    vy = 0;
+                }
+            } else if (my > 0) {
+                double ceiling = world.ceilingPlane(x, z, y + HEIGHT, ny + HEIGHT);
+                if (!Double.isNaN(ceiling)) {
+                    ny = ceiling - HEIGHT;
+                    vy = 0;
+                }
+            }
+            y = ny;
+            onGround = landed;
+
+            boolean hit = false;
+            if (mx != 0) {
+                double plane = world.wallPlaneX(x, x + mx, y, z);
+                if (!Double.isNaN(plane)) {
+                    x = plane;
+                    vx = 0;
+                    hit = true;
+                } else {
+                    x = x + mx;
+                }
+            }
+            if (mz != 0) {
+                double plane = world.wallPlaneZ(z, z + mz, x, y);
+                if (!Double.isNaN(plane)) {
+                    z = plane;
+                    vz = 0;
+                    hit = true;
+                } else {
+                    z = z + mz;
+                }
+            }
+            horizontalCollision = hit;
+        }
+    }
+
+    private static final class FakeCheckpoint implements Checkpoint {
+        final double x, y, z, vx, vy, vz;
+        final float yaw;
+        final boolean onGround, horizontalCollision, pendingStuck, sprinting;
+        final int noJumpDelay;
+        final InputRow row;
+
+        FakeCheckpoint(FakeEntity e) {
+            x = e.x;
+            y = e.y;
+            z = e.z;
+            vx = e.vx;
+            vy = e.vy;
+            vz = e.vz;
+            yaw = e.yaw;
+            onGround = e.onGround;
+            horizontalCollision = e.horizontalCollision;
+            pendingStuck = e.pendingStuck;
+            sprinting = e.sprinting;
+            noJumpDelay = e.noJumpDelay;
+            row = e.row;
+        }
+
+        void applyTo(FakeEntity e) {
+            e.x = x;
+            e.y = y;
+            e.z = z;
+            e.vx = vx;
+            e.vy = vy;
+            e.vz = vz;
+            e.yaw = yaw;
+            e.onGround = onGround;
+            e.horizontalCollision = horizontalCollision;
+            e.pendingStuck = pendingStuck;
+            e.sprinting = sprinting;
+            e.noJumpDelay = noJumpDelay;
+            e.row = row;
+        }
+    }
+
+    private final World world;
+
+    public MediumWorldFakeSimulator(World world) {
+        this.world = world;
+    }
+
+    public World getWorld() {
+        return world;
+    }
+
+    @Override
+    protected FakeEntity createEntity(Vec3dCore pendingStart, Vec3dCore pendingVelocity, Float pendingYaw) {
+        Vec3dCore start = pendingStart != null ? pendingStart : Vec3dCore.ZERO;
+        Vec3dCore vel = pendingVelocity != null ? pendingVelocity : Vec3dCore.GROUND_REST_VELOCITY;
+        float yaw = pendingYaw != null ? pendingYaw : 0.0F;
+        return new FakeEntity(world, start, vel, yaw);
+    }
+
+    @Override protected void resetEntity(FakeEntity e, StartResumeState resume) { e.reset(resume); }
+
+    @Override
+    protected StartResumeState describeResume(Checkpoint checkpoint) {
+        if (!(checkpoint instanceof FakeCheckpoint)) return null;
+        FakeCheckpoint c = (FakeCheckpoint) checkpoint;
+        StartResumeState r = new StartResumeState();
+        r.onGround = c.onGround;
+        r.wallContact = c.horizontalCollision;
+        r.sprinting = c.sprinting;
+        r.jumpCooldown = c.noJumpDelay;
+        if (c.pendingStuck) {
+            r.stuckMultiplier = new Vec3dCore(0.25, 0.05, 0.25);
+        }
+        if (c.row != null) {
+            for (InputRow.Key key : InputRow.Key.values()) {
+                if (c.row.isKeyActive(key)) r.heldLastTick.add(key);
+            }
+        }
+        return r;
+    }
+
+    @Override protected void setInput(FakeEntity e, InputRow row) { e.row = row; }
+
+    @Override protected void applyYaw(FakeEntity e, float yaw) { e.yaw = e.yaw + yaw; }
+
+    @Override protected void setYawAbsolute(FakeEntity e, float yaw) { e.yaw = yaw; }
+
+    @Override protected void applyTickEffects(FakeEntity e, int speedAmplifier, int jumpBoostAmplifier) { }
+
+    @Override protected void tickEntity(FakeEntity e) { e.tick(); }
+
+    @Override protected Vec3dCore getPos(FakeEntity e) { return new Vec3dCore(e.x, e.y, e.z); }
+
+    @Override protected boolean isOnGround(FakeEntity e) { return e.onGround; }
+
+    @Override protected boolean isSneaking(FakeEntity e) { return e.row.isKeyActive(InputRow.Key.SNEAK); }
+
+    @Override protected boolean isSprinting(FakeEntity e) { return e.sprinting; }
+
+    @Override protected float getMoveForward(FakeEntity e) { return Float.NaN; }
+
+    @Override protected float getMoveStrafe(FakeEntity e) { return Float.NaN; }
+
+    @Override protected boolean isWallCollision(FakeEntity e) { return e.horizontalCollision; }
+
+    @Override protected Vec3dCore getVelocity(FakeEntity e) { return new Vec3dCore(e.vx, e.vy, e.vz); }
+
+    @Override protected boolean isSoftCollision(FakeEntity e) { return false; }
+
+    @Override protected double getCollisionAngleDegrees(FakeEntity e) { return Double.NaN; }
+
+    @Override protected de.legoshi.parkourcalc.core.anglesolver.Medium getTickMedium(FakeEntity e) { return null; }
+
+    @Override protected double getTickGroundFriction(FakeEntity e) { return Double.NaN; }
+
+    @Override protected int getTickSoulsandCells(FakeEntity e) { return 0; }
+
+    @Override protected float getYaw(FakeEntity e) { return e.yaw; }
+
+    @Override protected List<Vec3dCore> getSubtickPath(FakeEntity e) { return Collections.emptyList(); }
+
+    @Override protected Vec3dCore getStart(FakeEntity e) { return e.startPos; }
+
+    @Override protected void setStart(FakeEntity e, Vec3dCore pos) { e.startPos = pos; }
+
+    @Override protected Vec3dCore getStartVel(FakeEntity e) { return e.startVel; }
+
+    @Override protected void setStartVel(FakeEntity e, Vec3dCore vel) { e.startVel = vel; }
+
+    @Override protected float getStartYawValue(FakeEntity e) { return e.startYaw; }
+
+    @Override protected void setStartYawValue(FakeEntity e, float yaw) { e.startYaw = yaw; }
+
+    @Override protected Checkpoint saveCheckpoint(FakeEntity e) { return new FakeCheckpoint(e); }
+
+    @Override protected void restoreCheckpoint(FakeEntity e, Checkpoint checkpoint) { ((FakeCheckpoint) checkpoint).applyTo(e); }
+}

--- a/core/src/test/java/de/legoshi/parkourcalc/core/SaveSelectionAsTasTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/SaveSelectionAsTasTest.java
@@ -1,5 +1,6 @@
 package de.legoshi.parkourcalc.core;
 
+import de.legoshi.parkourcalc.core.anglesolver.AngleSolverState;
 import de.legoshi.parkourcalc.core.ports.MinecraftAccess;
 import de.legoshi.parkourcalc.core.save.FileSystemSaveStore;
 import de.legoshi.parkourcalc.core.save.Result;
@@ -14,6 +15,7 @@ import org.junit.Test;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -54,7 +56,7 @@ public class SaveSelectionAsTasTest {
         Vec3dCore pos = new Vec3dCore(10.5, 64.0, -3.25);
         Vec3dCore vel = new Vec3dCore(0.12, -0.08, 0.34);
 
-        Result<String> saved = rig.controller.saveSelectionAsNewTas("slice1", rows, pos, vel, 45f, 10f);
+        Result<String> saved = rig.controller.saveSelectionAsNewTas("slice1", rows, Arrays.asList(0, 1), pos, vel, 45f, 10f, null);
         assertTrue(saved.ok);
 
         Result<SaveFile> loaded = SaveIO.load(rig.store, "slice1");
@@ -77,11 +79,45 @@ public class SaveSelectionAsTasTest {
     }
 
     @Test
+    public void sliceReanchorsSolverConstraintsAndWindow() throws Exception {
+        Path dir = Files.createTempDirectory("pkc-slice-solver");
+        Rig rig = new Rig(dir);
+        AngleSolverState solver = new AngleSolverState();
+        rig.controller.setAngleSolver(solver);
+        solver.addConstraint(5);
+        solver.addConstraint(7);
+        solver.addConstraint(2);
+        solver.setStartTick(5);
+        solver.setLandingTick(7);
+
+        List<InputRow> rows = new ArrayList<>();
+        rows.add(new InputRow());
+        rows.add(new InputRow());
+
+        Result<String> saved = rig.controller.saveSelectionAsNewTas("slice-solver", rows, Arrays.asList(5, 6),
+                new Vec3dCore(0, 64, 0), Vec3dCore.GROUND_REST_VELOCITY, 0f, 0f, null);
+        assertTrue(saved.ok);
+
+        Result<SaveFile> loaded = SaveIO.load(rig.store, "slice-solver");
+        assertTrue(loaded.ok);
+        SaveFile file = loaded.value;
+
+        assertEquals(2, file.angleSolver.ticks.size());
+        assertEquals(0, file.angleSolver.ticks.get(0).tick);
+        assertEquals(2, file.angleSolver.ticks.get(1).tick);
+        assertEquals(0, file.angleSolver.startTick);
+        assertEquals(2, file.angleSolver.landingTick);
+        assertEquals(3, solver.tickConstraintsOrNull(5).getConstraints().size()
+                + solver.tickConstraintsOrNull(7).getConstraints().size()
+                + solver.tickConstraintsOrNull(2).getConstraints().size());
+    }
+
+    @Test
     public void emptySelectionIsRejected() throws Exception {
         Path dir = Files.createTempDirectory("pkc-slice-empty");
         Rig rig = new Rig(dir);
-        Result<String> saved = rig.controller.saveSelectionAsNewTas("nope", new ArrayList<>(),
-                Vec3dCore.ZERO, Vec3dCore.ZERO, 0f, 0f);
+        Result<String> saved = rig.controller.saveSelectionAsNewTas("nope", new ArrayList<>(), new ArrayList<>(),
+                Vec3dCore.ZERO, Vec3dCore.ZERO, 0f, 0f, null);
         assertTrue(!saved.ok);
     }
 }

--- a/core/src/test/java/de/legoshi/parkourcalc/core/SaveSelectionAsTasTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/SaveSelectionAsTasTest.java
@@ -1,0 +1,87 @@
+package de.legoshi.parkourcalc.core;
+
+import de.legoshi.parkourcalc.core.ports.MinecraftAccess;
+import de.legoshi.parkourcalc.core.save.FileSystemSaveStore;
+import de.legoshi.parkourcalc.core.save.Result;
+import de.legoshi.parkourcalc.core.save.SaveFile;
+import de.legoshi.parkourcalc.core.save.SaveIO;
+import de.legoshi.parkourcalc.core.sim.SimulationRunner;
+import de.legoshi.parkourcalc.core.sim.Vec3dCore;
+import de.legoshi.parkourcalc.core.ui.InputData;
+import de.legoshi.parkourcalc.core.ui.InputRow;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class SaveSelectionAsTasTest {
+
+    private static final class Rig {
+        final InputData document = new InputData();
+        final SaveController controller;
+        final FileSystemSaveStore store;
+
+        Rig(Path dir) {
+            SimulationRunner runner = new SimulationRunner(new FakeSimulator());
+            controller = new SaveController(document, runner, (MinecraftAccess) null, () -> { });
+            store = new FileSystemSaveStore(dir, "test", "1.8.9", () -> null);
+            controller.setSaveStore(store);
+        }
+    }
+
+    @Test
+    public void slicePreservesStartStateAndRowsWithoutTouchingDocument() throws Exception {
+        Path dir = Files.createTempDirectory("pkc-slice");
+        Rig rig = new Rig(dir);
+
+        List<InputRow> rows = new ArrayList<>();
+        InputRow r0 = new InputRow();
+        r0.setKeyActive(InputRow.Key.W, true);
+        r0.setKeyActive(InputRow.Key.SPRINT, true);
+        r0.setYaw(12.5f);
+        rows.add(r0);
+        InputRow r1 = new InputRow();
+        r1.setKeyActive(InputRow.Key.JUMP, true);
+        rows.add(r1);
+
+        Vec3dCore pos = new Vec3dCore(10.5, 64.0, -3.25);
+        Vec3dCore vel = new Vec3dCore(0.12, -0.08, 0.34);
+
+        Result<String> saved = rig.controller.saveSelectionAsNewTas("slice1", rows, pos, vel, 45f, 10f);
+        assertTrue(saved.ok);
+
+        Result<SaveFile> loaded = SaveIO.load(rig.store, "slice1");
+        assertTrue(loaded.ok);
+        SaveFile file = loaded.value;
+
+        assertArrayEquals(new double[] { 10.5, 64.0, -3.25 }, file.start.pos, 0.0);
+        assertArrayEquals(new double[] { 0.12, -0.08, 0.34 }, file.start.vel, 0.0);
+        assertEquals(45f, file.start.yaw, 0f);
+        assertEquals(Float.valueOf(10f), file.start.pitch);
+
+        assertEquals(2, file.rows.size());
+        assertTrue(file.rows.get(0).keys.contains("W"));
+        assertTrue(file.rows.get(0).keys.contains("SPRINT"));
+        assertEquals(Float.valueOf(12.5f), file.rows.get(0).yaw);
+        assertTrue(file.rows.get(1).keys.contains("JUMP"));
+
+        assertEquals(0, rig.document.size());
+        assertNull(rig.controller.currentName());
+    }
+
+    @Test
+    public void emptySelectionIsRejected() throws Exception {
+        Path dir = Files.createTempDirectory("pkc-slice-empty");
+        Rig rig = new Rig(dir);
+        Result<String> saved = rig.controller.saveSelectionAsNewTas("nope", new ArrayList<>(),
+                Vec3dCore.ZERO, Vec3dCore.ZERO, 0f, 0f);
+        assertTrue(!saved.ok);
+    }
+}

--- a/core/src/test/java/de/legoshi/parkourcalc/core/SliceResimulationByteIdentityTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/SliceResimulationByteIdentityTest.java
@@ -1,0 +1,267 @@
+package de.legoshi.parkourcalc.core;
+
+import de.legoshi.parkourcalc.core.ports.MinecraftAccess;
+import de.legoshi.parkourcalc.core.save.FileSystemSaveStore;
+import de.legoshi.parkourcalc.core.save.Result;
+import de.legoshi.parkourcalc.core.save.SaveFile;
+import de.legoshi.parkourcalc.core.sim.SimulationRunner;
+import de.legoshi.parkourcalc.core.sim.TickState;
+import de.legoshi.parkourcalc.core.sim.Vec3dCore;
+import de.legoshi.parkourcalc.core.ui.InputData;
+import de.legoshi.parkourcalc.core.ui.InputRow;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import static de.legoshi.parkourcalc.core.MediumWorldFakeSimulator.Cell;
+import static de.legoshi.parkourcalc.core.MediumWorldFakeSimulator.World;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class SliceResimulationByteIdentityTest {
+
+    private static final class Rig {
+        final InputData doc;
+        final SimulationRunner runner;
+        final SaveController controller;
+
+        Rig(World world, FileSystemSaveStore store, InputData doc) {
+            this.doc = doc;
+            this.runner = new SimulationRunner(new MediumWorldFakeSimulator(world));
+            this.controller = new SaveController(doc, runner, (MinecraftAccess) null, () -> { });
+            this.controller.setSaveStore(store);
+        }
+    }
+
+    private static InputRow row(InputRow.Key... keys) {
+        InputRow r = new InputRow();
+        for (InputRow.Key k : keys) {
+            r.setKeyActive(k, true);
+        }
+        return r;
+    }
+
+    private static void addRows(InputData data, int count, InputRow.Key... keys) {
+        for (int i = 0; i < count; i++) {
+            data.getRows().add(row(keys));
+        }
+    }
+
+    private static FileSystemSaveStore store(String prefix) throws IOException {
+        Path dir = Files.createTempDirectory(prefix);
+        return new FileSystemSaveStore(dir, "test", "26.2", () -> null);
+    }
+
+    private static List<TickState> simulateOriginal(Rig rig, Vec3dCore startPos, Vec3dCore startVel, float startYaw) {
+        rig.runner.setStartPosition(startPos);
+        rig.runner.setStartVelocity(startVel);
+        rig.runner.setStartYaw(startYaw);
+        return new ArrayList<>(rig.runner.simulate(rig.doc));
+    }
+
+    private static String tag(World world, TickState pre) {
+        Set<Cell> cells = world.statesAt(pre.position.x, pre.position.y, pre.position.z);
+        StringBuilder sb = new StringBuilder(pre.onGround ? "ground" : "air");
+        if (pre.wallCollision) sb.append("+wall");
+        for (Cell c : cells) sb.append('+').append(c);
+        return sb.toString();
+    }
+
+    private static Set<String> coverage(World world, List<TickState> path) {
+        Set<String> tags = new LinkedHashSet<>();
+        for (TickState s : path) {
+            tags.add(tag(world, s));
+        }
+        return tags;
+    }
+
+    private static String dump(World world, List<TickState> path) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < path.size(); i++) {
+            TickState s = path.get(i);
+            sb.append(String.format(java.util.Locale.ROOT, "t%03d %-18s pos=%.4f,%.4f,%.4f vel=%.4f,%.4f,%.4f%n",
+                    i, tag(world, s), s.position.x, s.position.y, s.position.z, s.velocity.x, s.velocity.y, s.velocity.z));
+        }
+        return sb.toString();
+    }
+
+    private static void assertCoverage(World world, List<TickState> path, String... requiredTags) {
+        Set<String> seen = coverage(world, path);
+        List<String> missing = new ArrayList<>();
+        for (String t : requiredTags) {
+            if (!seen.contains(t)) missing.add(t);
+        }
+        assertTrue("scenario never reached " + missing + "; saw " + seen + "\n" + dump(world, path), missing.isEmpty());
+    }
+
+    private static boolean sameBits(Vec3dCore a, Vec3dCore b) {
+        return Double.doubleToLongBits(a.x) == Double.doubleToLongBits(b.x)
+                && Double.doubleToLongBits(a.y) == Double.doubleToLongBits(b.y)
+                && Double.doubleToLongBits(a.z) == Double.doubleToLongBits(b.z);
+    }
+
+    private static boolean sameState(TickState a, TickState b) {
+        return sameBits(a.position, b.position)
+                && sameBits(a.velocity, b.velocity)
+                && Float.floatToIntBits(a.yaw) == Float.floatToIntBits(b.yaw);
+    }
+
+    private static String describe(TickState s) {
+        return "pos=" + s.position.x + "," + s.position.y + "," + s.position.z
+                + " vel=" + s.velocity.x + "," + s.velocity.y + "," + s.velocity.z;
+    }
+
+    private static List<String> divergentCuts(World world, FileSystemSaveStore store, Rig source, List<TickState> path) {
+        List<String> failures = new ArrayList<>();
+        for (int cut = 0; cut < source.doc.size(); cut++) {
+            TickState pre = path.get(cut);
+            List<InputRow> copied = new ArrayList<>();
+            List<Integer> sourceRows = new ArrayList<>();
+            for (int i = cut; i < source.doc.size(); i++) {
+                copied.add(source.doc.get(i).copy());
+                sourceRows.add(i);
+            }
+            Result<String> saved = source.controller.saveSelectionAsNewTas("cut" + cut, copied, sourceRows,
+                    pre.position, pre.velocity, pre.yaw, 0f, source.runner.describeResumeAt(cut));
+            assertTrue(String.valueOf(saved.error), saved.ok);
+
+            Rig target = new Rig(world, store, new InputData());
+            Result<SaveFile> loaded = target.controller.load("cut" + cut);
+            assertTrue(String.valueOf(loaded.error), loaded.ok);
+            List<TickState> tail = target.runner.simulate(target.doc);
+
+            int expected = path.size() - cut;
+            String failure = null;
+            for (int i = 0; i < Math.min(expected, tail.size()); i++) {
+                TickState want = path.get(cut + i);
+                TickState got = tail.get(i);
+                if (!sameState(want, got)) {
+                    failure = "cut " + cut + " [" + tag(world, pre) + "] diverges at +" + i
+                            + " expected " + describe(want) + " got " + describe(got);
+                    break;
+                }
+            }
+            if (failure == null && expected != tail.size()) {
+                failure = "cut " + cut + " [" + tag(world, pre) + "] length " + tail.size() + " expected " + expected;
+            }
+            if (failure != null) {
+                failures.add(failure);
+            }
+        }
+        return failures;
+    }
+
+    private static void assertByteIdentical(World world, FileSystemSaveStore store, Rig source, List<TickState> path) {
+        List<String> failures = divergentCuts(world, store, source, path);
+        if (!failures.isEmpty()) {
+            StringBuilder sb = new StringBuilder();
+            sb.append(failures.size()).append(" of ").append(source.doc.size()).append(" cut positions diverge:\n");
+            for (String f : failures) {
+                sb.append("  ").append(f).append('\n');
+            }
+            assertTrue(sb.toString(), false);
+        }
+    }
+
+    @Test
+    public void groundRunWallJumpAndCeilingCutsAreByteIdentical() throws IOException {
+        World world = new World()
+                .add(Cell.SOLID, -3, 60, -3, 3, 64, 40)
+                .add(Cell.SOLID, -3, 64, 3.0, 3, 65, 3.4)
+                .add(Cell.SOLID, -3, 66.2, 5.2, 3, 67, 6.8);
+        InputData doc = new InputData();
+        addRows(doc, 14, InputRow.Key.W, InputRow.Key.SPRINT);
+        addRows(doc, 12, InputRow.Key.W, InputRow.Key.SPRINT, InputRow.Key.JUMP);
+        addRows(doc, 6, InputRow.Key.W);
+        addRows(doc, 14, InputRow.Key.W, InputRow.Key.SPRINT, InputRow.Key.JUMP);
+        addRows(doc, 6, InputRow.Key.W, InputRow.Key.SPRINT);
+
+        FileSystemSaveStore store = store("pkc-slice-ground");
+        Rig source = new Rig(world, store, doc);
+        List<TickState> path = simulateOriginal(source, new Vec3dCore(0, 64, 0), Vec3dCore.GROUND_REST_VELOCITY, 0f);
+
+        assertCoverage(world, path, "ground", "air", "ground+wall");
+        assertByteIdentical(world, store, source, path);
+    }
+
+    @Test
+    public void cliffWaterSubmergedWebLavaCutsAreByteIdentical() throws IOException {
+        World world = new World()
+                .add(Cell.SOLID, -3, 56, -3, 3, 64, 4)
+                .add(Cell.SOLID, -3, 52, 4, 3, 56, 60)
+                .add(Cell.WATER, -3, 56, 4, 3, 60, 14)
+                .add(Cell.WEB, -3, 56, 8, 3, 58.5, 8.5)
+                .add(Cell.LAVA, -3, 56, 16, 3, 58, 22);
+        InputData doc = new InputData();
+        addRows(doc, 15, InputRow.Key.W, InputRow.Key.SPRINT);
+        addRows(doc, 20, InputRow.Key.W, InputRow.Key.SPRINT);
+        addRows(doc, 6, InputRow.Key.W, InputRow.Key.SPRINT, InputRow.Key.JUMP);
+        addRows(doc, 65, InputRow.Key.W, InputRow.Key.SPRINT);
+        addRows(doc, 8, InputRow.Key.W, InputRow.Key.SPRINT, InputRow.Key.JUMP);
+        addRows(doc, 8, InputRow.Key.W, InputRow.Key.SPRINT);
+
+        FileSystemSaveStore store = store("pkc-slice-water");
+        Rig source = new Rig(world, store, doc);
+        List<TickState> path = simulateOriginal(source, new Vec3dCore(0, 64, 0), Vec3dCore.GROUND_REST_VELOCITY, 0f);
+
+        assertCoverage(world, path, "air", "air+WATER", "ground+WATER", "air+WATER+WEB", "ground+LAVA");
+        assertByteIdentical(world, store, source, path);
+    }
+
+    @Test
+    public void webOnGroundCutsAreByteIdentical() throws IOException {
+        World world = new World()
+                .add(Cell.SOLID, -3, 60, -3, 3, 64, 20)
+                .add(Cell.WEB, -3, 64, 2, 3, 67, 2.4);
+        InputData doc = new InputData();
+        addRows(doc, 40, InputRow.Key.W, InputRow.Key.SPRINT);
+
+        FileSystemSaveStore store = store("pkc-slice-web");
+        Rig source = new Rig(world, store, doc);
+        List<TickState> path = simulateOriginal(source, new Vec3dCore(0, 64, 0), Vec3dCore.GROUND_REST_VELOCITY, 0f);
+
+        assertCoverage(world, path, "ground", "ground+WEB");
+        assertByteIdentical(world, store, source, path);
+    }
+
+    @Test
+    public void exactZeroStartVelocitySurvivesSliceRoundTrip() throws IOException {
+        World world = new World()
+                .add(Cell.SOLID, -3, 60, -3, 3, 64, 20);
+        InputData doc = new InputData();
+        addRows(doc, 5, InputRow.Key.W);
+
+        FileSystemSaveStore store = store("pkc-slice-zerovel");
+        Rig source = new Rig(world, store, doc);
+        List<TickState> path = simulateOriginal(source, new Vec3dCore(0, 64, 0), Vec3dCore.ZERO, 0f);
+
+        TickState pre = path.get(0);
+        assertEquals(0L, Double.doubleToLongBits(pre.velocity.x));
+        assertEquals(0L, Double.doubleToLongBits(pre.velocity.y));
+        assertEquals(0L, Double.doubleToLongBits(pre.velocity.z));
+
+        List<InputRow> copied = new ArrayList<>();
+        List<Integer> sourceRows = new ArrayList<>();
+        for (int i = 0; i < doc.size(); i++) {
+            copied.add(doc.get(i).copy());
+            sourceRows.add(i);
+        }
+        Result<String> saved = source.controller.saveSelectionAsNewTas("zerovel", copied, sourceRows,
+                pre.position, pre.velocity, pre.yaw, 0f, source.runner.describeResumeAt(0));
+        assertTrue(String.valueOf(saved.error), saved.ok);
+
+        Rig target = new Rig(world, store, new InputData());
+        Result<SaveFile> loaded = target.controller.load("zerovel");
+        assertTrue(String.valueOf(loaded.error), loaded.ok);
+
+        Vec3dCore seeded = target.runner.getStartVelocity();
+        assertTrue("slice saved with exact-zero start velocity loads back as " + seeded.x + "," + seeded.y + "," + seeded.z,
+                sameBits(pre.velocity, seeded));
+    }
+}

--- a/core/src/test/java/de/legoshi/parkourcalc/core/UndoIntegrationTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/UndoIntegrationTest.java
@@ -46,9 +46,9 @@ public class UndoIntegrationTest {
             controller.setAngleSolver(solver);
             undo = new UndoController<>(
                     () -> SaveIO.undoSignature(data, runner.getStartPosition(), runner.getStartVelocity(),
-                            runner.getStartYaw(), runner.getStartPitch(), solver),
+                            runner.getStartYaw(), runner.getStartPitch(), runner.getStartResumeState(), solver),
                     () -> SaveIO.buildUndoSnapshot(data, runner.getStartPosition(), runner.getStartVelocity(),
-                            runner.getStartYaw(), runner.getStartPitch(), solver),
+                            runner.getStartYaw(), runner.getStartPitch(), runner.getStartResumeState(), solver),
                     SaveIO::undoJson,
                     controller::applySnapshotJson);
             controller.setUndoController(undo);
@@ -249,6 +249,6 @@ public class UndoIntegrationTest {
 
     private static String snapshot(Rig rig) {
         return SaveIO.undoSnapshotJson(rig.data, rig.runner.getStartPosition(), rig.runner.getStartVelocity(),
-                rig.runner.getStartYaw(), rig.runner.getStartPitch(), rig.solver);
+                rig.runner.getStartYaw(), rig.runner.getStartPitch(), rig.runner.getStartResumeState(), rig.solver);
     }
 }

--- a/core/src/test/java/de/legoshi/parkourcalc/core/ui/CopyPasteTicksTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/ui/CopyPasteTicksTest.java
@@ -1,0 +1,109 @@
+package de.legoshi.parkourcalc.core.ui;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.TreeSet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+
+public class CopyPasteTicksTest {
+
+    private static InputData dataWithYaws(float... yaws) {
+        InputData data = new InputData();
+        for (float y : yaws) {
+            InputRow row = new InputRow();
+            row.setYaw(y);
+            data.getRows().add(row);
+        }
+        return data;
+    }
+
+    private static InputOverlay overlay(InputData data, SelectionManager sel, int[] dirtySink) {
+        return new InputOverlay(data, new Settings(), sel, t -> dirtySink[0] = t, null, null, null, null);
+    }
+
+    @Test
+    public void pasteInsertsCopiesAfterSelectedRow() {
+        InputData data = dataWithYaws(0f, 1f, 2f, 3f, 4f);
+        SelectionManager sel = new SelectionManager(null);
+        int[] dirty = { -99 };
+        InputOverlay ov = overlay(data, sel, dirty);
+
+        sel.selectRows(1, 3);
+        ov.copySelectedRows();
+
+        sel.selectRows(0, 1);
+        ov.pasteRows();
+
+        assertEquals(8, data.size());
+        assertEquals(0f, data.get(0).getYaw(), 0f);
+        assertEquals(1f, data.get(1).getYaw(), 0f);
+        assertEquals(2f, data.get(2).getYaw(), 0f);
+        assertEquals(3f, data.get(3).getYaw(), 0f);
+        assertEquals(1f, data.get(4).getYaw(), 0f);
+        assertEquals(1, dirty[0]);
+        assertEquals(new TreeSet<>(Arrays.asList(1, 2, 3)), sel.getSelectedRows());
+    }
+
+    @Test
+    public void pasteWithoutSelectionAppendsAtEnd() {
+        InputData data = dataWithYaws(0f, 1f);
+        SelectionManager sel = new SelectionManager(null);
+        int[] dirty = { -99 };
+        InputOverlay ov = overlay(data, sel, dirty);
+
+        sel.selectRows(0, 2);
+        ov.copySelectedRows();
+
+        sel.clear();
+        ov.pasteRows();
+
+        assertEquals(4, data.size());
+        assertEquals(0f, data.get(2).getYaw(), 0f);
+        assertEquals(1f, data.get(3).getYaw(), 0f);
+        assertEquals(2, dirty[0]);
+    }
+
+    @Test
+    public void clipboardSurvivesDocumentSwap() {
+        InputData first = dataWithYaws(5f, 6f);
+        SelectionManager sel = new SelectionManager(null);
+        int[] dirty = { -99 };
+        InputOverlay ov = overlay(first, sel, dirty);
+
+        sel.selectRows(0, 2);
+        ov.copySelectedRows();
+
+        first.clear();
+        InputRow only = new InputRow();
+        only.setYaw(9f);
+        first.getRows().add(only);
+        sel.clear();
+
+        ov.pasteRows();
+
+        assertEquals(3, first.size());
+        assertEquals(9f, first.get(0).getYaw(), 0f);
+        assertEquals(5f, first.get(1).getYaw(), 0f);
+        assertEquals(6f, first.get(2).getYaw(), 0f);
+    }
+
+    @Test
+    public void pastedRowsAreIndependentCopies() {
+        InputData data = dataWithYaws(0f);
+        SelectionManager sel = new SelectionManager(null);
+        int[] dirty = { -99 };
+        InputOverlay ov = overlay(data, sel, dirty);
+
+        sel.selectRows(0, 1);
+        ov.copySelectedRows();
+        ov.pasteRows();
+
+        assertEquals(2, data.size());
+        assertNotSame(data.get(0), data.get(1));
+        data.get(1).setYaw(42f);
+        assertEquals(0f, data.get(0).getYaw(), 0f);
+    }
+}

--- a/core/src/test/java/de/legoshi/parkourcalc/core/ui/CopyPasteTicksTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/ui/CopyPasteTicksTest.java
@@ -1,12 +1,16 @@
 package de.legoshi.parkourcalc.core.ui;
 
+import de.legoshi.parkourcalc.core.anglesolver.AngleSolverState;
+import de.legoshi.parkourcalc.core.ui.anglesolver.AngleSolverTable;
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.TreeSet;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
 
 public class CopyPasteTicksTest {
 
@@ -88,6 +92,56 @@ public class CopyPasteTicksTest {
         assertEquals(9f, first.get(0).getYaw(), 0f);
         assertEquals(5f, first.get(1).getYaw(), 0f);
         assertEquals(6f, first.get(2).getYaw(), 0f);
+    }
+
+    @Test
+    public void pasteCarriesTickConstraintsAndShiftsExisting() {
+        InputData data = dataWithYaws(0f, 1f, 2f, 3f, 4f);
+        SelectionManager sel = new SelectionManager(null);
+        int[] dirty = { -99 };
+        InputOverlay ov = overlay(data, sel, dirty);
+        AngleSolverState solver = new AngleSolverState();
+        ov.setAngleSolver(new AngleSolverTable(solver, new Settings(), sel, new ConstraintSelection(), data::size));
+
+        solver.addConstraint(1);
+        solver.addConstraint(4);
+
+        sel.selectRows(1, 1);
+        ov.copySelectedRows();
+        sel.selectRows(2, 1);
+        ov.pasteRows();
+
+        assertEquals(6, data.size());
+        assertEquals(1, solver.tickConstraintsOrNull(1).getConstraints().size());
+        assertNotNull(solver.tickConstraintsOrNull(3));
+        assertEquals(1, solver.tickConstraintsOrNull(3).getConstraints().size());
+        assertNull(solver.tickConstraintsOrNull(4));
+        assertEquals(1, solver.tickConstraintsOrNull(5).getConstraints().size());
+        assertNotSame(solver.tickConstraintsOrNull(1).getConstraints().get(0),
+                solver.tickConstraintsOrNull(3).getConstraints().get(0));
+    }
+
+    @Test
+    public void pasteCarriesConstraintsAcrossDocumentSwap() {
+        InputData data = dataWithYaws(0f, 1f);
+        SelectionManager sel = new SelectionManager(null);
+        int[] dirty = { -99 };
+        InputOverlay ov = overlay(data, sel, dirty);
+        AngleSolverState solver = new AngleSolverState();
+        ov.setAngleSolver(new AngleSolverTable(solver, new Settings(), sel, new ConstraintSelection(), data::size));
+
+        solver.addConstraint(0);
+        sel.selectRows(0, 1);
+        ov.copySelectedRows();
+
+        data.clear();
+        solver.reset();
+        sel.clear();
+        ov.pasteRows();
+
+        assertEquals(1, data.size());
+        assertNotNull(solver.tickConstraintsOrNull(0));
+        assertEquals(1, solver.tickConstraintsOrNull(0).getConstraints().size());
     }
 
     @Test

--- a/forge-core/src/main/java/de/legoshi/parkourcalc/forge/core/lwjgl2/Lwjgl2InputState.java
+++ b/forge-core/src/main/java/de/legoshi/parkourcalc/forge/core/lwjgl2/Lwjgl2InputState.java
@@ -38,6 +38,14 @@ public final class Lwjgl2InputState {
         return isShiftDown() && Keyboard.isKeyDown(Keyboard.KEY_Z);
     }
 
+    public static boolean isCopyChordDown() {
+        return isCtrlDown() && Keyboard.isKeyDown(Keyboard.KEY_C);
+    }
+
+    public static boolean isPasteChordDown() {
+        return isCtrlDown() && Keyboard.isKeyDown(Keyboard.KEY_V);
+    }
+
     public static boolean isCtrlDown() {
         return Keyboard.isKeyDown(Keyboard.KEY_LCONTROL) || Keyboard.isKeyDown(Keyboard.KEY_RCONTROL);
     }

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricMinecraftAccess.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricMinecraftAccess.java
@@ -258,6 +258,18 @@ public final class FabricMinecraftAccess implements MinecraftAccess {
     }
 
     @Override
+    public boolean isCopyChordDown() {
+        long window = Minecraft.getInstance().getWindow().handle();
+        return isCtrlDown() && GLFW.glfwGetKey(window, GLFW.GLFW_KEY_C) == GLFW.GLFW_PRESS;
+    }
+
+    @Override
+    public boolean isPasteChordDown() {
+        long window = Minecraft.getInstance().getWindow().handle();
+        return isCtrlDown() && GLFW.glfwGetKey(window, GLFW.GLFW_KEY_V) == GLFW.GLFW_PRESS;
+    }
+
+    @Override
     public boolean isShiftDown() {
         long window = Minecraft.getInstance().getWindow().handle();
         return GLFW.glfwGetKey(window, GLFW.GLFW_KEY_LEFT_SHIFT) == GLFW.GLFW_PRESS

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricParkourCalculator.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricParkourCalculator.java
@@ -285,14 +285,15 @@ public class FabricParkourCalculator implements ClientModInitializer {
 
         boolean imguiWantsKeys = application.isControlPanelOpen() && ImGui.getIO().getWantTextInput();
         boolean canDispatch = client.gui.screen() == null && !imguiWantsKeys;
+        boolean chordFree = canDispatch && !isCtrlHeld(client);
 
-        if (toggled && canDispatch) {
+        if (toggled && chordFree) {
             setOverlayOpen(!application.isControlPanelOpen());
         }
-        if (deselectPressed && canDispatch) {
+        if (deselectPressed && chordFree) {
             application.getSelection().clear();
         }
-        if (playbackPressed && canDispatch) {
+        if (playbackPressed && chordFree) {
             togglePlayback();
         }
         if (landingConstraintsPressed && canDispatch) {
@@ -303,31 +304,31 @@ public class FabricParkourCalculator implements ClientModInitializer {
                     || GLFW.glfwGetKey(window, GLFW.GLFW_KEY_RIGHT_CONTROL) == GLFW.GLFW_PRESS;
             application.onConstraintKey(enter, remove);
         }
-        if (removeConstraintsPressed && canDispatch) {
+        if (removeConstraintsPressed && chordFree) {
             application.removeSelectedConstraints();
         }
-        if (applySurfaceStatePressed && canDispatch) {
+        if (applySurfaceStatePressed && chordFree) {
             application.applyPathSurfaceState();
         }
-        if (solvePressed && canDispatch) {
+        if (solvePressed && chordFree) {
             application.solveAngleSolver();
         }
-        if (solverStartPressed && canDispatch) {
+        if (solverStartPressed && chordFree) {
             application.setSolverStartTickFromSelection();
         }
-        if (solverEndPressed && canDispatch) {
+        if (solverEndPressed && chordFree) {
             application.setSolverLandingTickFromSelection();
         }
-        if (captureMomentum && canDispatch) {
+        if (captureMomentum && chordFree) {
             application.captureAngleSolverBlock(BlockSelection.Kind.MOMENTUM);
         }
-        if (captureCollision && canDispatch) {
+        if (captureCollision && chordFree) {
             application.captureAngleSolverBlock(BlockSelection.Kind.COLLISION);
         }
-        if (captureLand && canDispatch) {
+        if (captureLand && chordFree) {
             application.captureAngleSolverBlock(BlockSelection.Kind.LAND);
         }
-        if (clearBlocks && canDispatch) {
+        if (clearBlocks && chordFree) {
             application.clearAngleSolverBlocks();
         }
     }
@@ -344,6 +345,7 @@ public class FabricParkourCalculator implements ClientModInitializer {
     public static boolean dispatchOverlayHotkey(int glfwKey) {
         Minecraft client = Minecraft.getInstance();
         if (client.getWindow() == null) return false;
+        if (isCtrlHeld(client) && glfwKey != boundKey(landingConstraintsKeyBinding)) return false;
         if (glfwKey == boundKey(deselectKeyBinding)) {
             application.getSelection().clear();
             return true;
@@ -386,6 +388,12 @@ public class FabricParkourCalculator implements ClientModInitializer {
 
     private static int boundKey(KeyMapping mapping) {
         return KeyMappingHelper.getBoundKeyOf(mapping).getValue();
+    }
+
+    private static boolean isCtrlHeld(Minecraft client) {
+        long window = client.getWindow().handle();
+        return GLFW.glfwGetKey(window, GLFW.GLFW_KEY_LEFT_CONTROL) == GLFW.GLFW_PRESS
+                || GLFW.glfwGetKey(window, GLFW.GLFW_KEY_RIGHT_CONTROL) == GLFW.GLFW_PRESS;
     }
 
     public static void closeOverlay() {

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/sim/FabricSimulator.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/sim/FabricSimulator.java
@@ -4,8 +4,10 @@ import de.legoshi.parkourcalc.core.anglesolver.Medium;
 import de.legoshi.parkourcalc.core.sim.ChunkRange;
 import de.legoshi.parkourcalc.core.sim.Checkpoint;
 import de.legoshi.parkourcalc.core.sim.LazyEntitySimulator;
+import de.legoshi.parkourcalc.core.sim.StartResumeState;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.InputRow;
+import net.minecraft.world.entity.player.Input;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.world.entity.ai.attributes.Attributes;
@@ -47,8 +49,34 @@ public final class FabricSimulator extends LazyEntitySimulator<SimulatorEntity> 
         return new SimulatorEntity(simWorld, player.getGameProfile(), start, vel, yaw);
     }
 
-    @Override protected void resetEntity(SimulatorEntity e) {
-        e.resetPlayer();
+    @Override protected void resetEntity(SimulatorEntity e, StartResumeState resume) {
+        e.resetPlayer(resume);
+    }
+
+    @Override
+    protected StartResumeState describeResume(Checkpoint checkpoint) {
+        if (!(checkpoint instanceof SimulatorEntity.Checkpoint c)) return null;
+        StartResumeState r = new StartResumeState();
+        r.onGround = c.onGround;
+        r.wallContact = c.horizontalCollision;
+        r.softWallContact = c.collidedSoftly;
+        r.sprinting = c.sprinting;
+        r.sprintWindow = c.ticksLeftToDoubleTapSprint;
+        r.jumpCooldown = c.jumpingCooldown;
+        if (c.movementMultiplier != null && c.movementMultiplier.lengthSqr() > 1.0E-7) {
+            r.stuckMultiplier = new Vec3dCore(c.movementMultiplier.x, c.movementMultiplier.y, c.movementMultiplier.z);
+        }
+        Input held = c.playerInput;
+        if (held != null) {
+            if (held.forward()) r.heldLastTick.add(InputRow.Key.W);
+            if (held.backward()) r.heldLastTick.add(InputRow.Key.S);
+            if (held.left()) r.heldLastTick.add(InputRow.Key.A);
+            if (held.right()) r.heldLastTick.add(InputRow.Key.D);
+            if (held.jump()) r.heldLastTick.add(InputRow.Key.JUMP);
+            if (held.shift()) r.heldLastTick.add(InputRow.Key.SNEAK);
+            if (held.sprint()) r.heldLastTick.add(InputRow.Key.SPRINT);
+        }
+        return r;
     }
 
     @Override protected void setInput(SimulatorEntity e, InputRow row) {

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/sim/SimulatorEntity.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/sim/SimulatorEntity.java
@@ -2,6 +2,7 @@ package de.legoshi.parkourcalc.fabric.sim;
 
 import com.mojang.authlib.GameProfile;
 import de.legoshi.parkourcalc.core.anglesolver.Medium;
+import de.legoshi.parkourcalc.core.sim.StartResumeState;
 import de.legoshi.parkourcalc.core.sim.SubtickPath;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.InputRow;
@@ -93,6 +94,10 @@ public class SimulatorEntity extends Player {
     }
 
     public void resetPlayer() {
+        resetPlayer(null);
+    }
+
+    public void resetPlayer(StartResumeState resume) {
         this.noPhysics = true;
         this.removeAllEffects();
         this.setHealth(this.getMaxHealth());
@@ -110,6 +115,29 @@ public class SimulatorEntity extends Player {
         this.tickMedium = null;
         this.tickGroundFriction = Double.NaN;
         this.tickSoulsandCells = 0;
+        if (resume != null) {
+            applyResume(resume);
+        }
+    }
+
+    private void applyResume(StartResumeState resume) {
+        this.setOnGround(resume.onGround);
+        this.horizontalCollision = resume.wallContact;
+        this.minorHorizontalCollision = resume.softWallContact;
+        this.setSprinting(resume.sprinting);
+        this.sprintTriggerTime = resume.sprintWindow;
+        this.noJumpDelay = resume.jumpCooldown;
+        this.stuckSpeedMultiplier = resume.stuckMultiplier != null
+                ? new Vec3(resume.stuckMultiplier.x, resume.stuckMultiplier.y, resume.stuckMultiplier.z)
+                : Vec3.ZERO;
+        this.input.seedKeyPresses(new Input(
+                resume.heldLastTick.contains(InputRow.Key.W),
+                resume.heldLastTick.contains(InputRow.Key.S),
+                resume.heldLastTick.contains(InputRow.Key.A),
+                resume.heldLastTick.contains(InputRow.Key.D),
+                resume.heldLastTick.contains(InputRow.Key.JUMP),
+                resume.heldLastTick.contains(InputRow.Key.SNEAK),
+                resume.heldLastTick.contains(InputRow.Key.SPRINT)));
     }
 
     @Override
@@ -448,7 +476,7 @@ public class SimulatorEntity extends Player {
         this.minorHorizontalCollision = c.collidedSoftly;
         this.setSprinting(c.sprinting);
         this.sprintTriggerTime = c.ticksLeftToDoubleTapSprint;
-        this.input.keyPresses = c.playerInput;
+        this.input.seedKeyPresses(c.playerInput);
         this.noJumpDelay = c.jumpingCooldown;
         this.stuckSpeedMultiplier = c.movementMultiplier;
     }

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/sim/SimulatorInput.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/sim/SimulatorInput.java
@@ -19,7 +19,7 @@ public class SimulatorInput extends ClientInput {
 
     @Override
     public void tick() {
-        this.keyPresses = new Input(
+        seedKeyPresses(new Input(
                 data.isKeyActive(InputRow.Key.W),
                 data.isKeyActive(InputRow.Key.S),
                 data.isKeyActive(InputRow.Key.A),
@@ -27,10 +27,13 @@ public class SimulatorInput extends ClientInput {
                 data.isKeyActive(InputRow.Key.JUMP),
                 data.isKeyActive(InputRow.Key.SNEAK),
                 data.isKeyActive(InputRow.Key.SPRINT)
-        );
+        ));
+    }
 
-        float forward = axisValue(keyPresses.forward(), keyPresses.backward());
-        float strafe = axisValue(keyPresses.left(), keyPresses.right());
+    public void seedKeyPresses(Input presses) {
+        this.keyPresses = presses != null ? presses : Input.EMPTY;
+        float forward = axisValue(this.keyPresses.forward(), this.keyPresses.backward());
+        float strafe = axisValue(this.keyPresses.left(), this.keyPresses.right());
         this.moveVector = new Vec2(strafe, forward).normalized();
     }
 

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12MinecraftAccess.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12MinecraftAccess.java
@@ -208,6 +208,16 @@ public final class Forge12MinecraftAccess implements MinecraftAccess {
     }
 
     @Override
+    public boolean isCopyChordDown() {
+        return Lwjgl2InputState.isCopyChordDown();
+    }
+
+    @Override
+    public boolean isPasteChordDown() {
+        return Lwjgl2InputState.isPasteChordDown();
+    }
+
+    @Override
     public boolean isShiftDown() {
         return Lwjgl2InputState.isShiftDown();
     }

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12ParkourCalculator.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12ParkourCalculator.java
@@ -285,13 +285,14 @@ public class Forge12ParkourCalculator {
             }
         }
         if (mc.currentScreen == null) {
-            if (toggled) {
+            boolean chordFree = !isCtrlHeld();
+            if (toggled && chordFree) {
                 openOverlay(mc);
             }
-            if (deselectPressed) {
+            if (deselectPressed && chordFree) {
                 application.getSelection().clear();
             }
-            if (playbackPressed) {
+            if (playbackPressed && chordFree) {
                 togglePlayback();
             }
             if (landingConstraintsPressed) {
@@ -299,31 +300,31 @@ public class Forge12ParkourCalculator {
                 boolean remove = Keyboard.isKeyDown(Keyboard.KEY_LCONTROL) || Keyboard.isKeyDown(Keyboard.KEY_RCONTROL);
                 application.onConstraintKey(enter, remove);
             }
-            if (removeConstraintsPressed) {
+            if (removeConstraintsPressed && chordFree) {
                 application.removeSelectedConstraints();
             }
-            if (applySurfaceStatePressed) {
+            if (applySurfaceStatePressed && chordFree) {
                 application.applyPathSurfaceState();
             }
-            if (solvePressed) {
+            if (solvePressed && chordFree) {
                 application.solveAngleSolver();
             }
-            if (solverStartPressed) {
+            if (solverStartPressed && chordFree) {
                 application.setSolverStartTickFromSelection();
             }
-            if (solverEndPressed) {
+            if (solverEndPressed && chordFree) {
                 application.setSolverLandingTickFromSelection();
             }
-            if (captureMomentum) {
+            if (captureMomentum && chordFree) {
                 application.captureAngleSolverBlock(BlockSelection.Kind.MOMENTUM);
             }
-            if (captureCollision) {
+            if (captureCollision && chordFree) {
                 application.captureAngleSolverBlock(BlockSelection.Kind.COLLISION);
             }
-            if (captureLand) {
+            if (captureLand && chordFree) {
                 application.captureAngleSolverBlock(BlockSelection.Kind.LAND);
             }
-            if (clearBlocks) {
+            if (clearBlocks && chordFree) {
                 application.clearAngleSolverBlocks();
             }
         }
@@ -347,7 +348,12 @@ public class Forge12ParkourCalculator {
         ));
     }
 
+    private static boolean isCtrlHeld() {
+        return Keyboard.isKeyDown(Keyboard.KEY_LCONTROL) || Keyboard.isKeyDown(Keyboard.KEY_RCONTROL);
+    }
+
     private boolean dispatchHotkey(int keyCode) {
+        if (isCtrlHeld() && keyCode != landingConstraintsKeyBinding.getKeyCode()) return false;
         if (keyCode == landingConstraintsKeyBinding.getKeyCode()) {
             boolean enter = Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT);
             boolean remove = Keyboard.isKeyDown(Keyboard.KEY_LCONTROL) || Keyboard.isKeyDown(Keyboard.KEY_RCONTROL);

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/ParkourCalcGuiScreen.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/ParkourCalcGuiScreen.java
@@ -75,15 +75,16 @@ public final class ParkourCalcGuiScreen extends GuiScreen {
         }
 
         if (!wantsText) {
-            if (keyCode == toggleKeyCode) {
+            boolean ctrlHeld = Keyboard.isKeyDown(Keyboard.KEY_LCONTROL) || Keyboard.isKeyDown(Keyboard.KEY_RCONTROL);
+            if (keyCode == toggleKeyCode && !ctrlHeld) {
                 closeOverlay();
                 return;
             }
-            if (keyCode == deselectKeyCode) {
+            if (keyCode == deselectKeyCode && !ctrlHeld) {
                 selection.clear();
                 return;
             }
-            if (keyCode == playbackKeyCode) {
+            if (keyCode == playbackKeyCode && !ctrlHeld) {
                 togglePlayback.run();
                 return;
             }

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/sim/Forge12Simulator.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/sim/Forge12Simulator.java
@@ -4,6 +4,7 @@ import de.legoshi.parkourcalc.core.anglesolver.Medium;
 import de.legoshi.parkourcalc.core.sim.ChunkRange;
 import de.legoshi.parkourcalc.core.sim.Checkpoint;
 import de.legoshi.parkourcalc.core.sim.LazyEntitySimulator;
+import de.legoshi.parkourcalc.core.sim.StartResumeState;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.InputRow;
 import net.minecraft.client.Minecraft;
@@ -51,7 +52,30 @@ public final class Forge12Simulator extends LazyEntitySimulator<SimulatorEntity>
         return new SimulatorEntity(simWorld, player.getGameProfile(), start, vel, yaw);
     }
 
-    @Override protected void resetEntity(SimulatorEntity e) { e.resetPlayer(); }
+    @Override protected void resetEntity(SimulatorEntity e, StartResumeState resume) { e.resetPlayer(resume); }
+
+    @Override
+    protected StartResumeState describeResume(Checkpoint checkpoint) {
+        if (!(checkpoint instanceof SimulatorEntity.Checkpoint)) return null;
+        SimulatorEntity.Checkpoint c = (SimulatorEntity.Checkpoint) checkpoint;
+        StartResumeState r = new StartResumeState();
+        r.onGround = c.onGround;
+        r.wallContact = c.collidedHorizontally;
+        r.sprinting = c.sprinting;
+        r.jumpCooldown = c.jumpTicks;
+        r.airSprintFactor = c.jumpMovementFactor;
+        if (c.isInWeb) {
+            r.stuckMultiplier = new Vec3dCore(0.25, 0.05, 0.25);
+        }
+        if (c.sprintState != null) {
+            r.sprintWindow = c.sprintState.sprintToggleTimer;
+            r.sprintTicksLeft = c.sprintState.sprintingTicksLeft;
+            if (c.sprintState.prevSneak) r.heldLastTick.add(InputRow.Key.SNEAK);
+            if (c.sprintState.prevMoveForward > 0.0F) r.heldLastTick.add(InputRow.Key.W);
+            if (c.sprintState.prevMoveForward < 0.0F) r.heldLastTick.add(InputRow.Key.S);
+        }
+        return r;
+    }
     @Override protected void setInput(SimulatorEntity e, InputRow row) { e.setInput(row); }
     @Override protected void applyYaw(SimulatorEntity e, float yaw) { e.rotationYaw += yaw; }
     @Override protected void setYawAbsolute(SimulatorEntity e, float yaw) { e.rotationYaw = yaw; }

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/sim/SimulatorEntity.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/sim/SimulatorEntity.java
@@ -3,6 +3,7 @@ package de.legoshi.parkourcalc.forge12.sim;
 import com.mojang.authlib.GameProfile;
 import de.legoshi.parkourcalc.core.anglesolver.Medium;
 import de.legoshi.parkourcalc.forge.core.sim.PlayerSprintMachine;
+import de.legoshi.parkourcalc.core.sim.StartResumeState;
 import de.legoshi.parkourcalc.core.sim.SubtickPath;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.InputRow;
@@ -81,6 +82,10 @@ public class SimulatorEntity extends EntityPlayer {
     }
 
     public void resetPlayer() {
+        resetPlayer(null);
+    }
+
+    public void resetPlayer(StartResumeState resume) {
         this.noClip = true;
         this.setHealth(this.getMaxHealth());
         this.motionX = 0.0;
@@ -102,6 +107,28 @@ public class SimulatorEntity extends EntityPlayer {
         this.tickMedium = null;
         this.tickGroundFriction = Double.NaN;
         this.tickSoulsandCells = 0;
+        if (resume != null) {
+            applyResume(resume);
+        }
+    }
+
+    private void applyResume(StartResumeState resume) {
+        this.onGround = resume.onGround;
+        this.collidedHorizontally = resume.wallContact;
+        this.setSprinting(resume.sprinting);
+        this.jumpTicks = resume.jumpCooldown;
+        this.isInWeb = resume.stuckMultiplier != null;
+        this.jumpMovementFactor = !Float.isNaN(resume.airSprintFactor)
+                ? resume.airSprintFactor
+                : (resume.sprinting ? 0.026F : 0.02F);
+        boolean prevSneak = resume.heldLastTick.contains(InputRow.Key.SNEAK);
+        float prevForward = (resume.heldLastTick.contains(InputRow.Key.W) ? 1.0F : 0.0F)
+                - (resume.heldLastTick.contains(InputRow.Key.S) ? 1.0F : 0.0F);
+        if (prevSneak) {
+            prevForward *= 0.3F;
+        }
+        this.sprintState = new PlayerSprintMachine.State(prevSneak, prevForward,
+                resume.sprintWindow, resume.sprintTicksLeft, resume.sprinting);
     }
 
     @Override

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8MinecraftAccess.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8MinecraftAccess.java
@@ -220,6 +220,16 @@ public final class Forge8MinecraftAccess implements MinecraftAccess {
     }
 
     @Override
+    public boolean isCopyChordDown() {
+        return Lwjgl2InputState.isCopyChordDown();
+    }
+
+    @Override
+    public boolean isPasteChordDown() {
+        return Lwjgl2InputState.isPasteChordDown();
+    }
+
+    @Override
     public boolean isShiftDown() {
         return Lwjgl2InputState.isShiftDown();
     }

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8ParkourCalculator.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8ParkourCalculator.java
@@ -287,13 +287,14 @@ public class Forge8ParkourCalculator {
             }
         }
         if (mc.currentScreen == null) {
-            if (toggled) {
+            boolean chordFree = !isCtrlHeld();
+            if (toggled && chordFree) {
                 openOverlay(mc);
             }
-            if (deselectPressed) {
+            if (deselectPressed && chordFree) {
                 application.getSelection().clear();
             }
-            if (playbackPressed) {
+            if (playbackPressed && chordFree) {
                 togglePlayback();
             }
             if (landingConstraintsPressed) {
@@ -301,31 +302,31 @@ public class Forge8ParkourCalculator {
                 boolean remove = Keyboard.isKeyDown(Keyboard.KEY_LCONTROL) || Keyboard.isKeyDown(Keyboard.KEY_RCONTROL);
                 application.onConstraintKey(enter, remove);
             }
-            if (removeConstraintsPressed) {
+            if (removeConstraintsPressed && chordFree) {
                 application.removeSelectedConstraints();
             }
-            if (applySurfaceStatePressed) {
+            if (applySurfaceStatePressed && chordFree) {
                 application.applyPathSurfaceState();
             }
-            if (solvePressed) {
+            if (solvePressed && chordFree) {
                 application.solveAngleSolver();
             }
-            if (solverStartPressed) {
+            if (solverStartPressed && chordFree) {
                 application.setSolverStartTickFromSelection();
             }
-            if (solverEndPressed) {
+            if (solverEndPressed && chordFree) {
                 application.setSolverLandingTickFromSelection();
             }
-            if (captureMomentum) {
+            if (captureMomentum && chordFree) {
                 application.captureAngleSolverBlock(BlockSelection.Kind.MOMENTUM);
             }
-            if (captureCollision) {
+            if (captureCollision && chordFree) {
                 application.captureAngleSolverBlock(BlockSelection.Kind.COLLISION);
             }
-            if (captureLand) {
+            if (captureLand && chordFree) {
                 application.captureAngleSolverBlock(BlockSelection.Kind.LAND);
             }
-            if (clearBlocks) {
+            if (clearBlocks && chordFree) {
                 application.clearAngleSolverBlocks();
             }
         }
@@ -349,7 +350,12 @@ public class Forge8ParkourCalculator {
         ));
     }
 
+    private static boolean isCtrlHeld() {
+        return Keyboard.isKeyDown(Keyboard.KEY_LCONTROL) || Keyboard.isKeyDown(Keyboard.KEY_RCONTROL);
+    }
+
     private boolean dispatchHotkey(int keyCode) {
+        if (isCtrlHeld() && keyCode != landingConstraintsKeyBinding.getKeyCode()) return false;
         if (keyCode == landingConstraintsKeyBinding.getKeyCode()) {
             boolean enter = Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT);
             boolean remove = Keyboard.isKeyDown(Keyboard.KEY_LCONTROL) || Keyboard.isKeyDown(Keyboard.KEY_RCONTROL);

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/ParkourCalcGuiScreen.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/ParkourCalcGuiScreen.java
@@ -72,15 +72,16 @@ public final class ParkourCalcGuiScreen extends GuiScreen {
         }
 
         if (!wantsText) {
-            if (keyCode == toggleKeyCode) {
+            boolean ctrlHeld = Keyboard.isKeyDown(Keyboard.KEY_LCONTROL) || Keyboard.isKeyDown(Keyboard.KEY_RCONTROL);
+            if (keyCode == toggleKeyCode && !ctrlHeld) {
                 closeOverlay();
                 return;
             }
-            if (keyCode == deselectKeyCode) {
+            if (keyCode == deselectKeyCode && !ctrlHeld) {
                 selection.clear();
                 return;
             }
-            if (keyCode == playbackKeyCode) {
+            if (keyCode == playbackKeyCode && !ctrlHeld) {
                 togglePlayback.run();
                 return;
             }

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/sim/Forge8Simulator.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/sim/Forge8Simulator.java
@@ -4,6 +4,7 @@ import de.legoshi.parkourcalc.core.anglesolver.Medium;
 import de.legoshi.parkourcalc.core.sim.ChunkRange;
 import de.legoshi.parkourcalc.core.sim.Checkpoint;
 import de.legoshi.parkourcalc.core.sim.LazyEntitySimulator;
+import de.legoshi.parkourcalc.core.sim.StartResumeState;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.InputRow;
 import net.minecraft.client.Minecraft;
@@ -48,8 +49,31 @@ public final class Forge8Simulator extends LazyEntitySimulator<SimulatorEntity> 
         return new SimulatorEntity(simWorld, player.getGameProfile(), start, vel, yaw);
     }
 
-    @Override protected void resetEntity(SimulatorEntity e) {
-        e.resetPlayer();
+    @Override protected void resetEntity(SimulatorEntity e, StartResumeState resume) {
+        e.resetPlayer(resume);
+    }
+
+    @Override
+    protected StartResumeState describeResume(Checkpoint checkpoint) {
+        if (!(checkpoint instanceof SimulatorEntity.Checkpoint)) return null;
+        SimulatorEntity.Checkpoint c = (SimulatorEntity.Checkpoint) checkpoint;
+        StartResumeState r = new StartResumeState();
+        r.onGround = c.onGround;
+        r.wallContact = c.isCollidedHorizontally;
+        r.sprinting = c.sprinting;
+        r.jumpCooldown = c.jumpTicks;
+        r.airSprintFactor = c.jumpMovementFactor;
+        if (c.isInWeb) {
+            r.stuckMultiplier = new Vec3dCore(0.25, 0.05, 0.25);
+        }
+        if (c.sprintState != null) {
+            r.sprintWindow = c.sprintState.sprintToggleTimer;
+            r.sprintTicksLeft = c.sprintState.sprintingTicksLeft;
+            if (c.sprintState.prevSneak) r.heldLastTick.add(InputRow.Key.SNEAK);
+            if (c.sprintState.prevMoveForward > 0.0F) r.heldLastTick.add(InputRow.Key.W);
+            if (c.sprintState.prevMoveForward < 0.0F) r.heldLastTick.add(InputRow.Key.S);
+        }
+        return r;
     }
 
     @Override protected void setInput(SimulatorEntity e, InputRow row) {

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/sim/SimulatorEntity.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/sim/SimulatorEntity.java
@@ -3,6 +3,7 @@ package de.legoshi.parkourcalc.forge8.sim;
 import com.mojang.authlib.GameProfile;
 import de.legoshi.parkourcalc.core.anglesolver.Medium;
 import de.legoshi.parkourcalc.forge.core.sim.PlayerSprintMachine;
+import de.legoshi.parkourcalc.core.sim.StartResumeState;
 import de.legoshi.parkourcalc.core.sim.SubtickPath;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.InputRow;
@@ -79,6 +80,10 @@ public class SimulatorEntity extends EntityPlayer {
     }
 
     public void resetPlayer() {
+        resetPlayer(null);
+    }
+
+    public void resetPlayer(StartResumeState resume) {
         this.noClip = true;
         this.setHealth(this.getMaxHealth());
         this.motionX = 0.0;
@@ -100,6 +105,28 @@ public class SimulatorEntity extends EntityPlayer {
         this.tickMedium = null;
         this.tickGroundFriction = Double.NaN;
         this.tickSoulsandCells = 0;
+        if (resume != null) {
+            applyResume(resume);
+        }
+    }
+
+    private void applyResume(StartResumeState resume) {
+        this.onGround = resume.onGround;
+        this.isCollidedHorizontally = resume.wallContact;
+        this.setSprinting(resume.sprinting);
+        this.jumpTicks = resume.jumpCooldown;
+        this.isInWeb = resume.stuckMultiplier != null;
+        this.jumpMovementFactor = !Float.isNaN(resume.airSprintFactor)
+                ? resume.airSprintFactor
+                : (resume.sprinting ? 0.026F : 0.02F);
+        boolean prevSneak = resume.heldLastTick.contains(InputRow.Key.SNEAK);
+        float prevForward = (resume.heldLastTick.contains(InputRow.Key.W) ? 1.0F : 0.0F)
+                - (resume.heldLastTick.contains(InputRow.Key.S) ? 1.0F : 0.0F);
+        if (prevSneak) {
+            prevForward *= 0.3F;
+        }
+        this.sprintState = new PlayerSprintMachine.State(prevSneak, prevForward,
+                resume.sprintWindow, resume.sprintTicksLeft, resume.sprinting);
     }
 
     @Override


### PR DESCRIPTION
Implements #291.

## What
- **Right-click "Save selected as new TAS"** on the input table. It opens the name-entry modal and writes the selected ticks to a standalone save whose start position, velocity, yaw, and pitch are seeded from the first selected tick's pre-tick state, so the copied ticks land in exactly the same positions as in the source TAS. The currently open document is left untouched (non-destructive); the new file appears in Open.
- **Ctrl+C / Ctrl+V** copy and paste selected table rows. Paste inserts after the last selected row (or at the end when nothing is selected) and works across different TAS files, since the row clipboard lives on the long-lived overlay. Pasted rows do not carry start coordinates or velocity, matching Duplicate.

## Notes
- Letter-key chords are polled loader-side (ImGui 1.86 has no portable letter-key ids), mirroring the existing Ctrl+S / Ctrl+Z / Ctrl+Y handling. Added `isCopyChordDown` / `isPasteChordDown` to `MinecraftAccess` and the Fabric + both Forge loaders.
- Copy/paste chords only fire while the UI is open and no text field is focused, so text-field Ctrl+C/V still works.
- "Save selected as new TAS" creates the file without switching the editor to it; say the word if you'd rather it open the new TAS after creating.

## Tests
- `CopyPasteTicksTest`: paste-after-selection, paste-at-end, cross-document clipboard, independent copies.
- `SaveSelectionAsTasTest`: sliced save round-trips its start state and rows and leaves the open document untouched; empty selection rejected.
- `:core:build` (incl. `tableStyleCheck`) green; all three loaders compile.

In-game QA on the touched loaders is still pending.

Closes #291