### PR TITLE
feat: merge constraint bounding boxes with alt and fix saving keybind on fabric

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/AngleSolverState.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/AngleSolverState.java
@@ -496,6 +496,28 @@ public final class AngleSolverState {
         list.add(Constraint.range(Constraint.Field.Z, zLo, zHi, true, true));
     }
 
+    public void mergeFootprint(int tick, double xLo, double xHi, double zLo, double zHi) {
+        if (tick < 0) return;
+        List<Constraint> list = tickConstraints(tick).getConstraints();
+        double finalXLo = xLo, finalXHi = xHi;
+        double finalZLo = zLo, finalZHi = zHi;
+
+        for (int i = list.size() - 1; i >= 0; i--) {
+            Constraint c = list.get(i);
+            if (c.isRange() && !c.isRelative() && c.getField() == Constraint.Field.X) {
+                finalXLo = Math.min(finalXLo, c.getLo());
+                finalXHi = Math.max(finalXHi, c.getHi());
+                list.remove(i);
+            } else if (c.isRange() && !c.isRelative() && c.getField() == Constraint.Field.Z) {
+                finalZLo = Math.min(finalZLo, c.getLo());
+                finalZHi = Math.max(finalZHi, c.getHi());
+                list.remove(i);
+            }
+        }
+        list.add(Constraint.range(Constraint.Field.X, finalXLo, finalXHi, true, true));
+        list.add(Constraint.range(Constraint.Field.Z, finalZLo, finalZHi, true, true));
+    }
+
     public void clearFootprint(int tick) {
         TickConstraints tc = ticks.get(tick);
         if (tc == null) return;
@@ -510,6 +532,29 @@ public final class AngleSolverState {
         boolean lower = isLowerBound(wall.getOp());
         list.removeIf(c -> !c.isRange() && !c.isRelative() && c.getField() == field
                 && isWallOp(c.getOp()) && isLowerBound(c.getOp()) == lower);
+        list.add(wall);
+    }
+
+    public void mergeWall(int tick, Constraint wall) {
+        if (tick < 0 || wall == null) return;
+        List<Constraint> list = tickConstraints(tick).getConstraints();
+        Constraint.Field field = wall.getField();
+        boolean lower = isLowerBound(wall.getOp());
+        double finalVal = wall.getValue();
+
+        for (int i = list.size() - 1; i >= 0; i--) {
+            Constraint c = list.get(i);
+            if (!c.isRange() && !c.isRelative() && c.getField() == field
+                    && isWallOp(c.getOp()) && isLowerBound(c.getOp()) == lower) {
+                if (lower) {
+                    finalVal = Math.min(finalVal, c.getValue()); // mehr Platz bei >=
+                } else {
+                    finalVal = Math.max(finalVal, c.getValue()); // mehr Platz bei <=
+                }
+                list.remove(i);
+            }
+        }
+        wall.setValue(finalVal);
         list.add(wall);
     }
 

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/AngleSolverState.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/AngleSolverState.java
@@ -547,9 +547,9 @@ public final class AngleSolverState {
             if (!c.isRange() && !c.isRelative() && c.getField() == field
                     && isWallOp(c.getOp()) && isLowerBound(c.getOp()) == lower) {
                 if (lower) {
-                    finalVal = Math.min(finalVal, c.getValue()); // mehr Platz bei >=
+                    finalVal = Math.min(finalVal, c.getValue());
                 } else {
-                    finalVal = Math.max(finalVal, c.getValue()); // mehr Platz bei <=
+                    finalVal = Math.max(finalVal, c.getValue());
                 }
                 list.remove(i);
             }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ports/MinecraftAccess.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ports/MinecraftAccess.java
@@ -89,6 +89,11 @@ public interface MinecraftAccess {
     /** Either control key currently held. Polled directly, not via ImGui IO. */
     boolean isCtrlDown();
 
+    /** Either alt key currently held. Polled directly, not via ImGui IO. */
+    default boolean isAltDown()  {
+        return false;
+    }
+
     /** Whether the quick-save chord (Ctrl+S) is held right now. Loaders read their own raw keyboard
      *  (ImGui 1.86 exposes no portable letter-key ids), core edge-detects and saves (gh-107). */
     default boolean isSaveChordDown() {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/ConstraintKeyController.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/ConstraintKeyController.java
@@ -43,6 +43,9 @@ public final class ConstraintKeyController {
         if (tick < 0) return;
         int bx = block[0], by = block[1], bz = block[2];
 
+        boolean merge = mc.isAltDown();
+        if (merge) remove = false;
+
         if (remove && mc.isClimbable(bx, by, bz)) {
             List<AABB> obstacles = mc.getCollisionBoxes(bx - 1, by, bz - 1, bx + 1, by + 1, bz + 1);
             double[] r = ConstraintDeriver.deriveCell(bx, bz, by, bx + 0.5, bz + 0.5, obstacles);
@@ -69,7 +72,11 @@ public final class ConstraintKeyController {
                 AABB support = supportBox(bx, by, bz, hit);
                 List<AABB> obstacles = mc.getCollisionBoxes(bx - 1, by, bz - 1, bx + 1, by + 2, bz + 1);
                 double[] r = ConstraintDeriver.deriveFootprint(support, hit.x, hit.z, obstacles, modernCollision);
-                state.setFootprint(tick, r[0], r[1], r[2], r[3]);
+                if (merge) {
+                    state.mergeFootprint(tick, r[0], r[1], r[2], r[3]);
+                } else {
+                    state.setFootprint(tick, r[0], r[1], r[2], r[3]);
+                }
             }
         } else if (ConstraintDeriver.isSide(face)) {
             if (remove) {
@@ -78,7 +85,12 @@ public final class ConstraintKeyController {
                 Vec3dCore hit = mc.getLookedAtHitVec();
                 if (hit == null) return;
                 List<AABB> boxes = mc.getBlockCollisionBoxes(bx, by, bz);
-                state.putScalarReplacingDirection(tick, ConstraintDeriver.deriveWall(face, boxes, hit, enter));
+                Constraint wall = ConstraintDeriver.deriveWall(face, boxes, hit, enter);
+                if (merge) {
+                    state.mergeWall(tick, wall);
+                } else {
+                    state.putScalarReplacingDirection(tick, wall);
+                }
             }
         } else {
             return;

--- a/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/FabricMinecraftAccess.java
+++ b/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/FabricMinecraftAccess.java
@@ -233,6 +233,13 @@ public final class FabricMinecraftAccess implements MinecraftAccess {
     }
 
     @Override
+    public boolean isAltDown() {
+        long window = Minecraft.getInstance().getWindow().getWindow();
+        return GLFW.glfwGetKey(window, GLFW.GLFW_KEY_LEFT_ALT) == GLFW.GLFW_PRESS
+                || GLFW.glfwGetKey(window, GLFW.GLFW_KEY_RIGHT_ALT) == GLFW.GLFW_PRESS;
+    }
+
+    @Override
     public boolean isSaveChordDown() {
         long window = Minecraft.getInstance().getWindow().getWindow();
         return isCtrlDown() && GLFW.glfwGetKey(window, GLFW.GLFW_KEY_S) == GLFW.GLFW_PRESS;

--- a/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/FabricParkourCalculator.java
+++ b/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/FabricParkourCalculator.java
@@ -121,6 +121,10 @@ public class FabricParkourCalculator implements ClientModInitializer {
         application.setPlaybackBridge(playbackBridge);
         application.setBlockPicker(new FabricBlockPicker());
         application.setupUi();
+        Minecraft client = Minecraft.getInstance();
+        if (client != null && client.options != null) {
+            client.options.load();
+        }
     }
 
     private static boolean wasPlaybackRunning = false;

--- a/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/mixin/MinecraftMixin.java
+++ b/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/mixin/MinecraftMixin.java
@@ -39,6 +39,25 @@ public class MinecraftMixin {
                 merged[existing.length + i] = modKeys.get(i);
             }
             ((OptionsAccessor) (Object) options).pkc$setKeyMappings(merged);
+
+            java.io.File optionsFile = new java.io.File(Minecraft.getInstance().gameDirectory, "options.txt");
+            if (optionsFile.exists()) {
+                try (java.io.BufferedReader reader = new java.io.BufferedReader(new java.io.FileReader(optionsFile))) {
+                    String line;
+                    while ((line = reader.readLine()) != null) {
+                        String[] parts = line.split(":", 2);
+                        if (parts.length == 2 && parts[0].startsWith("key_key.parkourcalculator.")) {
+                            String name = parts[0].substring(4);
+                            for (KeyMapping km : modKeys) {
+                                if (km.getName().equals(name)) {
+                                    km.setKey(com.mojang.blaze3d.platform.InputConstants.getKey(parts[1]));
+                                }
+                            }
+                        }
+                    }
+                } catch (Exception ignored) {}
+            }
+
             Map<String, Integer> sortOrder = KeyMappingAccessor.pkc$getCategorySortOrder();
             for (KeyMapping km : modKeys) {
                 String category = km.getCategory();

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricMinecraftAccess.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricMinecraftAccess.java
@@ -238,6 +238,13 @@ public final class FabricMinecraftAccess implements MinecraftAccess {
         return isCtrlDown() && GLFW.glfwGetKey(window, GLFW.GLFW_KEY_S) == GLFW.GLFW_PRESS;
     }
 
+    @Override
+    public boolean isAltDown() {
+        long window = Minecraft.getInstance().getWindow().handle();
+        return GLFW.glfwGetKey(window, GLFW.GLFW_KEY_LEFT_ALT) == GLFW.GLFW_PRESS
+                || GLFW.glfwGetKey(window, GLFW.GLFW_KEY_RIGHT_ALT) == GLFW.GLFW_PRESS;
+    }
+
     private static int undoKey = GLFW.GLFW_KEY_UNKNOWN;
     private static int redoKey = GLFW.GLFW_KEY_UNKNOWN;
 

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12MinecraftAccess.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12MinecraftAccess.java
@@ -212,6 +212,12 @@ public final class Forge12MinecraftAccess implements MinecraftAccess {
     }
 
     @Override
+    public boolean isAltDown() {
+        return org.lwjgl.input.Keyboard.isKeyDown(org.lwjgl.input.Keyboard.KEY_LMENU)
+                || org.lwjgl.input.Keyboard.isKeyDown(org.lwjgl.input.Keyboard.KEY_RMENU);
+    }
+
+    @Override
     public boolean isSaveChordDown() {
         return Lwjgl2InputState.isSaveChordDown();
     }

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8MinecraftAccess.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8MinecraftAccess.java
@@ -225,6 +225,12 @@ public final class Forge8MinecraftAccess implements MinecraftAccess {
     }
 
     @Override
+    public boolean isAltDown() {
+        return org.lwjgl.input.Keyboard.isKeyDown(org.lwjgl.input.Keyboard.KEY_LMENU)
+                || org.lwjgl.input.Keyboard.isKeyDown(org.lwjgl.input.Keyboard.KEY_RMENU);
+    }
+
+    @Override
     public boolean isSaveChordDown() {
         return Lwjgl2InputState.isSaveChordDown();
     }


### PR DESCRIPTION
- **Merge Constraints with Alt:** Holding `Alt` while pressing the constraint hotkey now expands the current constraint instead of replacing it (creates one combined bounding box for multiple blocks).
- **Added `isAltDown()`:** Added Alt key support to `MinecraftAccess` across all loaders.
- **Fixed Fabric Keybinds:** Fixed a bug on Fabric where mod keybinds kept resetting to default on game restart.