### PR TITLE
feat(ui): add Edit menu with Undo/Redo items

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/MainWindowOverlay.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/MainWindowOverlay.java
@@ -249,6 +249,7 @@ public final class MainWindowOverlay implements RenderInterface {
         // ImGui offsets the first entry by half the item spacing; pre-subtract it so "File" lines up under the title text.
         ImGui.setCursorPosX(ThemeManager.headerTextPadX() - ImGui.getStyle().getItemSpacing().x * 0.5f);
         menu("File", fileMenu::renderMenuItems);
+        menu("Edit", this::renderEditMenuItems);
         menu("View", this::renderViewMenuItems);
         menu("Settings", this::renderSettingsMenuItems);
         menu("Help", this::renderHelpMenuItems);
@@ -287,6 +288,11 @@ public final class MainWindowOverlay implements RenderInterface {
             ThemeManager.popMenuPopupChrome();
             ImGui.endMenu();
         }
+    }
+
+    private void renderEditMenuItems() {
+        if (ImGui.menuItem("Undo", "Ctrl+Z") && onUndo != null) onUndo.run();
+        if (ImGui.menuItem("Redo", "Ctrl+Y") && onRedo != null) onRedo.run();
     }
 
     private void renderViewMenuItems() {


### PR DESCRIPTION
## What and why

Closes #289. The undo/redo actions were only reachable via the Ctrl+Z / Ctrl+Y keyboard chords. For anyone whose Z key is unreliable there was no way to undo. This adds an **Edit** menu to the main window menu bar with **Undo** and **Redo** items, giving a fully mouse-driven path that needs no keyboard.

## Changes

- New `Edit` menu (between `File` and `View`) in `MainWindowOverlay`, with `Undo` (`Ctrl+Z`) and `Redo` (`Ctrl+Y`) items.
- Items call the existing `onUndo` / `onRedo` runnables, so they share the exact behavior of the keyboard chords, including the "Undo" / "Nothing to undo" HUD feedback.

## Notes

- Core-only change; the `MainWindowOverlay` constructor is unchanged, so no loader wiring is affected and all three loaders pick it up automatically.
- Items are always enabled and rely on the existing HUD feedback rather than a `canUndo()` gate, to mirror the keyboard path exactly (an edit that has not yet been polled into the history is still undoable, which a committed-history gate would wrongly grey out).

## Testing

- `./gradlew :core:build` (compile + `tableStyleCheck` + fast test suite) green.
- UI-only change; in-game QA pass on one loader recommended before merge per branch rules.
