### PR TITLE
fix(playback): pin first-person arm sway to the driven rotation

### DIFF
--- a/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/sim/FabricSimulator.java
+++ b/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/sim/FabricSimulator.java
@@ -4,6 +4,7 @@ import de.legoshi.parkourcalc.core.anglesolver.Medium;
 import de.legoshi.parkourcalc.core.sim.ChunkRange;
 import de.legoshi.parkourcalc.core.sim.Checkpoint;
 import de.legoshi.parkourcalc.core.sim.LazyEntitySimulator;
+import de.legoshi.parkourcalc.core.sim.StartResumeState;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.InputRow;
 import net.minecraft.client.Minecraft;
@@ -11,6 +12,7 @@ import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
+import net.minecraft.world.entity.player.Input;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
@@ -47,8 +49,34 @@ public final class FabricSimulator extends LazyEntitySimulator<SimulatorEntity> 
         return new SimulatorEntity(simWorld, player.getGameProfile(), start, vel, yaw);
     }
 
-    @Override protected void resetEntity(SimulatorEntity e) {
-        e.resetPlayer();
+    @Override protected void resetEntity(SimulatorEntity e, StartResumeState resume) {
+        e.resetPlayer(resume);
+    }
+
+    @Override
+    protected StartResumeState describeResume(Checkpoint checkpoint) {
+        if (!(checkpoint instanceof SimulatorEntity.Checkpoint c)) return null;
+        StartResumeState r = new StartResumeState();
+        r.onGround = c.onGround;
+        r.wallContact = c.horizontalCollision;
+        r.softWallContact = c.collidedSoftly;
+        r.sprinting = c.sprinting;
+        r.sprintWindow = c.ticksLeftToDoubleTapSprint;
+        r.jumpCooldown = c.jumpingCooldown;
+        if (c.movementMultiplier != null && c.movementMultiplier.lengthSqr() > 1.0E-7) {
+            r.stuckMultiplier = new Vec3dCore(c.movementMultiplier.x, c.movementMultiplier.y, c.movementMultiplier.z);
+        }
+        Input held = c.playerInput;
+        if (held != null) {
+            if (held.forward()) r.heldLastTick.add(InputRow.Key.W);
+            if (held.backward()) r.heldLastTick.add(InputRow.Key.S);
+            if (held.left()) r.heldLastTick.add(InputRow.Key.A);
+            if (held.right()) r.heldLastTick.add(InputRow.Key.D);
+            if (held.jump()) r.heldLastTick.add(InputRow.Key.JUMP);
+            if (held.shift()) r.heldLastTick.add(InputRow.Key.SNEAK);
+            if (held.sprint()) r.heldLastTick.add(InputRow.Key.SPRINT);
+        }
+        return r;
     }
 
     @Override protected void setInput(SimulatorEntity e, InputRow row) {

--- a/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/sim/SimulatorEntity.java
+++ b/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/sim/SimulatorEntity.java
@@ -2,6 +2,7 @@ package de.legoshi.parkourcalc.fabric.sim;
 
 import com.mojang.authlib.GameProfile;
 import de.legoshi.parkourcalc.core.anglesolver.Medium;
+import de.legoshi.parkourcalc.core.sim.StartResumeState;
 import de.legoshi.parkourcalc.core.sim.SubtickPath;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.InputRow;
@@ -93,6 +94,10 @@ public class SimulatorEntity extends Player {
     }
 
     public void resetPlayer() {
+        resetPlayer(null);
+    }
+
+    public void resetPlayer(StartResumeState resume) {
         this.noPhysics = true;
         this.removeAllEffects();
         this.setHealth(this.getMaxHealth());
@@ -110,6 +115,29 @@ public class SimulatorEntity extends Player {
         this.tickMedium = null;
         this.tickGroundFriction = Double.NaN;
         this.tickSoulsandCells = 0;
+        if (resume != null) {
+            applyResume(resume);
+        }
+    }
+
+    private void applyResume(StartResumeState resume) {
+        this.setOnGround(resume.onGround);
+        this.horizontalCollision = resume.wallContact;
+        this.minorHorizontalCollision = resume.softWallContact;
+        this.setSprinting(resume.sprinting);
+        this.sprintTriggerTime = resume.sprintWindow;
+        this.noJumpDelay = resume.jumpCooldown;
+        this.stuckSpeedMultiplier = resume.stuckMultiplier != null
+                ? new Vec3(resume.stuckMultiplier.x, resume.stuckMultiplier.y, resume.stuckMultiplier.z)
+                : Vec3.ZERO;
+        this.input.keyPresses = new Input(
+                resume.heldLastTick.contains(InputRow.Key.W),
+                resume.heldLastTick.contains(InputRow.Key.S),
+                resume.heldLastTick.contains(InputRow.Key.A),
+                resume.heldLastTick.contains(InputRow.Key.D),
+                resume.heldLastTick.contains(InputRow.Key.JUMP),
+                resume.heldLastTick.contains(InputRow.Key.SNEAK),
+                resume.heldLastTick.contains(InputRow.Key.SPRINT));
     }
 
     @Override

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricPlaybackBridge.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricPlaybackBridge.java
@@ -203,6 +203,10 @@ public final class FabricPlaybackBridge implements PlaybackBridge {
         acc.pkc$setYRotLast(yaw);
         acc.pkc$setXRotLast(client.getXRot());
         acc.pkc$setPositionReminder(0);
+        client.yBob = yaw;
+        client.yBobO = yaw;
+        client.xBob = client.getXRot();
+        client.xBobO = client.getXRot();
     }
 
     @Override
@@ -234,6 +238,8 @@ public final class FabricPlaybackBridge implements PlaybackBridge {
         if (p == null) return;
         p.setYRot(absoluteYaw);
         p.yRotO = absoluteYaw;
+        p.yBob = absoluteYaw;
+        p.yBobO = absoluteYaw;
     }
 
     @Override
@@ -260,6 +266,8 @@ public final class FabricPlaybackBridge implements PlaybackBridge {
         if (p == null) return;
         p.setXRot(absolutePitch);
         p.xRotO = absolutePitch;
+        p.xBob = absolutePitch;
+        p.xBobO = absolutePitch;
     }
 
     @Override

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12PlaybackBridge.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12PlaybackBridge.java
@@ -207,6 +207,10 @@ public final class Forge12PlaybackBridge implements PlaybackBridge {
         client.lastReportedYaw = yaw;
         client.lastReportedPitch = client.rotationPitch;
         client.positionUpdateTicks = 0;
+        client.renderArmYaw = yaw;
+        client.prevRenderArmYaw = yaw;
+        client.renderArmPitch = client.rotationPitch;
+        client.prevRenderArmPitch = client.rotationPitch;
     }
 
     @Override
@@ -237,6 +241,8 @@ public final class Forge12PlaybackBridge implements PlaybackBridge {
         if (p == null) return;
         p.rotationYaw = absoluteYaw;
         p.prevRotationYaw = absoluteYaw;
+        p.renderArmYaw = absoluteYaw;
+        p.prevRenderArmYaw = absoluteYaw;
     }
 
     @Override
@@ -263,6 +269,8 @@ public final class Forge12PlaybackBridge implements PlaybackBridge {
         if (p == null) return;
         p.rotationPitch = absolutePitch;
         p.prevRotationPitch = absolutePitch;
+        p.renderArmPitch = absolutePitch;
+        p.prevRenderArmPitch = absolutePitch;
     }
 
     @Override

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8PlaybackBridge.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8PlaybackBridge.java
@@ -127,6 +127,10 @@ public final class Forge8PlaybackBridge implements PlaybackBridge {
         client.lastReportedYaw = yaw;
         client.lastReportedPitch = client.rotationPitch;
         client.positionUpdateTicks = 0;
+        client.renderArmYaw = yaw;
+        client.prevRenderArmYaw = yaw;
+        client.renderArmPitch = client.rotationPitch;
+        client.prevRenderArmPitch = client.rotationPitch;
     }
 
     private void beginGhostPlayback(Vec3dCore pos, Vec3dCore vel, float yaw, de.legoshi.parkourcalc.core.sim.Checkpoint carry) {
@@ -238,6 +242,8 @@ public final class Forge8PlaybackBridge implements PlaybackBridge {
         if (p == null) return;
         p.rotationYaw = absoluteYaw;
         p.prevRotationYaw = absoluteYaw;
+        p.renderArmYaw = absoluteYaw;
+        p.prevRenderArmYaw = absoluteYaw;
     }
 
     @Override
@@ -264,6 +270,8 @@ public final class Forge8PlaybackBridge implements PlaybackBridge {
         if (p == null) return;
         p.rotationPitch = absolutePitch;
         p.prevRotationPitch = absolutePitch;
+        p.renderArmPitch = absolutePitch;
+        p.prevRenderArmPitch = absolutePitch;
     }
 
     @Override


### PR DESCRIPTION
## Problem

During TAS playback the first-person arm drifts to the center of the screen and sticks there, or rotates out of view entirely, after fast turns or facings near +-180. Visual only; physics is unaffected.

## Root cause

`PlaybackController` writes yaw twice per tick: the raw bit-exact physics yaw before the tick, then the display yaw (short-way easing via `shortestDelta`) after the tick and each frame. A yaw-locked row crossing the +-180 seam leaves the two a multiple of 360 apart. Vanilla arm sway fields (`LocalPlayer.yBob/xBob` on Fabric, `EntityPlayerSP.renderArmYaw/renderArmPitch` on Forge) chase the raw yaw once per tick, and the arm renders tilted by `(viewYaw - swayYaw) * 0.1`, so each wrap is a permanent 36 degree arm offset that never converges. Teleports (playback start, right-click teleport-to-tick) additionally spin the arm for ~10 ticks while the sway crosses the raw yaw gap.

## Fix

All three loader bridges pin the arm sway fields to the rotation they write, in the non-ghost `setYaw`/`setPitch` and the singleplayer `teleport`. The pre-physics write makes the vanilla chase a no-op and the post-tick/per-frame writes carry the arm into display space, so no render ever sees the divergence. Trade-off: no vanilla arm drag during playback; the arm rigidly follows the eased view.

Client-sided replay was ruled out: its mouse path is already guarded on all loaders (Fabric cancels `turnPlayer`, Forge swaps in `FrozenMouseHelper`).

## Also: un-break dev CI (fabric-1.21.3 start.resume contract)

Every dev build since the #294 merge fails compiling `loader-fabric-1.21.3`: #294 added `describeResume` and the `StartResumeState` parameter on `LazyEntitySimulator.resetEntity` and updated the three original loaders, while #300 added the 1.21.3 loader against the old contract. The second commit ports the 26.2 implementations (`resetPlayer(StartResumeState)` + `applyResume`, two-arg `resetEntity`, `describeResume`).

## Testing

- `:core:test` fast suite green; all four loader builds green locally
- No loader test seam exists for MC render state; in-game QA: play a solver-applied TAS turning through south (facing crossing +-180), arm previously stuck mid-screen after the crossing, and right-click teleport to a mid-TAS tick previously spun the arm