### PR TITLE
fix: keep the simulator's player size consistent across resumed runs

### DIFF
--- a/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/sim/SimulatorEntity.java
+++ b/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/sim/SimulatorEntity.java
@@ -410,6 +410,8 @@ public class SimulatorEntity extends Player {
         c.playerInput = this.input.keyPresses;
         c.jumpingCooldown = this.noJumpDelay;
         c.movementMultiplier = this.stuckSpeedMultiplier;
+        c.pose = this.getPose();
+        c.crouching = this.crouching;
         return c;
     }
 
@@ -417,6 +419,9 @@ public class SimulatorEntity extends Player {
         // Start from the clean spawn baseline (same as a full run's resetToStart) so no uncaptured
         // entity state from the previous run leaks in; the overlay below restores the history it carries.
         resetPlayer();
+        this.crouching = c.crouching;
+        this.setPose(c.pose);
+        this.refreshDimensions();
         this.setPos(c.pos);
         this.setDeltaMovement(c.velocity);
         this.setYRot(c.yaw);
@@ -453,5 +458,7 @@ public class SimulatorEntity extends Player {
         Input playerInput;
         int jumpingCooldown;
         Vec3 movementMultiplier;
+        Pose pose;
+        boolean crouching;
     }
 }

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/sim/SimulatorEntity.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/sim/SimulatorEntity.java
@@ -433,6 +433,8 @@ public class SimulatorEntity extends Player {
         c.playerInput = this.input.keyPresses;
         c.jumpingCooldown = this.noJumpDelay;
         c.movementMultiplier = this.stuckSpeedMultiplier;
+        c.pose = this.getPose();
+        c.crouching = this.crouching;
         return c;
     }
 
@@ -440,6 +442,9 @@ public class SimulatorEntity extends Player {
         // Start from the clean spawn baseline (same as a full run's resetToStart) so no uncaptured
         // entity state from the previous run leaks in; the overlay below restores the history it carries.
         resetPlayer();
+        this.crouching = c.crouching;
+        this.setPose(c.pose);
+        this.refreshDimensions();
         this.setPos(c.pos);
         this.setDeltaMovement(c.velocity);
         this.setYRot(c.yaw);
@@ -476,5 +481,7 @@ public class SimulatorEntity extends Player {
         Input playerInput;
         int jumpingCooldown;
         Vec3 movementMultiplier;
+        Pose pose;
+        boolean crouching;
     }
 }

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/sim/SimulatorEntity.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/sim/SimulatorEntity.java
@@ -83,6 +83,8 @@ public class SimulatorEntity extends EntityPlayer {
     public void resetPlayer() {
         this.noClip = true;
         this.setHealth(this.getMaxHealth());
+        this.setSneaking(false);
+        this.setSize(0.6F, 1.8F);
         this.motionX = 0.0;
         this.motionY = 0.0;
         this.motionZ = 0.0;
@@ -309,6 +311,8 @@ public class SimulatorEntity extends EntityPlayer {
         c.landMovementFactor = this.getAIMoveSpeed();
         c.jumpTicks = this.jumpTicks;
         c.isInWeb = this.isInWeb;
+        c.width = this.width;
+        c.height = this.height;
         return c;
     }
 
@@ -329,6 +333,8 @@ public class SimulatorEntity extends EntityPlayer {
         this.setAIMoveSpeed(c.landMovementFactor);
         this.jumpTicks = c.jumpTicks;
         this.isInWeb = c.isInWeb;
+        this.width = c.width;
+        this.height = c.height;
         this.setPosition(c.posX, c.posY, c.posZ);
     }
 
@@ -359,5 +365,7 @@ public class SimulatorEntity extends EntityPlayer {
         float landMovementFactor;
         int jumpTicks;
         boolean isInWeb;
+        float width;
+        float height;
     }
 }


### PR DESCRIPTION
Closes #278

Changing a sneak input and then reverting it produced a different final tick position than the original run (reported on Forge 1.12.2, snow layers with a cobweb two blocks above; the same gap exists on both Fabric loaders).

Cause: `SimulationRunner.simulateFrom` resumes from a per-tick checkpoint, but the checkpoints did not carry the sneak-dependent hitbox state, so a resume that landed on a mid-sneak tick replayed with a standing hitbox and diverged from the continuous run. Reverting the edit then could not reproduce the original result.

**Forge 1.12.2** (`loader-forge-1.12.2/.../sim/SimulatorEntity.java`): sneaking shrinks the player from 1.8 to 1.65 blocks tall via `EntityPlayer.updateSize`, and the checkpoint did not carry `Entity.width`/`height`. In the reported setup that exact difference decides whether the head clips the cobweb.
- `saveCheckpoint` captures `width` and `height`.
- `restoreCheckpoint` reapplies them before `setPosition` rebuilds the bounding box.
- `resetPlayer` normalizes to `setSneaking(false)` + `setSize(0.6F, 1.8F)` before the settle ticks, so a full re-run never inherits the previous run's sneak size.

**Fabric, both loaders** (`loader-fabric/.../sim/SimulatorEntity.java`, `loader-fabric-1.21.3/.../sim/SimulatorEntity.java`): the pose set at the end of the previous tick decides the hitbox (1.8 standing, 1.5 crouching) used for the next tick's collisions, and neither the pose nor the mirrored `LocalPlayer` crouching flag was captured.
- `saveCheckpoint` captures the pose and the `crouching` flag.
- `restoreCheckpoint` reapplies them and calls `refreshDimensions()` before `setPos`, so the resumed entity collides with the same volume the continuous run had.
- No `resetPlayer` change needed: `updatePlayerPose` recomputes the pose absolutely each tick, so the settle ticks already normalize it.

Forge 1.8.9 is unaffected: sneaking does not change the hitbox there (that behavior started in 1.9).

Note: the loader modules could not be compiled in this session's environment (the Fabric/Forge maven hosts are blocked by its network policy). The 1.12.2 change only touches fields and methods already used by the surrounding code plus the standard `Entity.setSize`/`width`/`height` members; the Fabric changes use `getPose`/`setPose`/`refreshDimensions`, stable mojmap `Entity` methods, alongside the `Pose` enum both files already import. An in-game QA pass on the touched loaders with the issue's repro is still needed per the contribution flow.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GZuXo4mR8k1CdtAz7ovqUZ)_