### PR TITLE
ci: publish the fabric 1.21.3 jar to modrinth on release

### DIFF
--- a/.github/workflows/modrinth-backfill.yml
+++ b/.github/workflows/modrinth-backfill.yml
@@ -1,0 +1,45 @@
+name: modrinth-backfill
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'release tag whose fabric 1.21.3 jar should be published to Modrinth'
+        required: true
+        default: 'v1.9.0'
+
+permissions:
+  contents: read
+
+jobs:
+  backfill:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: derive version from tag
+        id: version
+        env:
+          TAG: ${{ inputs.tag }}
+        run: echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: download release asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release download "${{ inputs.tag }}" --repo "$GITHUB_REPOSITORY" --pattern "pkc-fabric-1.21.3-${{ steps.version.outputs.version }}.jar"
+
+      - name: fetch release changelog
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release view "${{ inputs.tag }}" --repo "$GITHUB_REPOSITORY" --json body --jq .body > changelog.md
+
+      - name: publish fabric 1.21.3 to modrinth
+        uses: Kir-Antipov/mc-publish@v3.3
+        with:
+          modrinth-id: Lxy4H4lS
+          modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
+          files: pkc-fabric-1.21.3-${{ steps.version.outputs.version }}.jar
+          name: ${{ steps.version.outputs.version }} (Fabric 1.21.3)
+          version: ${{ steps.version.outputs.version }}
+          version-type: ${{ contains(inputs.tag, '-') && 'beta' || 'release' }}
+          loaders: fabric
+          game-versions: '1.21.3'
+          changelog-file: changelog.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,19 @@ jobs:
           game-versions: '26.2'
           changelog-file: changelog.md
 
+      - name: publish fabric 1.21.3 to modrinth
+        uses: Kir-Antipov/mc-publish@v3.3
+        with:
+          modrinth-id: Lxy4H4lS
+          modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
+          files: loader-fabric-1.21.3/build/libs/pkc-fabric-1.21.3-${{ steps.version.outputs.version }}.jar
+          name: ${{ steps.version.outputs.version }} (Fabric 1.21.3)
+          version: ${{ steps.version.outputs.version }}
+          version-type: ${{ contains(github.ref_name, '-') && 'beta' || 'release' }}
+          loaders: fabric
+          game-versions: '1.21.3'
+          changelog-file: changelog.md
+
       - name: publish forge 1.8.9 to modrinth
         uses: Kir-Antipov/mc-publish@v3.3
         with:


### PR DESCRIPTION
## Problem

PR #300 added the 1.21.3 jar to the build artifacts and the GitHub release asset list, but no fourth mc-publish step was added to `release.yml`. Every release since then ships the jar on GitHub only; v1.9.0 is the first affected tag (4 GitHub assets, 3 Modrinth versions, `1.9.0 (Fabric 1.21.3)` missing).

## Changes

- `release.yml`: add the missing `publish fabric 1.21.3 to modrinth` step (name `X.Y.Z (Fabric 1.21.3)`, loader fabric, game version 1.21.3, same token and changelog wiring as the other three steps). Fixes all future releases.
- New `modrinth-backfill.yml`: `workflow_dispatch` with a `tag` input (default `v1.9.0`) that downloads the 1.21.3 jar and changelog from an existing GitHub release and publishes it to Modrinth. Needed because tags are immutable, so the v1.9.0 release run cannot be repeated.

## After merge

1. Run `gh workflow run modrinth-backfill.yml -f tag=v1.9.0` to backfill the missing 1.9.0 version.
2. Merge `main` back into `dev`.