### PR TITLE
fix(solver): stop dumping a full save snapshot per solve

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
@@ -198,9 +198,6 @@ public final class Application {
         if (saveStore != null) {
             angleSolverEngine.setRunLog(new SolveRunLog(saveStore.getSaveDir().resolve("runs"),
                     saveStore.getModVersion(), saveStore.getMcVersion()));
-            angleSolverEngine.setProblemSnapshotSource(() -> SaveIO.snapshotJson(saveStore, inputData,
-                    runner.getStartPosition(), runner.getStartVelocity(), runner.getStartYaw(), runner.getStartPitch(),
-                    runner.getStartResumeState(), angleSolverState, boxController.getStates()));
         }
         saveController.setSolverEngine(angleSolverEngine);
         undoController = new UndoController<>(

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/AngleSolverEngine.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/AngleSolverEngine.java
@@ -181,14 +181,9 @@ public final class AngleSolverEngine {
     private volatile SolveRunLog runLog;
     private volatile RunRecording recording;
     private volatile SolveRunRecord lastRunRecord;
-    private volatile java.util.function.Supplier<String> problemSnapshotSource;
 
     public void setRunLog(SolveRunLog log) {
         this.runLog = log;
-    }
-
-    public void setProblemSnapshotSource(java.util.function.Supplier<String> source) {
-        this.problemSnapshotSource = source;
     }
 
     public SolveRunRecord lastRunRecord() {
@@ -517,11 +512,6 @@ public final class AngleSolverEngine {
                 SolveRunRecord.problemOf(job.spec, countJumps(job.spec.asScenario())),
                 progress, t0);
         recording = rec;
-        SolveRunLog log = runLog;
-        java.util.function.Supplier<String> snapshot = problemSnapshotSource;
-        if (log != null && snapshot != null && log.needsProblem(rec.problem.hash)) {
-            log.writeProblem(rec.problem.hash, snapshot.get());
-        }
         solving = true;
         Thread worker = new Thread(() -> {
             try {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/SolveRunLog.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/SolveRunLog.java
@@ -7,15 +7,12 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.HashSet;
-import java.util.Set;
 
 public final class SolveRunLog {
 
     private final Path runsDir;
     private final String modVersion;
     private final String mcVersion;
-    private final Set<String> dumpedProblems = new HashSet<String>();
 
     public SolveRunLog(Path runsDir, String modVersion, String mcVersion) {
         this.runsDir = runsDir;
@@ -25,29 +22,6 @@ public final class SolveRunLog {
 
     public Path getRunsDir() {
         return runsDir;
-    }
-
-    public synchronized boolean needsProblem(String hash) {
-        if (hash == null) return false;
-        if (dumpedProblems.contains(hash)) return false;
-        return !Files.isRegularFile(problemFile(hash));
-    }
-
-    public synchronized void writeProblem(String hash, String json) {
-        if (hash == null || json == null) return;
-        try {
-            Path file = problemFile(hash);
-            Files.createDirectories(file.getParent());
-            if (!Files.isRegularFile(file)) {
-                Files.write(file, json.getBytes(StandardCharsets.UTF_8));
-            }
-            dumpedProblems.add(hash);
-        } catch (IOException ignored) {
-        }
-    }
-
-    private Path problemFile(String hash) {
-        return runsDir.resolve("problems").resolve(hash + ".json");
     }
 
     public synchronized void append(SolveRunRecord record) {

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/graph/SolveRunRecordTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/graph/SolveRunRecordTest.java
@@ -184,22 +184,6 @@ public class SolveRunRecordTest {
         assertTrue(back.finishedEpochMs > 0);
     }
 
-    @Test
-    public void problemDumpWritesOncePerHash() throws IOException {
-        Path dir = tmp.newFolder("runs2").toPath();
-        SolveRunLog log = new SolveRunLog(dir, "1.7.0", "26.2");
-        assertTrue(log.needsProblem("abc123"));
-        log.writeProblem("abc123", "{\"v\":1}");
-        assertFalse(log.needsProblem("abc123"));
-        Path file = dir.resolve("problems").resolve("abc123.json");
-        assertTrue(Files.isRegularFile(file));
-        log.writeProblem("abc123", "{\"v\":2}");
-        assertEquals("{\"v\":1}", new String(Files.readAllBytes(file), StandardCharsets.UTF_8));
-        SolveRunLog fresh = new SolveRunLog(dir, "1.7.0", "26.2");
-        assertFalse(fresh.needsProblem("abc123"));
-        assertFalse(log.needsProblem(null));
-    }
-
     private static SolveRunRecord sampleRecord() {
         SolverGraph graph = BuiltinGraphs.fast();
         JumpSpec spec = TestScenarios.spec(12, null);


### PR DESCRIPTION
Supersedes #302, which GitHub auto-closed when its `claude/*` head branch was renamed; same change, now rebased onto `dev` on a properly named branch.

The solve telemetry wrote a complete save-file snapshot to `parkourcalculator/runs/problems/<hash>.json` on every solve whose problem hash it had not seen before. On a real install this reached **11 GB**.

## Why the dedup never fired

`SolveRunRecord.problemHash` mixes in `startPos.x/z`, `startYaw` and `initialVelocity.x/z` at full `doubleToLongBits` precision, plus the start box bounds and every constraint RHS. The seed start state is read back from the previous trajectory (`SaveIO.java` reads `states.get(startTick)`), so a normal solve to Apply to solve loop changes the seed every iteration, which changes the hash every iteration, which writes a fresh pretty-printed snapshot. Nudging the start box does the same. The one workflow the dedup was meant to cover is the one where it never applies.

## Why the folder can go

Nothing ever read it back. `SolveRunLog` only had `needsProblem` (an existence check) and `writeProblem`; `getRunsDir()` had no non-test callers. It existed so a `runs/*.jsonl` record stayed reproducible after the inputs moved on, feeding the learned preset-selector dataset that the run matrix ruled out (VBS-SBS gap zero on feasibility, L2 marked NO-GO in `solver-graph-learning-survey.md`). Clicking Solve reproduces the current problem anyway.

## What changed

- `SolveRunLog`: removed `needsProblem`, `writeProblem`, `problemFile`, and the `dumpedProblems` set. It is now purely the jsonl appender.
- `AngleSolverEngine`: removed the `problemSnapshotSource` field, its setter, and the dump call before the solver worker spawns.
- `Application`: removed the `setProblemSnapshotSource(...)` wiring.
- `SolveRunRecordTest`: removed `problemDumpWritesOncePerHash`; the jsonl round-trip coverage stays.

55 lines deleted, none added.

## What is deliberately untouched

The `runs/<yyyy-MM-dd>.jsonl` run log still records one line per solve. The solver window's live stats never touched disk in the first place: they read the in-memory `SolveRunRecord` via `engine.lastRunRecord()`, `engine.elapsedSeconds()`, and `GraphRunState` for per-node visits and timings. Constraints live in the save files. Deleting an existing `problems/` directory has no effect on any of that.

Existing `problems/` directories are inert and safe to delete by hand.

## Testing

Rebased onto current `dev`; the conflicts were pure deletions against #294's `startResumeState` additions to the snapshot-source wiring and resolved by removing the block, as the original change intended. Full local suite `:core:test -PslowTests` is green.
