### PR TITLE
fix: keep the gizmo tail patch alive while per-tick hitboxes are shown

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/render/TailPatchGate.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/render/TailPatchGate.java
@@ -9,7 +9,8 @@ public final class TailPatchGate {
                                    int hitboxEdges, boolean useSubtick, PathRenderPlan plan,
                                    int bakedConstraintFaceVerts, int bakedConstraintLineVerts) {
         return built && structuralHashSame && boxCountSame
-                && hitboxEdges == 0 && !useSubtick
+                && hitboxEdges == plan.patch.hitboxEdges()
+                && !useSubtick
                 && plan.reachLineVerts == 0
                 && plan.constraintFaceVerts == bakedConstraintFaceVerts
                 && plan.constraintLineVerts == bakedConstraintLineVerts;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/BoxController.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/BoxController.java
@@ -345,6 +345,13 @@ public final class BoxController {
         }
     }
 
+    public void renderHitboxFloorOutline(BoxRenderer renderer, BoxColorPicker picker, boolean useSubtickPositions,
+                                         int from, int to) {
+        for (int i = from; i < to; i++) {
+            emitHitboxFloorOutlineAt(renderer, picker.argbFor(i, states.get(i)), useSubtickPositions, i);
+        }
+    }
+
     /** Emits one tick's hitbox floor outline; used both by the full-pass loop and by selection patching. */
     public void emitHitboxFloorOutlineAt(BoxRenderer renderer, int argb, boolean useSubtickPositions, int i) {
         double t = BoxStyle.HITBOX_EDGE_THICKNESS;
@@ -365,7 +372,9 @@ public final class BoxController {
 
     /** Number of walk positions (sub-tick samples) for this tick; hitbox geometry scales by this. */
     public int hitboxWalkCount(int index, boolean useSubtickPositions) {
-        return walkFor(index, states.get(index), useSubtickPositions).size();
+        if (!useSubtickPositions) return 1;
+        List<Vec3dCore> path = states.get(index).subtickPath;
+        return path.isEmpty() ? 1 : path.size();
     }
 
     private long totalHitboxWalk(boolean useSubtickPositions) {
@@ -390,6 +399,13 @@ public final class BoxController {
                                           double camX, double camY, double camZ, double maxDistanceSq) {
         for (int i = 0; i < states.size(); i++) {
             if (!inRange(i, camX, camY, camZ, maxDistanceSq)) continue;
+            emitHitboxFullWireframeAt(renderer, picker.argbFor(i, states.get(i)), useSubtickPositions, i);
+        }
+    }
+
+    public void renderHitboxFullWireframe(BoxRenderer renderer, BoxColorPicker picker, boolean useSubtickPositions,
+                                          int from, int to) {
+        for (int i = from; i < to; i++) {
             emitHitboxFullWireframeAt(renderer, picker.argbFor(i, states.get(i)), useSubtickPositions, i);
         }
     }

--- a/core/src/test/java/de/legoshi/parkourcalc/render/GizmoDragConstraintBench.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/render/GizmoDragConstraintBench.java
@@ -104,6 +104,13 @@ public class GizmoDragConstraintBench {
         int n = bc.size();
         faces.reset();
         bc.render(faces, plan.patch.facePicker, from, n);
+        if (plan.patch.hitboxEdges() != 0) {
+            if (plan.patch.showFullHitbox) {
+                bc.renderHitboxFullWireframe(faces, plan.patch.hitboxPicker, plan.patch.showSubtick, from, n);
+            } else {
+                bc.renderHitboxFloorOutline(faces, plan.patch.hitboxPicker, plan.patch.showSubtick, from, n);
+            }
+        }
         bc.renderFacingArrows(faces, plan.patch.drawYawArrows, plan.patch.drawCombinedArrows,
                 plan.patch.yawArrowArgb, plan.patch.combinedArrowArgb, from, Math.max(from, n - 1));
         plan.constraintFaceEmitter.accept(faces);
@@ -158,7 +165,9 @@ public class GizmoDragConstraintBench {
         SelectionManager sel = new SelectionManager(null);
         try {
             StringBuilder out = new StringBuilder();
-            for (int withConstraints = 0; withConstraints < 2; withConstraints++) {
+            for (int scenario = 0; scenario < 3; scenario++) {
+                int withConstraints = scenario == 1 ? 1 : 0;
+                settings.showFullHitbox = scenario == 2;
                 BoxController bc = controllerWith(path(N, 1));
                 AngleSolverState solver = new AngleSolverState();
                 if (withConstraints == 1) {
@@ -182,8 +191,9 @@ public class GizmoDragConstraintBench {
                 long[] r = driveFrames(bc, settings, sel, FRAMES, pathCounts);
 
                 out.append(String.format(
-                        "n=%d constraints=%s: patch frames %d (avg %.3f ms), rebuild frames %d (avg %.3f ms), plan avg %.3f ms, last verts %d%n",
+                        "n=%d constraints=%s hitbox=%s: patch frames %d (avg %.3f ms), rebuild frames %d (avg %.3f ms), plan avg %.3f ms, last verts %d%n",
                         N, withConstraints == 1 ? ("every " + CONSTRAINT_SPACING + " ticks") : "none",
+                        scenario == 2 ? "full" : "off",
                         pathCounts[0], pathCounts[0] == 0 ? 0 : r[0] / 1e6 / pathCounts[0],
                         pathCounts[1], pathCounts[1] == 0 ? 0 : r[1] / 1e6 / pathCounts[1],
                         r[2] / 1e6 / FRAMES, r[3]));

--- a/core/src/test/java/de/legoshi/parkourcalc/render/TailPatchEquivalenceTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/render/TailPatchEquivalenceTest.java
@@ -192,6 +192,72 @@ public class TailPatchEquivalenceTest {
     }
 
     @Test
+    public void hitboxTailPatchMatchesFullRebake() {
+        runHitboxScenario(false);
+        runHitboxScenario(true);
+    }
+
+    private void runHitboxScenario(boolean fullHitbox) {
+        int n = 40;
+        int dirtyTick = 25;
+        int edges = fullHitbox ? 12 : 4;
+        List<TickState> before = path(n, 1);
+        List<TickState> after = new ArrayList<TickState>(before.subList(0, dirtyTick + 1));
+        after.addAll(path(n, 2).subList(dirtyTick + 1, n));
+
+        BoxColorPicker hitboxPicker = (i, s) -> BoxStyle.hitboxLineArgb(settings, false);
+
+        BoxController bc = controllerWith(before, new float[n]);
+        List<String> baseFaces = hitboxFaces(bc, hitboxPicker, fullHitbox);
+
+        long revBefore = bc.getGeometryRev();
+        bc.takeDirtyFrom(revBefore);
+        bc.replaceFrom(dirtyTick + 1, after.subList(dirtyTick + 1, n));
+        bc.setPitches(new float[n]);
+        assertEquals(dirtyTick + 1, bc.takeDirtyFrom(revBefore));
+
+        int from = dirtyTick;
+        BoxController expected = controllerWith(after, new float[n]);
+        assertEquals(hitboxFaces(expected, hitboxPicker, fullHitbox),
+                patchedHitboxFaces(baseFaces, bc, hitboxPicker, fullHitbox, edges, from));
+    }
+
+    private List<String> hitboxFaces(BoxController bc, BoxColorPicker hitboxPicker, boolean fullHitbox) {
+        Rec r = new Rec(BoxRenderer.Mode.FACES);
+        bc.render(r, facePicker, 0, 0, 0, ALL);
+        if (fullHitbox) {
+            bc.renderHitboxFullWireframe(r, hitboxPicker, false, 0, 0, 0, ALL);
+        } else {
+            bc.renderHitboxFloorOutline(r, hitboxPicker, false, 0, 0, 0, ALL);
+        }
+        bc.renderFacingArrows(r, true, false, yawArgb, combinedArgb, 0, 0, 0, ALL);
+        return r.verts;
+    }
+
+    private List<String> patchedHitboxFaces(List<String> base, BoxController bc, BoxColorPicker hitboxPicker,
+                                            boolean fullHitbox, int edges, int from) {
+        int n = bc.size();
+        List<String> out = new ArrayList<String>(base);
+        Rec fr = new Rec(BoxRenderer.Mode.FACES);
+        bc.render(fr, facePicker, from, n);
+        splice(out, from * FACE_VERTS, n * FACE_VERTS, fr.verts);
+        int perBox = edges * PathVertexLayout.THICK_EDGE_VERTS;
+        int hitboxBase = n * FACE_VERTS;
+        Rec hr = new Rec(BoxRenderer.Mode.FACES);
+        if (fullHitbox) {
+            bc.renderHitboxFullWireframe(hr, hitboxPicker, false, from, n);
+        } else {
+            bc.renderHitboxFloorOutline(hr, hitboxPicker, false, from, n);
+        }
+        splice(out, hitboxBase + from * perBox, hitboxBase + n * perBox, hr.verts);
+        Rec ar = new Rec(BoxRenderer.Mode.FACES);
+        bc.renderFacingArrows(ar, true, false, yawArgb, combinedArgb, from, n - 1);
+        int arrowBase = hitboxBase + n * perBox;
+        splice(out, arrowBase + from * ARROW_VERTS, arrowBase + (n - 1) * ARROW_VERTS, ar.verts);
+        return out;
+    }
+
+    @Test
     public void constraintRegionPatchMatchesFullRebake() {
         int n = 40;
         int dirtyTick = 25;

--- a/core/src/test/java/de/legoshi/parkourcalc/render/TailPatchGateTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/render/TailPatchGateTest.java
@@ -96,4 +96,22 @@ public class TailPatchGateTest {
         assertFalse(TailPatchGate.canPatch(true, true, true, 0, true, plan, 0, 0));
         assertTrue(TailPatchGate.canPatch(true, true, true, 0, false, plan, 0, 0));
     }
+
+    @Test
+    public void matchingHitboxLayoutAllowsPatch() {
+        Settings settings = new Settings();
+        settings.showHitbox = true;
+        BoxController bc = boxes(4);
+        PathRenderPlan plan = PathRenderPlan.build(bc, settings, new SelectionManager(null));
+        assertEquals(4, plan.patch.hitboxEdges());
+        assertTrue(TailPatchGate.canPatch(true, true, true, 4, false, plan, 0, 0));
+        assertFalse(TailPatchGate.canPatch(true, true, true, 0, false, plan, 0, 0));
+        assertFalse(TailPatchGate.canPatch(true, true, true, 4, true, plan, 0, 0));
+
+        settings.showFullHitbox = true;
+        PathRenderPlan fullPlan = PathRenderPlan.build(bc, settings, new SelectionManager(null));
+        assertEquals(12, fullPlan.patch.hitboxEdges());
+        assertTrue(TailPatchGate.canPatch(true, true, true, 12, false, fullPlan, 0, 0));
+        assertFalse(TailPatchGate.canPatch(true, true, true, 4, false, fullPlan, 0, 0));
+    }
 }

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/render/CachedBoxGeometry.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/render/CachedBoxGeometry.java
@@ -130,6 +130,18 @@ public final class CachedBoxGeometry implements AutoCloseable {
                 BoxRenderer.Mode.FACES,
                 r -> boxController.render(r, patch.facePicker, from, n)
         );
+        if (ok && hitboxEdges != 0) {
+            Consumer<BoxRenderer> emit = patch.showFullHitbox
+                    ? r -> boxController.renderHitboxFullWireframe(r, patch.hitboxPicker, useSubtick, from, n)
+                    : r -> boxController.renderHitboxFloorOutline(r, patch.hitboxPicker, useSubtick, from, n);
+            ok = writeVerts(
+                    faceSegments,
+                    hitboxBase + hitboxStarts[from],
+                    PrimitiveTopology.TRIANGLES,
+                    BoxRenderer.Mode.FACES,
+                    emit
+            );
+        }
         if (ok && arrowsPerBox > 0 && from < n - 1) {
             int stride = arrowsPerBox * PathVertexLayout.ARROW_VERTS_PER_BOX;
             ok = writeVerts(

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/render/Forge12CachedBoxGeometry.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/render/Forge12CachedBoxGeometry.java
@@ -108,6 +108,19 @@ public final class Forge12CachedBoxGeometry {
                 (n - from) * PathVertexLayout.FACE_VERTS_PER_BOX,
                 r -> boxController.render(r, patch.facePicker, from, n)
         );
+        if (hitboxEdges != 0) {
+            final boolean full = patch.showFullHitbox;
+            writeVerts(faceVbo, hitboxBase + hitboxStarts[from], GL11.GL_TRIANGLES, BoxRenderer.Mode.FACES,
+                    hitboxStarts[n] - hitboxStarts[from],
+                    r -> {
+                        if (full) {
+                            boxController.renderHitboxFullWireframe(r, patch.hitboxPicker, useSubtick, from, n);
+                        } else {
+                            boxController.renderHitboxFloorOutline(r, patch.hitboxPicker, useSubtick, from, n);
+                        }
+                    }
+            );
+        }
         if (arrowsPerBox > 0 && from < n - 1) {
             int stride = arrowsPerBox * PathVertexLayout.ARROW_VERTS_PER_BOX;
             writeVerts(faceVbo, arrowBase + from * stride, GL11.GL_TRIANGLES, BoxRenderer.Mode.FACES,

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/render/Forge8CachedBoxGeometry.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/render/Forge8CachedBoxGeometry.java
@@ -108,6 +108,19 @@ public final class Forge8CachedBoxGeometry {
                 (n - from) * PathVertexLayout.FACE_VERTS_PER_BOX,
                 r -> boxController.render(r, patch.facePicker, from, n)
         );
+        if (hitboxEdges != 0) {
+            final boolean full = patch.showFullHitbox;
+            writeVerts(faceVbo, hitboxBase + hitboxStarts[from], GL11.GL_TRIANGLES, BoxRenderer.Mode.FACES,
+                    hitboxStarts[n] - hitboxStarts[from],
+                    r -> {
+                        if (full) {
+                            boxController.renderHitboxFullWireframe(r, patch.hitboxPicker, useSubtick, from, n);
+                        } else {
+                            boxController.renderHitboxFloorOutline(r, patch.hitboxPicker, useSubtick, from, n);
+                        }
+                    }
+            );
+        }
         if (arrowsPerBox > 0 && from < n - 1) {
             int stride = arrowsPerBox * PathVertexLayout.ARROW_VERTS_PER_BOX;
             writeVerts(faceVbo, arrowBase + from * stride, GL11.GL_TRIANGLES, BoxRenderer.Mode.FACES,


### PR DESCRIPTION
Closes #301

## What was lagging

Dragging the yaw gizmo on a long TAS (~4000 ticks) with "player hitbox for ticks" enabled dropped to slideshow rates. The gizmo itself is ~100 line vertices per frame and is not the cost; the drag resimulates the tail every frame, and `TailPatchGate.canPatch` still required `hitboxEdges == 0`, so every drag frame fell back to a full rebake of the cached geometry plus a VBO delete/realloc/re-upload (about 11.5 MB per frame with the floor outline, 30 MB with the full wireframe, at 4000 ticks). This is the same failure mode already fixed for constraint plates in #276; the hitbox clause was the one left standing.

## The fix

With subtick sampling off, the hitbox region has a constant per-box vertex stride (walk count is always 1), structurally identical to the arrow region that was already patchable. So:

- `TailPatchGate` now accepts a baked hitbox layout that matches the plan (`hitboxEdges == plan.patch.hitboxEdges()`) instead of requiring the hitbox to be absent.
- `BoxController` gains `from/to` range overloads of `renderHitboxFloorOutline` / `renderHitboxFullWireframe`, mirroring the existing box and arrow range renderers.
- All three loaders' `patchTail` now rewrite the hitbox slice `[hitboxBase + hitboxStarts[from], hitboxBase + hitboxStarts[n])` in place, between the existing main-face and arrow patches, using the same offsets `patchBox` already uses for selection recoloring.
- `hitboxWalkCount` short-circuits when subtick sampling is off, so the per-frame face budget check no longer iterates every tick state.

Subtick sampling and reach lines still force a full rebuild, deliberately: subtick walk lengths change on resim and shift every downstream offset, and reach line re-emits raycast the world per tick.

## Arrows and the 3D boxes (also asked in the report)

Audited both: the tick boxes and the facing arrows were already covered by the tail patch (`patchTail` rewrites the main and arrow slices, and the gate has no clause for them), so they never trigger the full-rebake path and do not cause this lag.

## Tests

- `TailPatchGateTest`: new coverage that a matching hitbox layout (4 and 12 edges) allows the patch, a mismatched layout or subtick sampling still forces a rebuild.
- `TailPatchEquivalenceTest`: new `hitboxTailPatchMatchesFullRebake` verifies the spliced main+hitbox+arrow buffer equals a full rebake for both floor outline and full wireframe.
- `GizmoDragConstraintBench` (env-gated, `PKC_BENCH=1`): patch emission now includes the hitbox slice and a full-hitbox scenario was added.

`./gradlew :core:test` and `:core:tableStyleCheck` are green locally. The loader-side changes could not be compiled in this sandbox (the MC maven repositories are unreachable from it), so CI's full build is the compile gate for those; they mirror the existing `patchBox` hitbox writes line for line. Not yet QA'd in-game on a loader; #276's measurements for the identical constraint-plate case were 16.1 ms/frame emission before vs 0.8 ms after.