### PR TITLE
feat(ui): add per-tick hotbar slot input column

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/PlaybackController.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/PlaybackController.java
@@ -270,6 +270,10 @@ public final class PlaybackController {
             lastSpeedAmplifier = speedAmp;
             lastJumpBoostAmplifier = jumpAmp;
         }
+        int hotbarSlot = row.getHotbarSlot();
+        if (hotbarSlot >= 1) {
+            bridge.setHotbarSlot(hotbarSlot - 1);
+        }
         Float yaw = row.getYaw();
         prevTickYaw = displayTargetYaw;
         if (yaw != null) {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ports/PlaybackBridge.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ports/PlaybackBridge.java
@@ -44,5 +44,8 @@ public interface PlaybackBridge {
 
     void applyEffects(int speedAmplifier, int jumpBoostAmplifier);
 
+    /** Switch the held hotbar slot (0-8) so playback places from the right slot. No-op if unsupported. */
+    default void setHotbarSlot(int slotZeroBased) {}
+
     default void dumpPlayerState(int tickIndex) {}
 }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveFile.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveFile.java
@@ -38,6 +38,7 @@ public final class SaveFile {
         public boolean pitchLocked;
         public int speedAmplifier;
         public int jumpBoostAmplifier;
+        public int hotbarSlot;
     }
 
     /** Angle Solver problem: defaults, per-tick constraints/overrides, and last solve result. */

--- a/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveIO.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveIO.java
@@ -347,6 +347,7 @@ public final class SaveIO {
         r.pitchLocked = row.isPitchLocked();
         r.speedAmplifier = row.getSpeedAmplifier();
         r.jumpBoostAmplifier = row.getJumpBoostAmplifier();
+        r.hotbarSlot = row.getHotbarSlot();
         return r;
     }
 
@@ -361,7 +362,8 @@ public final class SaveIO {
                 && Objects.equals(r.pitch, row.getPitch())
                 && r.pitchLocked == row.isPitchLocked()
                 && r.speedAmplifier == row.getSpeedAmplifier()
-                && r.jumpBoostAmplifier == row.getJumpBoostAmplifier();
+                && r.jumpBoostAmplifier == row.getJumpBoostAmplifier()
+                && r.hotbarSlot == row.getHotbarSlot();
     }
 
     private static InputRow toInputRow(SaveFile.Row r) {
@@ -381,6 +383,7 @@ public final class SaveIO {
         if (r != null) {
             row.setSpeedAmplifier(r.speedAmplifier);
             row.setJumpBoostAmplifier(r.jumpBoostAmplifier);
+            row.setHotbarSlot(r.hotbarSlot);
         }
         return row;
     }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputOverlay.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputOverlay.java
@@ -39,6 +39,7 @@ public final class InputOverlay {
     private static final String COL_PITCH = "Pit";
     private static final String COL_SPEED = "Speed";
     private static final String COL_JUMP_BOOST = "Jump";
+    private static final String COL_HOTBAR = "Slot";
     private static final float INDEX_DIGIT_WIDTH = 32f;
     private static final float INDEX_DIGIT_SLACK = 6f;
     private static final float TABLE_MIN_HEIGHT = 80f;
@@ -55,6 +56,7 @@ public final class InputOverlay {
 
     private static final String ID_SPEED_SUFFIX = "##speed";
     private static final String ID_JUMP_SUFFIX = "##jump";
+    private static final String ID_HOTBAR_SUFFIX = "##hotbar";
     private static final String ID_PITCH_INPUT = "##pitch";
 
     private static final String MENU_APPLY_SPEED_TO_ALL = "Apply tick 1 Speed to all rows";
@@ -65,6 +67,12 @@ public final class InputOverlay {
     };
     private static final float AMP_CELL_WIDTH = 110;
     private static final float AMP_COLUMN_WIDTH = 120;
+
+    private static final String[] HOTBAR_LABELS = {
+            "-", "1", "2", "3", "4", "5", "6", "7", "8", "9"
+    };
+    private static final float HOTBAR_CELL_WIDTH = 54;
+    private static final float HOTBAR_COLUMN_WIDTH = 64;
 
     private static final String MENU_SET_TO_PLAYER = "Set to user position";
     private static final String LABEL_ROWS = "Rows:";
@@ -110,6 +118,7 @@ public final class InputOverlay {
     private final ImString pitchInput = new ImString(32);
     private final ImInt rowsToAdd = new ImInt(1);
     private final ImInt ampBuf = new ImInt();
+    private final ImInt hotbarBuf = new ImInt();
 
     private int draggingRowIndex = -1;
     private int editingYawRow = -1;
@@ -292,6 +301,10 @@ public final class InputOverlay {
         return settings.showColJumpBoost;
     }
 
+    private boolean isHotbarColumnVisible() {
+        return settings.showColHotbar;
+    }
+
     private int potionColumnCount() {
         return (isSpeedColumnVisible() ? 1 : 0) + (isJumpBoostColumnVisible() ? 1 : 0);
     }
@@ -301,6 +314,7 @@ public final class InputOverlay {
         for (InputRow.Key key : MOVEMENT_KEYS) if (isKeyColumnVisible(key)) count++;
         for (InputRow.Key key : MODIFIER_KEYS) if (isKeyColumnVisible(key)) count++;
         for (InputRow.Key key : MOUSE_KEYS) if (isKeyColumnVisible(key)) count++;
+        if (isHotbarColumnVisible()) count++;
         if (isYawColumnVisible()) count++;
         if (isPitchColumnVisible()) count++;
         return count;
@@ -334,6 +348,7 @@ public final class InputOverlay {
         for (InputRow.Key key : MOUSE_KEYS) {
             if (isKeyColumnVisible(key)) columnSum += ThemeManager.tableColumnWidth(headerLabel(key), 0f);
         }
+        if (isHotbarColumnVisible()) columnSum += ThemeManager.tableColumnWidth(COL_HOTBAR, HOTBAR_COLUMN_WIDTH * scale);
         boolean speed = isSpeedColumnVisible();
         boolean jump = isJumpBoostColumnVisible();
         if (speed) {
@@ -546,6 +561,9 @@ public final class InputOverlay {
         setupKeyColumns(MOVEMENT_KEYS);
         setupKeyColumns(MODIFIER_KEYS);
         setupKeyColumns(MOUSE_KEYS);
+        if (isHotbarColumnVisible()) {
+            ImGui.tableSetupColumn(COL_HOTBAR, ImGuiTableColumnFlags.WidthFixed, ThemeManager.tableColumnWidth(COL_HOTBAR, HOTBAR_COLUMN_WIDTH * scale));
+        }
         if (isYawColumnVisible()) {
             ImGui.tableSetupColumn(COL_YAW, ImGuiTableColumnFlags.WidthFixed, ThemeManager.tableColumnWidth(COL_YAW, yawColumnWidth()));
         }
@@ -582,6 +600,11 @@ public final class InputOverlay {
         col = renderKeyColumnHeaders(MOVEMENT_KEYS, col);
         col = renderKeyColumnHeaders(MODIFIER_KEYS, col);
         col = renderKeyColumnHeaders(MOUSE_KEYS, col);
+        if (isHotbarColumnVisible()) {
+            ImGui.tableSetColumnIndex(col++);
+            ThemeManager.tableHeaderCentered(COL_HOTBAR);
+            TooltipUtil.onHover(headerColTooltip(COL_HOTBAR));
+        }
         if (isYawColumnVisible()) {
             ImGui.tableSetColumnIndex(col++);
             ThemeManager.tableHeaderCentered(COL_YAW);
@@ -636,6 +659,7 @@ public final class InputOverlay {
             case COL_PITCH: return "Pitch turn per tick; press F to lock a cell to an absolute pitch (-90 up to 90 down). Empty = inherit previous tick's pitch.";
             case COL_SPEED: return "Speed potion amplifier (none = no effect).";
             case COL_JUMP_BOOST: return "Jump Boost potion amplifier (none = no effect).";
+            case COL_HOTBAR: return "Held hotbar slot (1-9) to switch to during playback. Empty = keep the previous slot.";
             default: return col;
         }
     }
@@ -842,6 +866,7 @@ public final class InputOverlay {
         }
 
         renderKeyColumns(row, index, rowH);
+        if (isHotbarColumnVisible()) renderHotbarColumn(row, index);
         if (isYawColumnVisible()) renderYawColumn(row, index, centerY);
         if (isPitchColumnVisible()) renderPitchColumn(row, index, centerY);
         renderPotionColumns(row, index);
@@ -1164,6 +1189,17 @@ public final class InputOverlay {
             ImGui.setScrollY(top);
         } else if (bottom > scroll + viewportH) {
             ImGui.setScrollY(bottom - viewportH);
+        }
+    }
+
+    private void renderHotbarColumn(InputRow row, int rowIndex) {
+        ImGui.tableNextColumn();
+        float hotW = HOTBAR_CELL_WIDTH * uiScale();
+        hotbarBuf.set(row.getHotbarSlot());
+        ThemeManager.centerNextItem(hotW);
+        if (Controls.tableCombo(ID_HOTBAR_SUFFIX, hotbarBuf, HOTBAR_LABELS, hotW)) {
+            row.setHotbarSlot(hotbarBuf.get());
+            notifyChange(rowIndex);
         }
     }
 

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputRow.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputRow.java
@@ -10,6 +10,8 @@ public class InputRow {
 
     public static final int MAX_AMPLIFIER = 9;
 
+    public static final int MAX_HOTBAR_SLOT = 9;
+
     private final int id;
     private final Set<Key> activeKeys = EnumSet.noneOf(Key.class);
     private Float yaw;
@@ -18,6 +20,7 @@ public class InputRow {
     private boolean pitchLocked;
     private int speedAmplifier;
     private int jumpBoostAmplifier;
+    private int hotbarSlot;
     private int modCount;
 
     // LEFT_CLICK / RIGHT_CLICK appended last to keep existing ordinals stable for old saves.
@@ -109,10 +112,26 @@ public class InputRow {
         this.jumpBoostAmplifier = clamped;
     }
 
+    public int getHotbarSlot() {
+        return hotbarSlot;
+    }
+
+    public void setHotbarSlot(int slot) {
+        int clamped = clampHotbarSlot(slot);
+        if (this.hotbarSlot != clamped) modCount++;
+        this.hotbarSlot = clamped;
+    }
+
     private static int clampAmplifier(int amplifier) {
         if (amplifier < 0) return 0;
         if (amplifier > MAX_AMPLIFIER) return MAX_AMPLIFIER;
         return amplifier;
+    }
+
+    private static int clampHotbarSlot(int slot) {
+        if (slot < 0) return 0;
+        if (slot > MAX_HOTBAR_SLOT) return MAX_HOTBAR_SLOT;
+        return slot;
     }
 
     public InputRow copy() {
@@ -124,6 +143,7 @@ public class InputRow {
         copy.pitchLocked = this.pitchLocked;
         copy.speedAmplifier = this.speedAmplifier;
         copy.jumpBoostAmplifier = this.jumpBoostAmplifier;
+        copy.hotbarSlot = this.hotbarSlot;
         return copy;
     }
 }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/Settings.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/Settings.java
@@ -56,6 +56,7 @@ public final class Settings {
     private static final boolean DEFAULT_SHOW_SUBTICK = false;
     private static final boolean DEFAULT_SHOW_COL_SPEED = false;
     private static final boolean DEFAULT_SHOW_COL_JUMP_BOOST = false;
+    private static final boolean DEFAULT_SHOW_COL_HOTBAR = false;
     private static final boolean DEFAULT_SHOW_CONSTRAINTS = true;
     private static final boolean DEFAULT_HIGHLIGHT_ON_GROUND_ROWS = true;
 
@@ -159,6 +160,7 @@ public final class Settings {
     public boolean showSubtick = DEFAULT_SHOW_SUBTICK;
     public boolean showColSpeed = DEFAULT_SHOW_COL_SPEED;
     public boolean showColJumpBoost = DEFAULT_SHOW_COL_JUMP_BOOST;
+    public boolean showColHotbar = DEFAULT_SHOW_COL_HOTBAR;
     public boolean showConstraints = DEFAULT_SHOW_CONSTRAINTS;
     public boolean highlightOnGroundRows = DEFAULT_HIGHLIGHT_ON_GROUND_ROWS;
 
@@ -267,6 +269,7 @@ public final class Settings {
         showSubtick = DEFAULT_SHOW_SUBTICK;
         showColSpeed = DEFAULT_SHOW_COL_SPEED;
         showColJumpBoost = DEFAULT_SHOW_COL_JUMP_BOOST;
+        showColHotbar = DEFAULT_SHOW_COL_HOTBAR;
         showConstraints = DEFAULT_SHOW_CONSTRAINTS;
         highlightOnGroundRows = DEFAULT_HIGHLIGHT_ON_GROUND_ROWS;
         showColA = DEFAULT_SHOW_COL_A;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/SettingsModal.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/SettingsModal.java
@@ -35,6 +35,7 @@ public final class SettingsModal {
     private static final String TT_SUBTICK = "Renders the interpolated path between adjacent ticks, exposing collision moments inside a tick.";
     private static final String TT_COL_SPEED_AMP = "Adds a per-tick Speed potion amplifier column to the input table.";
     private static final String TT_COL_JUMP_BOOST_AMP = "Adds a per-tick Jump Boost potion amplifier column to the input table.";
+    private static final String TT_COL_HOTBAR = "Adds a per-tick hotbar slot column (1-9). During playback the held slot switches on ticks that set one; empty keeps the previous slot.";
     private static final String TT_CONSTRAINTS = "Draws Angle Solver position constraints (X/Z) as translucent plates at the tick they apply to. The front plate sits on the constraint; the back fades out toward the open/free direction. Only visible while the Angle Solver is open.";
     private static final String TT_C_EXPAND = "Grow each plate outward by the player hitbox half-width (0.3) so the plate covers your hitbox: your hitbox fits inside the plate exactly when the tick is valid.";
     private static final String TT_C_DIM = "Size in blocks. Width is across the constraint, height is vertical, length is along the plate (front depth from the boundary / back reach behind it).";
@@ -382,6 +383,7 @@ public final class SettingsModal {
             checkboxRow("Right click (RMB)", "##col_rmb", settings.showColRightClick, TT_COL_RMB, v -> settings.showColRightClick = v);
             checkboxRow("Speed", "##show_speed", settings.showColSpeed, TT_COL_SPEED_AMP, v -> settings.showColSpeed = v);
             checkboxRow("Jump Boost", "##show_jump_boost", settings.showColJumpBoost, TT_COL_JUMP_BOOST_AMP, v -> settings.showColJumpBoost = v);
+            checkboxRow("Hotbar slot", "##show_hotbar", settings.showColHotbar, TT_COL_HOTBAR, v -> settings.showColHotbar = v);
             ThemeManager.endStandardFormTable();
         }
 

--- a/core/src/test/java/de/legoshi/parkourcalc/core/ColumnVisibilitySettingsTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/ColumnVisibilitySettingsTest.java
@@ -25,6 +25,7 @@ public class ColumnVisibilitySettingsTest {
         assertFalse(s.showColPitch);
         assertFalse(s.showColLeftClick);
         assertFalse(s.showColRightClick);
+        assertFalse(s.showColHotbar);
     }
 
     @Test
@@ -36,6 +37,7 @@ public class ColumnVisibilitySettingsTest {
         saved.showColSneak = false;
         saved.showColPitch = true;
         saved.showColLeftClick = true;
+        saved.showColHotbar = true;
         SettingsIO.save(file, saved);
 
         Settings loaded = new Settings();
@@ -45,6 +47,7 @@ public class ColumnVisibilitySettingsTest {
         assertFalse(loaded.showColSneak);
         assertTrue("opted-in new column must persist", loaded.showColPitch);
         assertTrue(loaded.showColLeftClick);
+        assertTrue("opted-in hotbar column must persist", loaded.showColHotbar);
         assertTrue(loaded.showColA);
         assertFalse(loaded.showColRightClick);
     }
@@ -55,9 +58,11 @@ public class ColumnVisibilitySettingsTest {
         s.showColA = false;
         s.showColPitch = true;
         s.showColRightClick = true;
+        s.showColHotbar = true;
         s.reset();
         assertTrue(s.showColA);
         assertFalse(s.showColPitch);
         assertFalse(s.showColRightClick);
+        assertFalse(s.showColHotbar);
     }
 }

--- a/core/src/test/java/de/legoshi/parkourcalc/core/InputRowSaveRoundTripTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/InputRowSaveRoundTripTest.java
@@ -73,6 +73,24 @@ public class InputRowSaveRoundTripTest {
     }
 
     @Test
+    public void hotbarSlotRoundTrips() throws Exception {
+        FileSystemSaveStore store = store(Files.createTempDirectory("pkc-rt-hotbar"));
+
+        InputData in = new InputData();
+        InputRow r0 = new InputRow();
+        r0.setHotbarSlot(3);
+        in.getRows().add(r0);
+
+        InputRow r1 = new InputRow();
+        in.getRows().add(r1);
+
+        InputData out = saveAndReload(store, in);
+        assertEquals(2, out.size());
+        assertEquals(3, out.get(0).getHotbarSlot());
+        assertEquals("an unset hotbar slot stays 0 (inherit)", 0, out.get(1).getHotbarSlot());
+    }
+
+    @Test
     public void absentPitchRoundTripsAsNull() throws Exception {
         FileSystemSaveStore store = store(Files.createTempDirectory("pkc-rt-nopitch"));
 

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricPlaybackBridge.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricPlaybackBridge.java
@@ -321,6 +321,15 @@ public final class FabricPlaybackBridge implements PlaybackBridge {
     }
 
     @Override
+    public void setHotbarSlot(int slotZeroBased) {
+        if (ghostMode) return;
+        if (slotZeroBased < 0 || slotZeroBased > 8) return;
+        LocalPlayer p = Minecraft.getInstance().player;
+        if (p == null) return;
+        p.getInventory().setSelectedSlot(slotZeroBased);
+    }
+
+    @Override
     public void dumpPlayerState(int tickIndex) {
         net.minecraft.world.entity.player.Player p = ghost != null ? ghost : Minecraft.getInstance().player;
         if (p == null) return;

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12PlaybackBridge.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12PlaybackBridge.java
@@ -346,6 +346,15 @@ public final class Forge12PlaybackBridge implements PlaybackBridge {
     }
 
     @Override
+    public void setHotbarSlot(int slotZeroBased) {
+        if (ghostMode) return;
+        if (slotZeroBased < 0 || slotZeroBased > 8) return;
+        EntityPlayerSP p = Minecraft.getMinecraft().player;
+        if (p == null) return;
+        p.inventory.currentItem = slotZeroBased;
+    }
+
+    @Override
     public void dumpPlayerState(int tickIndex) {
         net.minecraft.entity.player.EntityPlayer p = ghost != null ? ghost : Minecraft.getMinecraft().player;
         if (p == null) return;

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8PlaybackBridge.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8PlaybackBridge.java
@@ -345,6 +345,15 @@ public final class Forge8PlaybackBridge implements PlaybackBridge {
     }
 
     @Override
+    public void setHotbarSlot(int slotZeroBased) {
+        if (ghostMode) return;
+        if (slotZeroBased < 0 || slotZeroBased > 8) return;
+        EntityPlayerSP p = Minecraft.getMinecraft().thePlayer;
+        if (p == null) return;
+        p.inventory.currentItem = slotZeroBased;
+    }
+
+    @Override
     public void dumpPlayerState(int tickIndex) {
         net.minecraft.entity.player.EntityPlayer p = ghost != null ? ghost : Minecraft.getMinecraft().thePlayer;
         if (p == null) return;


### PR DESCRIPTION
Closes #281

Adds a per-tick hotbar slot input column so a TAS can switch the held inventory slot during playback, which is useful for speed builds.

## What
- New default-off "Slot" column in the input table. Each tick can pick an inventory slot 1-9 (the "-" entry means keep the previous slot). Toggle it under Settings, Visible columns, "Hotbar slot".
- During playback the held hotbar slot switches on ticks that set one; an empty cell inherits the last selected slot (Minecraft holds a slot until it changes). The vanilla held-item-change packet is sent automatically before the next interaction, so right-click placement uses the correct slot.
- The value is persisted in saves and in undo/redo history.

## Where
- `InputRow` / `SaveFile.Row` / `SaveIO`: the `hotbarSlot` field (0 = none/inherit, 1-9) and its save round-trip.
- `InputOverlay` / `Settings` / `SettingsModal`: the column and its visibility toggle.
- `PlaybackBridge.setHotbarSlot` (new port default) driven from `PlaybackController.tick()`, implemented for Fabric (`getInventory().setSelectedSlot`) and both Forge loaders (`inventory.currentItem`). No-op during multiplayer ghost playback.

## Notes
- Slot selection uses a dropdown to match the existing Speed / Jump Boost columns rather than free-text entry; the values are the discrete 1-9. Happy to switch it to a typed input if you prefer.
- Hotbar selection has no effect on the physics simulation, so there are no solver or simulator changes.
- Core builds with the fast test suite green (added coverage for the save round-trip and the column-visibility default/persist/reset), and all three loaders compile. Still wants an in-game QA pass on the touched loaders to confirm the held-slot switch and block placement during replay.
