### PR TITLE
feat: add "Allow damage" setting so the entity takes real damage without dying

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/Settings.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/Settings.java
@@ -96,6 +96,7 @@ public final class Settings {
 
     private static final boolean DEFAULT_KEEP_BOXES_DURING_PLAYBACK = false;
     private static final boolean DEFAULT_DISABLE_FLIGHT_DURING_PLAYBACK = true;
+    private static final boolean DEFAULT_ALLOW_DAMAGE = false;
 
     private static final float DEFAULT_YAW_FLICK_SPEED = 7200.0f;
     public static final float MIN_YAW_FLICK_SPEED = 30.0f;
@@ -217,6 +218,8 @@ public final class Settings {
 
     public boolean disableFlightDuringPlayback = DEFAULT_DISABLE_FLIGHT_DURING_PLAYBACK;
 
+    public boolean allowDamage = DEFAULT_ALLOW_DAMAGE;
+
     public static int defaultTickInfoPrecision() {
         return DEFAULT_TICK_INFO_PRECISION;
     }
@@ -307,5 +310,6 @@ public final class Settings {
         hudMessageOrder = DEFAULT_HUD_MESSAGE_ORDER;
         keepBoxesDuringPlayback = DEFAULT_KEEP_BOXES_DURING_PLAYBACK;
         disableFlightDuringPlayback = DEFAULT_DISABLE_FLIGHT_DURING_PLAYBACK;
+        allowDamage = DEFAULT_ALLOW_DAMAGE;
     }
 }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/SettingsModal.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/SettingsModal.java
@@ -64,6 +64,7 @@ public final class SettingsModal {
     private static final String TT_HUD_MESSAGE_ORDER = "Downwards: new messages appear at the top and the window grows downward. Upwards: new messages appear at the bottom and the window grows upward from its bottom edge, like chat.";
     private static final String TT_KEEP_BOXES_PLAYBACK = "Keeps the tick-box path overlay drawn in-world while playback is running, instead of hiding it.";
     private static final String TT_DISABLE_FLIGHT_PLAYBACK = "Prevents double-tapping jump from starting creative flight while playback is running (singleplayer). Flight behaves normally again once playback ends.";
+    private static final String TT_ALLOW_DAMAGE = "Lets the simulation and playback entity take real damage (for example fall damage) so its physics are reproduced. Health is pinned so it never loses hearts or dies. Off by default.";
     private static final String TT_SOLVER_PRECISION = "Decimal places for Angle Solver stats: solved yaws, objective values, constraint chips, and the constraint value editor.";
     private static final String TT_EXPERIMENTAL_BLOCK_CAPTURE = "Enables in-world block capture: tag blocks by role with hotkeys (M momentum, N collision, K land, Delete clears). The hotkeys are registered at startup, so turning this on or off only takes effect after a game restart.";
 
@@ -430,6 +431,7 @@ public final class SettingsModal {
         sectionHeader("Player");
         if (beginLayoutTable("##settings_playback_player")) {
             checkboxRow("Disable creative flight", "##disable_flight_playback", settings.disableFlightDuringPlayback, TT_DISABLE_FLIGHT_PLAYBACK, v -> settings.disableFlightDuringPlayback = v);
+            checkboxRow("Allow damage", "##allow_damage_playback", settings.allowDamage, TT_ALLOW_DAMAGE, v -> settings.allowDamage = v);
             ThemeManager.endStandardFormTable();
         }
     }

--- a/core/src/test/java/de/legoshi/parkourcalc/core/AllowDamageSettingTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/AllowDamageSettingTest.java
@@ -1,0 +1,41 @@
+package de.legoshi.parkourcalc.core;
+
+import de.legoshi.parkourcalc.core.ui.Settings;
+import de.legoshi.parkourcalc.core.ui.SettingsIO;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class AllowDamageSettingTest {
+
+    @Test
+    public void defaultsToOff() {
+        assertFalse(new Settings().allowDamage);
+    }
+
+    @Test
+    public void persistsAcrossSaveAndLoad() throws Exception {
+        Path file = Files.createTempDirectory("pkc-allowdamage").resolve("settings.json");
+
+        Settings saved = new Settings();
+        saved.allowDamage = true;
+        SettingsIO.save(file, saved);
+
+        Settings loaded = new Settings();
+        SettingsIO.load(file, loaded);
+
+        assertTrue(loaded.allowDamage);
+    }
+
+    @Test
+    public void resetRestoresOff() {
+        Settings s = new Settings();
+        s.allowDamage = true;
+        s.reset();
+        assertFalse(s.allowDamage);
+    }
+}

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricParkourCalculator.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricParkourCalculator.java
@@ -210,7 +210,17 @@ public class FabricParkourCalculator implements ClientModInitializer {
     }
 
     public static boolean shouldSuppressFallDamage(net.minecraft.world.entity.Entity self) {
-        return application.isPlaybackRunning() && self instanceof net.minecraft.world.entity.player.Player;
+        return application.isPlaybackRunning()
+                && !application.getSettings().allowDamage
+                && self instanceof net.minecraft.world.entity.player.Player;
+    }
+
+    public static boolean shouldPinHealthDuringPlayback(net.minecraft.world.entity.Entity self) {
+        if (!application.isPlaybackRunning()) return false;
+        if (!application.getSettings().allowDamage) return false;
+        if (!(self instanceof net.minecraft.world.entity.player.Player)) return false;
+        net.minecraft.client.player.LocalPlayer local = Minecraft.getInstance().player;
+        return local != null && self.getUUID().equals(local.getUUID());
     }
 
     private static void onEndTick(Minecraft client) {

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricPlaybackBridge.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricPlaybackBridge.java
@@ -104,8 +104,11 @@ public final class FabricPlaybackBridge implements PlaybackBridge {
             g.applyCarry(carry);
         } else {
             g.setOnGround(true);
+            g.fallDistance = 0.0;
         }
-        g.fallDistance = 0.0;
+        if (!FabricParkourCalculator.getSettings().allowDamage) {
+            g.fallDistance = 0.0;
+        }
         g.setOldPosAndRot();
         g.copyModelCustomisationFrom(client);
         level.addEntity(g);
@@ -192,8 +195,11 @@ public final class FabricPlaybackBridge implements PlaybackBridge {
             de.legoshi.parkourcalc.fabric.sim.SimulatorEntity.applyCheckpoint(client, carry);
         } else {
             client.setOnGround(true);
+            client.fallDistance = 0.0;
         }
-        client.fallDistance = 0.0;
+        if (!FabricParkourCalculator.getSettings().allowDamage) {
+            client.fallDistance = 0.0;
+        }
         // Suppress the player tick's position packet until the server's requestTeleport
         // arms its teleport-pending state, otherwise the client races and trips moved-wrongly.
         LocalPlayerAccessor acc = (LocalPlayerAccessor) client;

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/mixin/HealthPinMixin.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/mixin/HealthPinMixin.java
@@ -1,0 +1,20 @@
+package de.legoshi.parkourcalc.fabric.mixin;
+
+import de.legoshi.parkourcalc.fabric.FabricParkourCalculator;
+import net.minecraft.world.entity.LivingEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Mixin(LivingEntity.class)
+public abstract class HealthPinMixin {
+
+    @ModifyVariable(method = "setHealth", at = @At("HEAD"), argsOnly = true, ordinal = 0)
+    private float pkc$pinHealthDuringPlayback(float health) {
+        LivingEntity self = (LivingEntity) (Object) this;
+        if (FabricParkourCalculator.shouldPinHealthDuringPlayback(self)) {
+            return self.getMaxHealth();
+        }
+        return health;
+    }
+}

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/sim/GhostPlayerEntity.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/sim/GhostPlayerEntity.java
@@ -51,6 +51,7 @@ public class GhostPlayerEntity extends AbstractClientPlayer {
         this.input.keyPresses = c.playerInput;
         this.noJumpDelay = c.jumpingCooldown;
         this.stuckSpeedMultiplier = c.movementMultiplier;
+        this.fallDistance = c.fallDistance;
     }
 
     @Override

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/sim/SimulatorEntity.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/sim/SimulatorEntity.java
@@ -3,6 +3,7 @@ package de.legoshi.parkourcalc.fabric.sim;
 import com.mojang.authlib.GameProfile;
 import de.legoshi.parkourcalc.core.anglesolver.Medium;
 import de.legoshi.parkourcalc.core.sim.StartResumeState;
+import de.legoshi.parkourcalc.fabric.FabricParkourCalculator;
 import de.legoshi.parkourcalc.core.sim.SubtickPath;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.InputRow;
@@ -169,7 +170,19 @@ public class SimulatorEntity extends Player {
 
     @Override
     public boolean hurtServer(ServerLevel world, DamageSource source, float amount) {
-        return false;
+        if (!FabricParkourCalculator.getSettings().allowDamage) {
+            return false;
+        }
+        return super.hurtServer(world, source, amount);
+    }
+
+    @Override
+    public void setHealth(float health) {
+        if (FabricParkourCalculator.getSettings().allowDamage) {
+            super.setHealth(this.getMaxHealth());
+        } else {
+            super.setHealth(health);
+        }
     }
 
     @Override
@@ -463,6 +476,7 @@ public class SimulatorEntity extends Player {
         c.movementMultiplier = this.stuckSpeedMultiplier;
         c.pose = this.getPose();
         c.crouching = this.crouching;
+        c.fallDistance = this.fallDistance;
         return c;
     }
 
@@ -484,6 +498,7 @@ public class SimulatorEntity extends Player {
         this.input.seedKeyPresses(c.playerInput);
         this.noJumpDelay = c.jumpingCooldown;
         this.stuckSpeedMultiplier = c.movementMultiplier;
+        this.fallDistance = c.fallDistance;
     }
 
     public static void applyCheckpoint(net.minecraft.client.player.LocalPlayer p, de.legoshi.parkourcalc.core.sim.Checkpoint state) {
@@ -495,6 +510,7 @@ public class SimulatorEntity extends Player {
         p.setSprinting(c.sprinting);
         p.noJumpDelay = c.jumpingCooldown;
         p.stuckSpeedMultiplier = c.movementMultiplier;
+        p.fallDistance = c.fallDistance;
     }
 
     public static final class Checkpoint implements de.legoshi.parkourcalc.core.sim.Checkpoint {
@@ -511,5 +527,6 @@ public class SimulatorEntity extends Player {
         Vec3 movementMultiplier;
         Pose pose;
         boolean crouching;
+        double fallDistance;
     }
 }

--- a/loader-fabric/src/client/resources/parkourcalculator.client.mixins.json
+++ b/loader-fabric/src/client/resources/parkourcalculator.client.mixins.json
@@ -7,6 +7,7 @@
     "LocalPlayerAccessor",
     "LocalPlayerTickMixin",
     "FallDamageSuppressMixin",
+    "HealthPinMixin",
     "GameRendererMixin",
     "HudMixin",
     "KeyMappingAccessor",

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12ParkourCalculator.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12ParkourCalculator.java
@@ -40,6 +40,7 @@ public class Forge12ParkourCalculator {
     public static final String MODID = "parkourcalculator";
 
     private static final Logger LOG = LogManager.getLogger("ParkourCalculator");
+    private static Forge12ParkourCalculator instance;
 
     private final Application application = new Application(
             new Forge12Simulator(),
@@ -84,6 +85,7 @@ public class Forge12ParkourCalculator {
 
     @Mod.EventHandler
     public void init(FMLInitializationEvent event) {
+        instance = this;
         application.setModVersion(modVersion());
         application.setFilePicker(new OsFilePicker());
         application.setSaveStore(new FileSystemSaveStore(
@@ -186,9 +188,24 @@ public class Forge12ParkourCalculator {
     @SubscribeEvent
     public void onLivingAttack(net.minecraftforge.event.entity.living.LivingAttackEvent event) {
         if (!application.isPlaybackRunning()) return;
+        if (application.getSettings().allowDamage) return;
         if (event.getSource() != net.minecraft.util.DamageSource.FALL) return;
         if (!(event.getEntityLiving() instanceof net.minecraft.entity.player.EntityPlayer)) return;
         event.setCanceled(true);
+    }
+
+    @SubscribeEvent
+    public void onLivingHurt(net.minecraftforge.event.entity.living.LivingHurtEvent event) {
+        if (!application.isPlaybackRunning()) return;
+        if (!application.getSettings().allowDamage) return;
+        if (!(event.getEntityLiving() instanceof net.minecraft.entity.player.EntityPlayer)) return;
+        if (Minecraft.getMinecraft().player == null) return;
+        if (!event.getEntityLiving().getUniqueID().equals(Minecraft.getMinecraft().player.getUniqueID())) return;
+        event.setCanceled(true);
+    }
+
+    public static boolean isDamageAllowed() {
+        return instance != null && instance.application.getSettings().allowDamage;
     }
 
     @SubscribeEvent

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12PlaybackBridge.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12PlaybackBridge.java
@@ -98,8 +98,11 @@ public final class Forge12PlaybackBridge implements PlaybackBridge {
             g.applyCarry(carry);
         } else {
             g.onGround = true;
+            g.fallDistance = 0.0F;
         }
-        g.fallDistance = 0.0F;
+        if (!Forge12ParkourCalculator.isDamageAllowed()) {
+            g.fallDistance = 0.0F;
+        }
         world.addEntityToWorld(GHOST_ENTITY_ID, g);
         ghost = g;
         client.moveStrafing = 0.0F;
@@ -182,6 +185,10 @@ public final class Forge12PlaybackBridge implements PlaybackBridge {
                 sp.setSprinting(false);
                 sp.setSneaking(false);
                 sp.onGround = true;
+                sp.fallDistance = 0.0F;
+            }
+            if (!Forge12ParkourCalculator.isDamageAllowed()) {
+                sp.fallDistance = 0.0F;
             }
             sp.velocityChanged = false;
         });
@@ -197,8 +204,11 @@ public final class Forge12PlaybackBridge implements PlaybackBridge {
             de.legoshi.parkourcalc.forge12.sim.SimulatorEntity.applyCheckpoint(client, carry);
         } else {
             client.onGround = true;
+            client.fallDistance = 0.0F;
         }
-        client.fallDistance = 0.0F;
+        if (!Forge12ParkourCalculator.isDamageAllowed()) {
+            client.fallDistance = 0.0F;
+        }
         // Suppress onUpdateWalkingPlayer's position packet until the server's scheduled
         // setPlayerLocation arms targetPos, otherwise the client races and trips moved-wrongly.
         client.lastReportedPosX = pos.x;

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/sim/GhostPlayerEntity.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/sim/GhostPlayerEntity.java
@@ -2,6 +2,7 @@ package de.legoshi.parkourcalc.forge12.sim;
 
 import com.mojang.authlib.GameProfile;
 import de.legoshi.parkourcalc.core.ui.InputRow;
+import de.legoshi.parkourcalc.forge12.Forge12ParkourCalculator;
 import de.legoshi.parkourcalc.forge.core.sim.PlayerSprintMachine;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.AbstractClientPlayer;
@@ -83,7 +84,10 @@ public class GhostPlayerEntity extends AbstractClientPlayer {
 
     @Override
     public boolean attackEntityFrom(DamageSource source, float amount) {
-        return false;
+        if (!Forge12ParkourCalculator.isDamageAllowed()) {
+            return false;
+        }
+        return super.attackEntityFrom(source, amount);
     }
 
     @Override

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/sim/SimulatorEntity.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/sim/SimulatorEntity.java
@@ -2,6 +2,7 @@ package de.legoshi.parkourcalc.forge12.sim;
 
 import com.mojang.authlib.GameProfile;
 import de.legoshi.parkourcalc.core.anglesolver.Medium;
+import de.legoshi.parkourcalc.forge12.Forge12ParkourCalculator;
 import de.legoshi.parkourcalc.forge.core.sim.PlayerSprintMachine;
 import de.legoshi.parkourcalc.core.sim.StartResumeState;
 import de.legoshi.parkourcalc.core.sim.SubtickPath;
@@ -139,7 +140,19 @@ public class SimulatorEntity extends EntityPlayer {
 
     @Override
     public boolean attackEntityFrom(DamageSource source, float amount) {
-        return false;
+        if (!Forge12ParkourCalculator.isDamageAllowed()) {
+            return false;
+        }
+        return super.attackEntityFrom(source, amount);
+    }
+
+    @Override
+    public void setHealth(float health) {
+        if (Forge12ParkourCalculator.isDamageAllowed()) {
+            super.setHealth(this.getMaxHealth());
+        } else {
+            super.setHealth(health);
+        }
     }
 
     @Override
@@ -340,6 +353,7 @@ public class SimulatorEntity extends EntityPlayer {
         c.isInWeb = this.isInWeb;
         c.width = this.width;
         c.height = this.height;
+        c.fallDistance = this.fallDistance;
         return c;
     }
 
@@ -362,6 +376,7 @@ public class SimulatorEntity extends EntityPlayer {
         this.isInWeb = c.isInWeb;
         this.width = c.width;
         this.height = c.height;
+        this.fallDistance = c.fallDistance;
         this.setPosition(c.posX, c.posY, c.posZ);
     }
 
@@ -375,6 +390,7 @@ public class SimulatorEntity extends EntityPlayer {
         p.setAIMoveSpeed(c.landMovementFactor);
         p.jumpMovementFactor = c.jumpMovementFactor;
         p.jumpTicks = c.jumpTicks;
+        p.fallDistance = c.fallDistance;
         if (c.isInWeb) {
             p.setInWeb();
         }
@@ -394,5 +410,6 @@ public class SimulatorEntity extends EntityPlayer {
         boolean isInWeb;
         float width;
         float height;
+        float fallDistance;
     }
 }

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8ParkourCalculator.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8ParkourCalculator.java
@@ -40,6 +40,7 @@ public class Forge8ParkourCalculator {
     public static final String MODID = "parkourcalculator";
 
     private static final Logger LOG = LogManager.getLogger("ParkourCalculator");
+    private static Forge8ParkourCalculator instance;
 
     private final Application application = new Application(
             new Forge8Simulator(),
@@ -86,6 +87,7 @@ public class Forge8ParkourCalculator {
 
     @Mod.EventHandler
     public void init(FMLInitializationEvent event) {
+        instance = this;
         application.setModVersion(modVersion());
         application.setFilePicker(new OsFilePicker());
         application.setSaveStore(new FileSystemSaveStore(
@@ -188,9 +190,24 @@ public class Forge8ParkourCalculator {
     @SubscribeEvent
     public void onLivingAttack(net.minecraftforge.event.entity.living.LivingAttackEvent event) {
         if (!application.isPlaybackRunning()) return;
+        if (application.getSettings().allowDamage) return;
         if (event.source != net.minecraft.util.DamageSource.fall) return;
         if (!(event.entityLiving instanceof net.minecraft.entity.player.EntityPlayer)) return;
         event.setCanceled(true);
+    }
+
+    @SubscribeEvent
+    public void onLivingHurt(net.minecraftforge.event.entity.living.LivingHurtEvent event) {
+        if (!application.isPlaybackRunning()) return;
+        if (!application.getSettings().allowDamage) return;
+        if (!(event.entityLiving instanceof net.minecraft.entity.player.EntityPlayer)) return;
+        if (Minecraft.getMinecraft().thePlayer == null) return;
+        if (!event.entityLiving.getUniqueID().equals(Minecraft.getMinecraft().thePlayer.getUniqueID())) return;
+        event.setCanceled(true);
+    }
+
+    public static boolean isDamageAllowed() {
+        return instance != null && instance.application.getSettings().allowDamage;
     }
 
     @SubscribeEvent

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8PlaybackBridge.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8PlaybackBridge.java
@@ -102,6 +102,10 @@ public final class Forge8PlaybackBridge implements PlaybackBridge {
                 sp.setSprinting(false);
                 sp.setSneaking(false);
                 sp.onGround = true;
+                sp.fallDistance = 0.0F;
+            }
+            if (!Forge8ParkourCalculator.isDamageAllowed()) {
+                sp.fallDistance = 0.0F;
             }
             sp.velocityChanged = false;
         });
@@ -117,8 +121,11 @@ public final class Forge8PlaybackBridge implements PlaybackBridge {
             de.legoshi.parkourcalc.forge8.sim.SimulatorEntity.applyCheckpoint(client, carry);
         } else {
             client.onGround = true;
+            client.fallDistance = 0.0F;
         }
-        client.fallDistance = 0.0F;
+        if (!Forge8ParkourCalculator.isDamageAllowed()) {
+            client.fallDistance = 0.0F;
+        }
         // Suppress onUpdateWalkingPlayer's position packet until the server's scheduled
         // setPlayerLocation arms targetPos, otherwise the client races and trips moved-wrongly.
         client.lastReportedPosX = pos.x;
@@ -150,8 +157,11 @@ public final class Forge8PlaybackBridge implements PlaybackBridge {
             g.applyCarry(carry);
         } else {
             g.onGround = true;
+            g.fallDistance = 0.0F;
         }
-        g.fallDistance = 0.0F;
+        if (!Forge8ParkourCalculator.isDamageAllowed()) {
+            g.fallDistance = 0.0F;
+        }
         g.getDataWatcher().updateObject(10, client.getDataWatcher().getWatchableObjectByte(10));
         world.addEntityToWorld(GHOST_ENTITY_ID, g);
         ghost = g;

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/sim/GhostPlayerEntity.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/sim/GhostPlayerEntity.java
@@ -2,6 +2,7 @@ package de.legoshi.parkourcalc.forge8.sim;
 
 import com.mojang.authlib.GameProfile;
 import de.legoshi.parkourcalc.core.ui.InputRow;
+import de.legoshi.parkourcalc.forge8.Forge8ParkourCalculator;
 import de.legoshi.parkourcalc.forge.core.sim.PlayerSprintMachine;
 import net.minecraft.client.entity.AbstractClientPlayer;
 import net.minecraft.potion.Potion;
@@ -79,7 +80,10 @@ public class GhostPlayerEntity extends AbstractClientPlayer {
 
     @Override
     public boolean attackEntityFrom(DamageSource source, float amount) {
-        return false;
+        if (!Forge8ParkourCalculator.isDamageAllowed()) {
+            return false;
+        }
+        return super.attackEntityFrom(source, amount);
     }
 
     @Override

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/sim/SimulatorEntity.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/sim/SimulatorEntity.java
@@ -2,6 +2,7 @@ package de.legoshi.parkourcalc.forge8.sim;
 
 import com.mojang.authlib.GameProfile;
 import de.legoshi.parkourcalc.core.anglesolver.Medium;
+import de.legoshi.parkourcalc.forge8.Forge8ParkourCalculator;
 import de.legoshi.parkourcalc.forge.core.sim.PlayerSprintMachine;
 import de.legoshi.parkourcalc.core.sim.StartResumeState;
 import de.legoshi.parkourcalc.core.sim.SubtickPath;
@@ -135,7 +136,19 @@ public class SimulatorEntity extends EntityPlayer {
 
     @Override
     public boolean attackEntityFrom(DamageSource source, float amount) {
-        return false;
+        if (!Forge8ParkourCalculator.isDamageAllowed()) {
+            return false;
+        }
+        return super.attackEntityFrom(source, amount);
+    }
+
+    @Override
+    public void setHealth(float health) {
+        if (Forge8ParkourCalculator.isDamageAllowed()) {
+            super.setHealth(this.getMaxHealth());
+        } else {
+            super.setHealth(health);
+        }
     }
 
     @Override
@@ -330,6 +343,7 @@ public class SimulatorEntity extends EntityPlayer {
         c.landMovementFactor = this.getAIMoveSpeed();
         c.jumpTicks = this.jumpTicks;
         c.isInWeb = this.isInWeb;
+        c.fallDistance = this.fallDistance;
         return c;
     }
 
@@ -350,6 +364,7 @@ public class SimulatorEntity extends EntityPlayer {
         this.setAIMoveSpeed(c.landMovementFactor);
         this.jumpTicks = c.jumpTicks;
         this.isInWeb = c.isInWeb;
+        this.fallDistance = c.fallDistance;
         this.setPosition(c.posX, c.posY, c.posZ);
     }
 
@@ -363,6 +378,7 @@ public class SimulatorEntity extends EntityPlayer {
         p.setAIMoveSpeed(c.landMovementFactor);
         p.jumpMovementFactor = c.jumpMovementFactor;
         p.jumpTicks = c.jumpTicks;
+        p.fallDistance = c.fallDistance;
         if (c.isInWeb) {
             p.setInWeb();
         }
@@ -380,5 +396,6 @@ public class SimulatorEntity extends EntityPlayer {
         float landMovementFactor;
         int jumpTicks;
         boolean isInWeb;
+        float fallDistance;
     }
 }


### PR DESCRIPTION
Adds an off-by-default **Allow damage** toggle under Settings > Playback > Player. When enabled, the simulation and playback entity processes real Minecraft damage (for example fall damage) so its physics apply, while its health is pinned to full so it never loses hearts or dies. Fall distance is now carried through each Checkpoint so re-simulating or replaying from within a fall still computes the correct damage.

Across loaders: Fabric un-suppresses fall damage and pins health via a new `HealthPinMixin`; the Forge loaders gate their fall-damage cancel and add a `LivingHurtEvent` health guard. The simulator and ghost entities process damage while pinning health.

Default is off, so existing behavior and the core regression gate are unchanged. Needs the usual in-game QA on each touched loader (the health-pin and fall-damage paths are only exercisable in-game).

Closes #282