### PR TITLE
fix: derive B-key constraints from the looked-at block's own hitbox

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/ports/MinecraftAccess.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ports/MinecraftAccess.java
@@ -62,6 +62,10 @@ public interface MinecraftAccess {
         return Collections.emptyList();
     }
 
+    default List<AABB> getBlockCollisionBoxes(int x, int y, int z) {
+        return getCollisionBoxes(x, y, z, x, y, z);
+    }
+
     default double getEyeHeight(boolean sneaking) {
         return 1.62;
     }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/ConstraintKeyController.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/ConstraintKeyController.java
@@ -77,7 +77,7 @@ public final class ConstraintKeyController {
             } else {
                 Vec3dCore hit = mc.getLookedAtHitVec();
                 if (hit == null) return;
-                List<AABB> boxes = mc.getCollisionBoxes(bx, by, bz, bx, by, bz);
+                List<AABB> boxes = mc.getBlockCollisionBoxes(bx, by, bz);
                 state.putScalarReplacingDirection(tick, ConstraintDeriver.deriveWall(face, boxes, hit, enter));
             }
         } else {
@@ -104,7 +104,7 @@ public final class ConstraintKeyController {
     }
 
     private AABB supportBox(int bx, int by, int bz, Vec3dCore hit) {
-        List<AABB> boxes = mc.getCollisionBoxes(bx, by, bz, bx, by, bz);
+        List<AABB> boxes = mc.getBlockCollisionBoxes(bx, by, bz);
         AABB best = null;
         double bestGap = Double.POSITIVE_INFINITY;
         for (AABB b : boxes) {

--- a/core/src/test/java/de/legoshi/parkourcalc/core/FakeMinecraftAccess.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/FakeMinecraftAccess.java
@@ -6,16 +6,26 @@ import de.legoshi.parkourcalc.core.sim.Face;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
 
 public class FakeMinecraftAccess implements MinecraftAccess {
 
     public final List<AABB> worldBoxes = new ArrayList<>();
+    public final Map<List<Integer>, List<AABB>> blockBoxes = new HashMap<>();
     public int[] lookedAtBlock;
     public Face lookedAtFace;
     public Vec3dCore lookedAtHitVec;
     public boolean ready = true;
+
+    public void addBlock(int x, int y, int z, AABB... boxes) {
+        List<AABB> own = new ArrayList<>(Arrays.asList(boxes));
+        blockBoxes.put(Arrays.asList(x, y, z), own);
+        worldBoxes.addAll(own);
+    }
 
     @Override public Vec3dCore getPlayerPosition() { return Vec3dCore.ZERO; }
     @Override public float getPlayerYaw() { return 0f; }
@@ -36,6 +46,13 @@ public class FakeMinecraftAccess implements MinecraftAccess {
             }
         }
         return out;
+    }
+
+    @Override
+    public List<AABB> getBlockCollisionBoxes(int x, int y, int z) {
+        List<AABB> own = blockBoxes.get(Arrays.asList(x, y, z));
+        if (own != null) return new ArrayList<>(own);
+        return MinecraftAccess.super.getBlockCollisionBoxes(x, y, z);
     }
 
     @Override public boolean isMousePressedLeft() { return false; }

--- a/core/src/test/java/de/legoshi/parkourcalc/ui/ConstraintKeyControllerTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/ui/ConstraintKeyControllerTest.java
@@ -107,4 +107,22 @@ public class ConstraintKeyControllerTest {
         assertEquals(Constraint.Op.GE, wall.getOp());
         assertEquals("wall sits on the inset collision face, not the outline hit", 5.9375 + HALF, wall.getValue(), EPS);
     }
+
+    @Test
+    public void footprintOnASlabUsesTheSlabNotTheWallProtrudingFromBelow() {
+        mc.addBlock(5, 63, 8, box(5.25, 63.0, 8.25, 5.75, 64.5, 8.75));
+        mc.addBlock(5, 64, 8, box(5.0, 64.0, 8.0, 6.0, 64.5, 9.0));
+        mc.lookedAtBlock = new int[] {5, 64, 8};
+        mc.lookedAtFace = Face.POS_Y;
+        mc.lookedAtHitVec = new Vec3dCore(5.5, 64.5, 8.5);
+
+        controller.onKey(false, false);
+
+        Constraint x = range(Constraint.Field.X);
+        assertEquals("slab footprint, not the wall's narrow cross-section", 5 - HALF, x.getLo(), EPS);
+        assertEquals(6 + HALF, x.getHi(), EPS);
+        Constraint z = range(Constraint.Field.Z);
+        assertEquals(8 - HALF, z.getLo(), EPS);
+        assertEquals(9 + HALF, z.getHi(), EPS);
+    }
 }

--- a/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/FabricMinecraftAccess.java
+++ b/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/FabricMinecraftAccess.java
@@ -166,6 +166,20 @@ public final class FabricMinecraftAccess implements MinecraftAccess {
         return out;
     }
 
+    @Override
+    public List<AABB> getBlockCollisionBoxes(int x, int y, int z) {
+        List<AABB> out = new ArrayList<>();
+        ClientLevel world = Minecraft.getInstance().level;
+        if (world == null) return out;
+        BlockPos pos = new BlockPos(x, y, z);
+        for (net.minecraft.world.phys.AABB bb : world.getBlockState(pos).getCollisionShape(world, pos).toAabbs()) {
+            out.add(new AABB(
+                    new Vec3dCore(x + bb.minX, y + bb.minY, z + bb.minZ),
+                    new Vec3dCore(x + bb.maxX, y + bb.maxY, z + bb.maxZ)));
+        }
+        return out;
+    }
+
     private static Face toFace(Direction side) {
         if (side == null) return null;
         switch (side) {

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricMinecraftAccess.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricMinecraftAccess.java
@@ -166,6 +166,20 @@ public final class FabricMinecraftAccess implements MinecraftAccess {
         return out;
     }
 
+    @Override
+    public List<AABB> getBlockCollisionBoxes(int x, int y, int z) {
+        List<AABB> out = new ArrayList<>();
+        ClientLevel world = Minecraft.getInstance().level;
+        if (world == null) return out;
+        BlockPos pos = new BlockPos(x, y, z);
+        for (net.minecraft.world.phys.AABB bb : world.getBlockState(pos).getCollisionShape(world, pos).toAabbs()) {
+            out.add(new AABB(
+                    new Vec3dCore(x + bb.minX, y + bb.minY, z + bb.minZ),
+                    new Vec3dCore(x + bb.maxX, y + bb.maxY, z + bb.maxZ)));
+        }
+        return out;
+    }
+
     private static Face toFace(Direction side) {
         if (side == null) return null;
         switch (side) {

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12MinecraftAccess.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12MinecraftAccess.java
@@ -154,6 +154,21 @@ public final class Forge12MinecraftAccess implements MinecraftAccess {
         return out;
     }
 
+    @Override
+    public List<AABB> getBlockCollisionBoxes(int x, int y, int z) {
+        List<AABB> out = new ArrayList<>();
+        World world = Minecraft.getMinecraft().world;
+        if (world == null) return out;
+        BlockPos pos = new BlockPos(x, y, z);
+        AxisAlignedBB mask = new AxisAlignedBB(x - 1.0, y - 1.0, z - 1.0, x + 2.0, y + 2.0, z + 2.0);
+        List<AxisAlignedBB> boxes = new ArrayList<>();
+        world.getBlockState(pos).addCollisionBoxToList(world, pos, mask, boxes, null, false);
+        for (AxisAlignedBB bb : boxes) {
+            out.add(new AABB(new Vec3dCore(bb.minX, bb.minY, bb.minZ), new Vec3dCore(bb.maxX, bb.maxY, bb.maxZ)));
+        }
+        return out;
+    }
+
     private static Face toFace(EnumFacing side) {
         if (side == null) return null;
         switch (side) {

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8MinecraftAccess.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8MinecraftAccess.java
@@ -166,6 +166,22 @@ public final class Forge8MinecraftAccess implements MinecraftAccess {
         return out;
     }
 
+    @Override
+    public List<AABB> getBlockCollisionBoxes(int x, int y, int z) {
+        List<AABB> out = new ArrayList<>();
+        World world = Minecraft.getMinecraft().theWorld;
+        if (world == null) return out;
+        BlockPos pos = new BlockPos(x, y, z);
+        IBlockState state = world.getBlockState(pos);
+        AxisAlignedBB mask = new AxisAlignedBB(x - 1.0, y - 1.0, z - 1.0, x + 2.0, y + 2.0, z + 2.0);
+        List<AxisAlignedBB> boxes = new ArrayList<>();
+        state.getBlock().addCollisionBoxesToList(world, pos, state, mask, boxes, null);
+        for (AxisAlignedBB bb : boxes) {
+            out.add(new AABB(new Vec3dCore(bb.minX, bb.minY, bb.minZ), new Vec3dCore(bb.maxX, bb.maxY, bb.maxZ)));
+        }
+        return out;
+    }
+
     private static Face toFace(EnumFacing side) {
         if (side == null) return null;
         switch (side) {


### PR DESCRIPTION
Closes #308

Pressing the B constraint hotkey on a slab placed on top of a cobble wall applied the constraint to the wall's hitbox instead of the slab's.

Cause: `ConstraintKeyController.supportBox` picked its support box from `getCollisionBoxes` over the looked-at cell, which is a world region query. A wall's collision box is 1.5 blocks tall and protrudes into the slab's cell with the exact same top height (1.5) as the slab, so the closest-top tie broke toward whichever box the world enumerated first, the wall. The footprint then derived from the wall's narrow cross-section.

Fix: `MinecraftAccess` gains `getBlockCollisionBoxes(x, y, z)`, the collision boxes of that block only, matching the block the raycast actually hit. All four loaders implement it (both Fabric loaders via `BlockState.getCollisionShape`, Forge 1.8.9 via `Block.addCollisionBoxesToList`, Forge 1.12.2 via `IBlockState.addCollisionBoxToList`), and `ConstraintKeyController` uses it for the footprint support box and the side-face wall derivation. This also means `mergeCoplanarSupport` now merges within the looked-at block's own shape, which is what the shelf and stair scenarios already exercise. Neighbor-aware queries (obstacle clipping, ladder cell) still use the region query as before.

Test: `FakeMinecraftAccess` gains per-block box ownership, and `ConstraintKeyControllerTest` gets a slab-over-wall case asserting the footprint derives from the slab box. `:core:test` is green (129 test classes).

Note: the loader modules could not be compiled in this session's environment (the Fabric/Forge maven hosts are blocked by its network policy); the loader overrides mirror the API usage of the existing `getCollisionBoxes` implementations in the same files. An in-game QA pass on the touched loaders is still needed per the contribution flow.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GZuXo4mR8k1CdtAz7ovqUZ)_