### PR TITLE
feat: right click teleport to the selected tick, singleplayer only

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/PlaybackController.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/PlaybackController.java
@@ -123,6 +123,17 @@ public final class PlaybackController {
         return "";
     }
 
+    public boolean canTeleportToTick() {
+        return bridge != null && bridge.isSingleplayer() && !running;
+    }
+
+    public boolean teleportToTick(Vec3dCore pos, float yaw, float pitch) {
+        if (!canTeleportToTick()) return false;
+        bridge.teleport(pos, Vec3dCore.ZERO, yaw, null);
+        bridge.setPitch(pitch);
+        return true;
+    }
+
     public void start() {
         StartRange range = startRangeResolver != null ? startRangeResolver.get() : null;
         if (range == null) {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputOverlay.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputOverlay.java
@@ -67,6 +67,7 @@ public final class InputOverlay {
     private static final float AMP_COLUMN_WIDTH = 120;
 
     private static final String MENU_SET_TO_PLAYER = "Set to user position";
+    private static final String MENU_TELEPORT_TO_TICK = "Teleport player to tick %d";
     private static final String LABEL_ROWS = "Rows:";
     private static final String MENU_ADD_AT_END = "Add %d row(s) at end";
     private static final String MENU_ADD_ABOVE = "Add %d row(s) above";
@@ -1289,6 +1290,7 @@ public final class InputOverlay {
             onSetPlayerPosition.run();
             notifyFullResim();
         }
+        renderTeleportToTickOption();
         renderApplyPotionOptions();
         renderYawLockOption();
         renderPitchLockOption();
@@ -1297,6 +1299,17 @@ public final class InputOverlay {
         renderDeleteOption();
 
         ImGui.endPopup();
+    }
+
+    private void renderTeleportToTickOption() {
+        if (playback == null || boxController == null || !playback.canTeleportToTick()) return;
+        int row = selection.singleSelectedRow();
+        if (row < 0) return;
+        TickState state = boxController.getState(row);
+        if (state == null) return;
+        if (contextButton(String.format(MENU_TELEPORT_TO_TICK, row + 1))) {
+            playback.teleportToTick(state.position, state.yaw, boxController.getPitch(row));
+        }
     }
 
     private void renderYawLockOption() {

--- a/core/src/test/java/de/legoshi/parkourcalc/core/FakePlaybackBridge.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/FakePlaybackBridge.java
@@ -18,6 +18,7 @@ public class FakePlaybackBridge implements PlaybackBridge {
     public Vec3dCore teleportVel;
     public float teleportYaw;
     public Checkpoint teleportCarry;
+    public float pitch;
     public final Map<InputRow.Key, Boolean> keys = new EnumMap<InputRow.Key, Boolean>(InputRow.Key.class);
 
     @Override public boolean isSingleplayer() { return true; }
@@ -34,6 +35,7 @@ public class FakePlaybackBridge implements PlaybackBridge {
 
     @Override public void setKey(InputRow.Key key, boolean pressed) { keys.put(key, pressed); }
     @Override public void setYaw(float absoluteYaw) { }
+    @Override public void setPitch(float absolutePitch) { pitch = absolutePitch; }
     @Override public void releaseAllKeys() { releaseAllCalls++; keys.clear(); }
     @Override public void suppressFlight() { suppressFlightCalls++; }
     @Override public void closeUI() { }

--- a/core/src/test/java/de/legoshi/parkourcalc/core/TickTeleportTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/TickTeleportTest.java
@@ -1,0 +1,87 @@
+package de.legoshi.parkourcalc.core;
+
+import de.legoshi.parkourcalc.core.sim.SimulationRunner;
+import de.legoshi.parkourcalc.core.sim.Vec3dCore;
+import de.legoshi.parkourcalc.core.ui.InputData;
+import de.legoshi.parkourcalc.core.ui.InputRow;
+import de.legoshi.parkourcalc.core.ui.Settings;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class TickTeleportTest {
+
+    private static InputData rows(int n) {
+        InputData data = new InputData();
+        for (int i = 0; i < n; i++) {
+            data.getRows().add(new InputRow());
+        }
+        return data;
+    }
+
+    private static PlaybackController controller(FakePlaybackBridge bridge, InputData data) {
+        PlaybackController pc = new PlaybackController(data, new SimulationRunner(new FakeSimulator()), new Settings());
+        if (bridge != null) pc.setBridge(bridge);
+        return pc;
+    }
+
+    @Test
+    public void teleportsToTheGivenTickStateWithZeroVelocityAndNoCarry() {
+        FakePlaybackBridge bridge = new FakePlaybackBridge();
+        PlaybackController pc = controller(bridge, rows(3));
+
+        Vec3dCore pos = new Vec3dCore(12.5, 65.0, -3.25);
+        assertTrue(pc.canTeleportToTick());
+        assertTrue(pc.teleportToTick(pos, 135f, -20f));
+
+        assertEquals(1, bridge.teleportCalls);
+        assertEquals(pos, bridge.teleportPos);
+        assertEquals(Vec3dCore.ZERO, bridge.teleportVel);
+        assertEquals(135f, bridge.teleportYaw, 0f);
+        assertNull("plain teleport carries no checkpoint state", bridge.teleportCarry);
+        assertEquals(-20f, bridge.pitch, 0f);
+    }
+
+    @Test
+    public void multiplayerBlocksTeleportEvenWhenCalledDirectly() {
+        FakePlaybackBridge bridge = new FakePlaybackBridge() {
+            @Override
+            public boolean isSingleplayer() {
+                return false;
+            }
+        };
+        PlaybackController pc = controller(bridge, rows(3));
+
+        assertFalse(pc.canTeleportToTick());
+        assertFalse(pc.teleportToTick(new Vec3dCore(1, 2, 3), 0f, 0f));
+        assertEquals("the bridge must never see a multiplayer teleport", 0, bridge.teleportCalls);
+    }
+
+    @Test
+    public void missingBridgeBlocksTeleport() {
+        PlaybackController pc = controller(null, rows(3));
+        assertFalse(pc.canTeleportToTick());
+        assertFalse(pc.teleportToTick(new Vec3dCore(1, 2, 3), 0f, 0f));
+    }
+
+    @Test
+    public void runningPlaybackBlocksTeleport() {
+        FakePlaybackBridge bridge = new FakePlaybackBridge();
+        InputData data = rows(4);
+        PlaybackController pc = controller(bridge, data);
+
+        pc.start(0, data.size(), Vec3dCore.ZERO, Vec3dCore.ZERO, 0f);
+        assertTrue(pc.isRunning());
+        assertEquals(1, bridge.teleportCalls);
+
+        assertFalse(pc.canTeleportToTick());
+        assertFalse(pc.teleportToTick(new Vec3dCore(1, 2, 3), 0f, 0f));
+        assertEquals(1, bridge.teleportCalls);
+
+        pc.stop();
+        assertTrue(pc.canTeleportToTick());
+    }
+}


### PR DESCRIPTION
Closes #303

## What it does

With a single tick selected, the input table's right click context menu gains a "Teleport player to tick N" entry (in the position segment, right under "Set to user position"). Clicking it teleports the player to that tick's pre-tick position, with the tick's entering facing and pitch, zero velocity and no checkpoint carry. The tick-to-state mapping is the same one playback and the tick info panel use: row r shows `boxController.getState(r)`, the state at the start of Tick r+1.

## Singleplayer only, both checks

- Secondary check (visibility): the menu entry only renders when `PlaybackBridge.isSingleplayer()` is true, the strict check that also excludes a LAN-published integrated server, the same one playback start uses.
- Active check: `PlaybackController.teleportToTick` re-validates `canTeleportToTick()` before touching the bridge and returns false otherwise, so nothing can trigger a teleport on multiplayer even if called directly. This matters doubly because the bridges' multiplayer `teleport` path spawns the ghost playback entity; the guard keeps that path unreachable from this feature.
- Playback in progress also hides and blocks the entry so a teleport can never fight the replay's own teleport.

## How it's wired

No new port and no loader changes: the `PlaybackBridge.teleport(...)` implementations that already exist in all three loaders (integrated-server thread teleport plus client sync) do the work. `PlaybackController` exposes `canTeleportToTick()` / `teleportToTick(pos, yaw, pitch)`, and `InputOverlay` renders the menu entry through the `PlaybackController` it already holds.

## Tests

New `TickTeleportTest` covers: teleporting passes the tick state with zero velocity and no carry and sets pitch; a multiplayer bridge is never called; a missing bridge and running playback both block; teleporting is allowed again after playback stops. `./gradlew :core:test` and `:core:tableStyleCheck` are green locally (this sandbox cannot reach the MC maven repositories, so CI's full build is the loader compile gate, though this change touches no loader code).