### PR TITLE
feat: add extend path & solve to block keybind

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
@@ -742,4 +742,84 @@ public final class Application {
     public void renderPlayback() {
         playback.renderFrame();
     }
+
+    public void extendPathAndSolveToBlock(double targetX, double targetY, double targetZ) {
+        List<InputRow> rows = this.inputData.getRows();
+        int originalSize = rows.size();
+
+        boolean wasAbove = false;
+        double startY = runner.getStartPosition().y;
+        if (originalSize > 0) {
+            TickState lastState = this.boxController.getState(originalSize - 1);
+            if (lastState != null) {
+                startY = lastState.position.y;
+            }
+        }
+        if (startY > targetY) {
+            wasAbove = true;
+        }
+
+        // 1. Probe-Airtime-Ticks mit W + Sprint anhängen
+        int maxSimTicks = 100;
+        for (int i = 0; i < maxSimTicks; i++) {
+            InputRow newRow = new InputRow();
+            newRow.setKeyActive(InputRow.Key.W, true);
+            newRow.setKeyActive(InputRow.Key.SPRINT, true);
+            rows.add(newRow);
+        }
+
+        this.runSimulation();
+
+        // 2. Exakten Lande-Tick finden
+        int crossingIndex = -1;
+        for (int i = originalSize; i < rows.size(); i++) {
+            TickState state = this.boxController.getState(i);
+            if (state == null) continue;
+
+            if (state.position.y > targetY) {
+                wasAbove = true;
+            }
+
+            if (wasAbove && state.position.y <= targetY && state.velocity.y <= 0) {
+                crossingIndex = i;
+                break;
+            }
+        }
+
+        if (crossingIndex == -1) {
+            while (rows.size() > originalSize) {
+                rows.remove(rows.size() - 1);
+            }
+            this.runSimulation();
+            pushHudMessage("Target height not reached", HudMessageStyle.COLOR_WARN);
+            return;
+        }
+
+        // 3. Überflüssige Ticks nach der Landung abschneiden
+        while (rows.size() > crossingIndex + 1) {
+            rows.remove(rows.size() - 1);
+        }
+
+        int jumpTick = crossingIndex;
+        this.selection.clear();
+        this.selection.handleClick(jumpTick);
+        this.onConstraintKey(false, false);
+
+        InputRow landingRow = rows.get(jumpTick);
+        if (landingRow != null) {
+            landingRow.setKeyActive(InputRow.Key.JUMP, true);
+        }
+
+        TickConstraints tc = this.angleSolverState.tickConstraints(jumpTick);
+        if (tc != null && tc.getOverride() != null) {
+            tc.getOverride().setSlipperiness(Slipperiness.DEFAULT);
+        }
+
+        this.runSimulation();
+        this.angleSolverState.setLandingTick(jumpTick);
+        saveController.markDirty();
+        this.solveAngleSolver();
+        pushHudMessage("Path extended to T" + (jumpTick + 1) + " · solving...", HudMessages.COLOR_DEFAULT);
+    }
 }
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
 # Gradle 9 requires JVM 17+; pin to installed JDK 21 so gradlew works even when JAVA_HOME/PATH points at JDK 8.
-org.gradle.java.home=C\:\\Program Files\\Eclipse Adoptium\\jdk-21.0.5.11-hotspot
+org.gradle.java.home=C\:\\Program Files\\Java\\jdk-21
 
 # Mod Properties (shared across modules)
 mod_version=1.9.0 # x-release-please-version

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
 # Gradle 9 requires JVM 17+; pin to installed JDK 21 so gradlew works even when JAVA_HOME/PATH points at JDK 8.
-org.gradle.java.home=C\:\\Program Files\\Java\\jdk-21
+org.gradle.java.home=C\:\\Program Files\\Eclipse Adoptium\\jdk-21.0.5.11-hotspot
 
 # Mod Properties (shared across modules)
 mod_version=1.9.0 # x-release-please-version

--- a/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/FabricParkourCalculator.java
+++ b/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/FabricParkourCalculator.java
@@ -39,6 +39,7 @@ public class FabricParkourCalculator implements ClientModInitializer {
     public static KeyMapping playbackKeyBinding;
     public static KeyMapping landingConstraintsKeyBinding;
     public static KeyMapping removeConstraintsKeyBinding;
+    public static KeyMapping extendPathAndSolveKeyBinding;
     private static KeyMapping applySurfaceStateKeyBinding;
     private static KeyMapping solveKeyBinding;
     private static KeyMapping solverStartTickKeyBinding;
@@ -81,6 +82,7 @@ public class FabricParkourCalculator implements ClientModInitializer {
         playbackKeyBinding = key("key.parkourcalculator.toggle_playback", GLFW.GLFW_KEY_P);
         landingConstraintsKeyBinding = key("key.parkourcalculator.add_landing_constraints", GLFW.GLFW_KEY_B);
         removeConstraintsKeyBinding = key("key.parkourcalculator.remove_selected_constraints", GLFW.GLFW_KEY_X);
+        extendPathAndSolveKeyBinding = key("key.parkourcalculator.extend_path_and_solve_to_block", GLFW.GLFW_KEY_U);
         applySurfaceStateKeyBinding = key("key.parkourcalculator.apply_surface_state", GLFW.GLFW_KEY_H);
         solveKeyBinding = key("key.parkourcalculator.solve", GLFW.GLFW_KEY_V);
         solverStartTickKeyBinding = key("key.parkourcalculator.set_solver_start", GLFW.GLFW_KEY_I);
@@ -254,6 +256,10 @@ public class FabricParkourCalculator implements ClientModInitializer {
         while (removeConstraintsKeyBinding.consumeClick()) {
             removeConstraintsPressed = true;
         }
+        boolean extendPathAndSolvePressed = false;
+        while (extendPathAndSolveKeyBinding.consumeClick()) {
+            extendPathAndSolvePressed = true;
+        }
         boolean applySurfaceStatePressed = false;
         while (applySurfaceStateKeyBinding.consumeClick()) {
             applySurfaceStatePressed = true;
@@ -312,6 +318,9 @@ public class FabricParkourCalculator implements ClientModInitializer {
         if (removeConstraintsPressed && canDispatch) {
             application.removeSelectedConstraints();
         }
+        if (extendPathAndSolvePressed && canDispatch) {
+            triggerExtendPathAndSolve(client);
+        }
         if (applySurfaceStatePressed && canDispatch) {
             application.applyPathSurfaceState();
         }
@@ -369,6 +378,10 @@ public class FabricParkourCalculator implements ClientModInitializer {
         }
         if (glfwKey == boundKey(removeConstraintsKeyBinding)) {
             application.removeSelectedConstraints();
+            return true;
+        }
+        if (glfwKey == boundKey(extendPathAndSolveKeyBinding)) {
+            triggerExtendPathAndSolve(client);
             return true;
         }
         if (glfwKey == boundKey(applySurfaceStateKeyBinding)) {
@@ -478,6 +491,23 @@ public class FabricParkourCalculator implements ClientModInitializer {
 
     public static void resolveAutoScale(int displayHeightPx) {
         application.resolveAutoScaleIfNeeded(displayHeightPx);
+    }
+
+    private static void triggerExtendPathAndSolve(Minecraft client) {
+        if (client.hitResult instanceof net.minecraft.world.phys.BlockHitResult blockHit && client.hitResult.getType() == net.minecraft.world.phys.HitResult.Type.BLOCK) {
+            net.minecraft.core.BlockPos pos = blockHit.getBlockPos();
+            double targetX = pos.getX() + 0.5;
+            double targetY = pos.getY() + 1.0;
+            if (client.level != null) {
+                net.minecraft.world.level.block.state.BlockState state = client.level.getBlockState(pos);
+                net.minecraft.world.phys.shapes.VoxelShape shape = state.getCollisionShape(client.level, pos);
+                if (!shape.isEmpty()) {
+                    targetY = pos.getY() + shape.max(net.minecraft.core.Direction.Axis.Y);
+                }
+            }
+            double targetZ = pos.getZ() + 0.5;
+            application.extendPathAndSolveToBlock(targetX, targetY, targetZ);
+        }
     }
 
     private static String modVersion() {

--- a/loader-fabric-1.21.3/src/main/resources/assets/parkourcalculator/lang/en_us.json
+++ b/loader-fabric-1.21.3/src/main/resources/assets/parkourcalculator/lang/en_us.json
@@ -4,6 +4,7 @@
     "key.parkourcalculator.toggle_playback": "Start/Stop Playback",
     "key.parkourcalculator.add_landing_constraints": "Add block as constraint",
     "key.parkourcalculator.remove_selected_constraints": "Remove selected constraints",
+    "key.parkourcalculator.extend_path_and_solve_to_block": "Extend Path & Solve to Block",
     "key.parkourcalculator.apply_surface_state": "Apply surface state from path",
     "key.parkourcalculator.solve": "Solve and apply (Angle Solver)",
     "key.parkourcalculator.set_solver_start": "Set solver start tick",

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricParkourCalculator.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricParkourCalculator.java
@@ -38,6 +38,7 @@ public class FabricParkourCalculator implements ClientModInitializer {
     public static KeyMapping playbackKeyBinding;
     public static KeyMapping landingConstraintsKeyBinding;
     public static KeyMapping removeConstraintsKeyBinding;
+    public static KeyMapping extendPathAndSolveKeyBinding;
     private static KeyMapping applySurfaceStateKeyBinding;
     private static KeyMapping solveKeyBinding;
     private static KeyMapping solverStartTickKeyBinding;
@@ -94,6 +95,12 @@ public class FabricParkourCalculator implements ClientModInitializer {
                 "key.parkourcalculator.remove_selected_constraints",
                 InputConstants.Type.KEYSYM,
                 GLFW.GLFW_KEY_X,
+                category
+        ));
+        extendPathAndSolveKeyBinding = KeyMappingHelper.registerKeyMapping(new KeyMapping(
+                "key.parkourcalculator.extend_path_and_solve_to_block",
+                InputConstants.Type.KEYSYM,
+                GLFW.GLFW_KEY_U,
                 category
         ));
         applySurfaceStateKeyBinding = KeyMappingHelper.registerKeyMapping(new KeyMapping(
@@ -289,6 +296,10 @@ public class FabricParkourCalculator implements ClientModInitializer {
         while (removeConstraintsKeyBinding.consumeClick()) {
             removeConstraintsPressed = true;
         }
+        boolean extendPathAndSolvePressed = false;
+        while (extendPathAndSolveKeyBinding.consumeClick()) {
+            extendPathAndSolvePressed = true;
+        }
         boolean applySurfaceStatePressed = false;
         while (applySurfaceStateKeyBinding.consumeClick()) {
             applySurfaceStatePressed = true;
@@ -348,6 +359,9 @@ public class FabricParkourCalculator implements ClientModInitializer {
         if (removeConstraintsPressed && chordFree) {
             application.removeSelectedConstraints();
         }
+        if (extendPathAndSolvePressed && chordFree) {
+            triggerExtendPathAndSolve(client);
+        }
         if (applySurfaceStatePressed && chordFree) {
             application.applyPathSurfaceState();
         }
@@ -406,6 +420,10 @@ public class FabricParkourCalculator implements ClientModInitializer {
         }
         if (glfwKey == boundKey(removeConstraintsKeyBinding)) {
             application.removeSelectedConstraints();
+            return true;
+        }
+        if (glfwKey == boundKey(extendPathAndSolveKeyBinding)) {
+            triggerExtendPathAndSolve(client);
             return true;
         }
         if (glfwKey == boundKey(applySurfaceStateKeyBinding)) {
@@ -543,6 +561,23 @@ public class FabricParkourCalculator implements ClientModInitializer {
 
     public static void resolveAutoScale(int displayHeightPx) {
         application.resolveAutoScaleIfNeeded(displayHeightPx);
+    }
+
+    private static void triggerExtendPathAndSolve(Minecraft client) {
+        if (client.hitResult instanceof net.minecraft.world.phys.BlockHitResult blockHit && client.hitResult.getType() == net.minecraft.world.phys.HitResult.Type.BLOCK) {
+            net.minecraft.core.BlockPos pos = blockHit.getBlockPos();
+            double targetX = pos.getX() + 0.5;
+            double targetY = pos.getY() + 1.0;
+            if (client.level != null) {
+                net.minecraft.world.level.block.state.BlockState state = client.level.getBlockState(pos);
+                net.minecraft.world.phys.shapes.VoxelShape shape = state.getCollisionShape(client.level, pos);
+                if (!shape.isEmpty()) {
+                    targetY = pos.getY() + shape.max(net.minecraft.core.Direction.Axis.Y);
+                }
+            }
+            double targetZ = pos.getZ() + 0.5;
+            application.extendPathAndSolveToBlock(targetX, targetY, targetZ);
+        }
     }
 
     private static String modVersion() {

--- a/loader-fabric/src/client/resources/assets/parkourcalculator/lang/en_us.json
+++ b/loader-fabric/src/client/resources/assets/parkourcalculator/lang/en_us.json
@@ -4,6 +4,7 @@
     "key.parkourcalculator.toggle_playback": "Start/Stop Playback",
     "key.parkourcalculator.add_landing_constraints": "Add block as constraint",
     "key.parkourcalculator.remove_selected_constraints": "Remove selected constraints",
+    "key.parkourcalculator.extend_path_and_solve_to_block": "Extend Path & Solve to Block",
     "key.parkourcalculator.apply_surface_state": "Apply surface state from path",
     "key.parkourcalculator.solve": "Solve and apply (Angle Solver)",
     "key.parkourcalculator.set_solver_start": "Set solver start tick",

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12ParkourCalculator.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12ParkourCalculator.java
@@ -78,6 +78,7 @@ public class Forge12ParkourCalculator {
     private KeyBinding playbackKeyBinding;
     private KeyBinding landingConstraintsKeyBinding;
     private KeyBinding removeConstraintsKeyBinding;
+    private KeyBinding extendPathAndSolveKeyBinding;
     private KeyBinding applySurfaceStateKeyBinding;
     private KeyBinding solveKeyBinding;
     private KeyBinding solverStartTickKeyBinding;
@@ -130,6 +131,8 @@ public class Forge12ParkourCalculator {
         ClientRegistry.registerKeyBinding(landingConstraintsKeyBinding);
         removeConstraintsKeyBinding = new KeyBinding("key.parkourcalculator.remove_selected_constraints", Keyboard.KEY_X, "key.categories.parkourcalculator");
         ClientRegistry.registerKeyBinding(removeConstraintsKeyBinding);
+        extendPathAndSolveKeyBinding = new KeyBinding("key.parkourcalculator.extend_path_and_solve_to_block", Keyboard.KEY_U, "key.categories.parkourcalculator");
+        ClientRegistry.registerKeyBinding(extendPathAndSolveKeyBinding);
         applySurfaceStateKeyBinding = new KeyBinding("key.parkourcalculator.apply_surface_state", Keyboard.KEY_H, "key.categories.parkourcalculator");
         ClientRegistry.registerKeyBinding(applySurfaceStateKeyBinding);
         solveKeyBinding = new KeyBinding("key.parkourcalculator.solve", Keyboard.KEY_V, "key.categories.parkourcalculator");
@@ -301,6 +304,10 @@ public class Forge12ParkourCalculator {
         while (removeConstraintsKeyBinding.isPressed()) {
             removeConstraintsPressed = true;
         }
+        boolean extendPathAndSolvePressed = false;
+        while (extendPathAndSolveKeyBinding.isPressed()) {
+            extendPathAndSolvePressed = true;
+        }
         boolean applySurfaceStatePressed = false;
         while (applySurfaceStateKeyBinding.isPressed()) {
             applySurfaceStatePressed = true;
@@ -353,6 +360,9 @@ public class Forge12ParkourCalculator {
             }
             if (removeConstraintsPressed && chordFree) {
                 application.removeSelectedConstraints();
+            }
+            if (extendPathAndSolvePressed && chordFree) {
+                triggerExtendPathAndSolve(mc);
             }
             if (applySurfaceStatePressed && chordFree) {
                 application.applyPathSurfaceState();
@@ -415,6 +425,10 @@ public class Forge12ParkourCalculator {
             application.removeSelectedConstraints();
             return true;
         }
+        if (keyCode == extendPathAndSolveKeyBinding.getKeyCode()) {
+            triggerExtendPathAndSolve(Minecraft.getMinecraft());
+            return true;
+        }
         if (keyCode == applySurfaceStateKeyBinding.getKeyCode()) {
             application.applyPathSurfaceState();
             return true;
@@ -473,6 +487,25 @@ public class Forge12ParkourCalculator {
         if (!event.isCancelable()) return;
         if (application.shouldSuppressLeftClick() || application.shouldSuppressRightClick()) {
             event.setCanceled(true);
+        }
+    }
+
+    private void triggerExtendPathAndSolve(Minecraft mc) {
+        if (mc.objectMouseOver != null && mc.objectMouseOver.typeOfHit == net.minecraft.util.math.RayTraceResult.Type.BLOCK) {
+            net.minecraft.util.math.BlockPos pos = mc.objectMouseOver.getBlockPos();
+            double targetX = pos.getX() + 0.5;
+            double targetY = pos.getY() + 1.0;
+            if (mc.world != null) {
+                net.minecraft.block.state.IBlockState state = mc.world.getBlockState(pos);
+                net.minecraft.util.math.AxisAlignedBB aabb = state.getCollisionBoundingBox(mc.world, pos);
+                if (aabb != null && aabb != net.minecraft.block.Block.NULL_AABB) {
+                    targetY = pos.getY() + aabb.maxY;
+                } else {
+                    targetY = pos.getY() + state.getBlock().getBoundingBox(state, mc.world, pos).maxY;
+                }
+            }
+            double targetZ = pos.getZ() + 0.5;
+            application.extendPathAndSolveToBlock(targetX, targetY, targetZ);
         }
     }
 

--- a/loader-forge-1.12.2/src/main/resources/assets/parkourcalculator/lang/en_us.lang
+++ b/loader-forge-1.12.2/src/main/resources/assets/parkourcalculator/lang/en_us.lang
@@ -3,6 +3,7 @@ key.parkourcalculator.deselect_all=Deselect all
 key.parkourcalculator.toggle_playback=Start/Stop Playback
 key.parkourcalculator.add_landing_constraints=Add block as constraint
 key.parkourcalculator.remove_selected_constraints=Remove selected constraints
+key.parkourcalculator.extend_path_and_solve_to_block=Extend Path & Solve to Block
 key.parkourcalculator.apply_surface_state=Apply surface state from path
 key.parkourcalculator.solve=Solve and apply (Angle Solver)
 key.parkourcalculator.set_solver_start=Set solver start tick

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8ParkourCalculator.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8ParkourCalculator.java
@@ -79,6 +79,7 @@ public class Forge8ParkourCalculator {
     private KeyBinding playbackKeyBinding;
     private KeyBinding landingConstraintsKeyBinding;
     private KeyBinding removeConstraintsKeyBinding;
+    private KeyBinding extendPathAndSolveKeyBinding;
     private KeyBinding applySurfaceStateKeyBinding;
     private KeyBinding solveKeyBinding;
     private KeyBinding solverStartTickKeyBinding;
@@ -131,6 +132,8 @@ public class Forge8ParkourCalculator {
         ClientRegistry.registerKeyBinding(landingConstraintsKeyBinding);
         removeConstraintsKeyBinding = new KeyBinding("key.parkourcalculator.remove_selected_constraints", Keyboard.KEY_X, "key.categories.parkourcalculator");
         ClientRegistry.registerKeyBinding(removeConstraintsKeyBinding);
+        extendPathAndSolveKeyBinding = new KeyBinding("key.parkourcalculator.extend_path_and_solve_to_block", Keyboard.KEY_U, "key.categories.parkourcalculator");
+        ClientRegistry.registerKeyBinding(extendPathAndSolveKeyBinding);
         applySurfaceStateKeyBinding = new KeyBinding("key.parkourcalculator.apply_surface_state", Keyboard.KEY_H, "key.categories.parkourcalculator");
         ClientRegistry.registerKeyBinding(applySurfaceStateKeyBinding);
         solveKeyBinding = new KeyBinding("key.parkourcalculator.solve", Keyboard.KEY_V, "key.categories.parkourcalculator");
@@ -302,6 +305,10 @@ public class Forge8ParkourCalculator {
         while (removeConstraintsKeyBinding.isPressed()) {
             removeConstraintsPressed = true;
         }
+        boolean extendPathAndSolvePressed = false;
+        while (extendPathAndSolveKeyBinding.isPressed()) {
+            extendPathAndSolvePressed = true;
+        }
         boolean applySurfaceStatePressed = false;
         while (applySurfaceStateKeyBinding.isPressed()) {
             applySurfaceStatePressed = true;
@@ -354,6 +361,9 @@ public class Forge8ParkourCalculator {
             }
             if (removeConstraintsPressed && chordFree) {
                 application.removeSelectedConstraints();
+            }
+            if (extendPathAndSolvePressed && chordFree) {
+                triggerExtendPathAndSolve(mc);
             }
             if (applySurfaceStatePressed && chordFree) {
                 application.applyPathSurfaceState();
@@ -416,6 +426,10 @@ public class Forge8ParkourCalculator {
             application.removeSelectedConstraints();
             return true;
         }
+        if (keyCode == extendPathAndSolveKeyBinding.getKeyCode()) {
+            triggerExtendPathAndSolve(Minecraft.getMinecraft());
+            return true;
+        }
         if (keyCode == applySurfaceStateKeyBinding.getKeyCode()) {
             application.applyPathSurfaceState();
             return true;
@@ -474,6 +488,26 @@ public class Forge8ParkourCalculator {
         if (!event.isCancelable()) return;
         if (application.shouldSuppressLeftClick() || application.shouldSuppressRightClick()) {
             event.setCanceled(true);
+        }
+    }
+
+    private void triggerExtendPathAndSolve(Minecraft mc) {
+        if (mc.objectMouseOver != null && mc.objectMouseOver.typeOfHit == net.minecraft.util.MovingObjectPosition.MovingObjectType.BLOCK) {
+            net.minecraft.util.BlockPos pos = mc.objectMouseOver.getBlockPos();
+            double targetX = pos.getX() + 0.5;
+            double targetY = pos.getY() + 1.0;
+            if (mc.theWorld != null) {
+                net.minecraft.block.state.IBlockState state = mc.theWorld.getBlockState(pos);
+                net.minecraft.block.Block block = state.getBlock();
+                net.minecraft.util.AxisAlignedBB aabb = block.getCollisionBoundingBox(mc.theWorld, pos, state);
+                if (aabb != null) {
+                    targetY = aabb.maxY;
+                } else {
+                    targetY = pos.getY() + block.getBlockBoundsMaxY();
+                }
+            }
+            double targetZ = pos.getZ() + 0.5;
+            application.extendPathAndSolveToBlock(targetX, targetY, targetZ);
         }
     }
 

--- a/loader-forge-1.8.9/src/main/resources/assets/parkourcalculator/lang/en_US.lang
+++ b/loader-forge-1.8.9/src/main/resources/assets/parkourcalculator/lang/en_US.lang
@@ -3,6 +3,7 @@ key.parkourcalculator.deselect_all=Deselect all
 key.parkourcalculator.toggle_playback=Start/Stop Playback
 key.parkourcalculator.add_landing_constraints=Add block as constraint
 key.parkourcalculator.remove_selected_constraints=Remove selected constraints
+key.parkourcalculator.extend_path_and_solve_to_block=Extend Path & Solve to Block
 key.parkourcalculator.apply_surface_state=Apply surface state from path
 key.parkourcalculator.solve=Solve and apply (Angle Solver)
 key.parkourcalculator.set_solver_start=Set solver start tick


### PR DESCRIPTION
Added a new keybind (`U` by default): **Extend Path & Solve to Block**.

Pressing the keybind while aiming at a block automatically:
- Simulates ahead by appending airtime ticks (W + Sprint) until player Y drops to the target block's collision top.
- Sets the landing constraint and ground jump input on the exact landing tick.
- Runs the Angle Solver to solve the jump trajectory directly to the block.