### PR TITLE
fix(forge): reuse path bake buffers instead of allocating direct memory per rebake

### DIFF
--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/render/Forge12CachedBoxGeometry.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/render/Forge12CachedBoxGeometry.java
@@ -54,6 +54,17 @@ public final class Forge12CachedBoxGeometry {
     private int reachLineVerts;
     private int lastBakeVertices;
     private Set<Integer> bakedSelection = new HashSet<Integer>();
+    private BufferBuilder scratch;
+    private int scratchInts;
+
+    private BufferBuilder scratch(int vertexCount) {
+        int ints = vertexCount * INTS_PER_VERTEX + INTS_PER_VERTEX;
+        if (scratch == null || ints > scratchInts) {
+            scratch = new BufferBuilder(ints);
+            scratchInts = ints;
+        }
+        return scratch;
+    }
 
     public void ensureBuilt(BoxController boxController, PathRenderPlan plan) {
         long rev = boxController.getGeometryRev();
@@ -167,8 +178,8 @@ public final class Forge12CachedBoxGeometry {
         lastBakeVertices = (int) vertices;
         if (vertices == 0) return null;
 
-        // A private builder, not the shared Tessellator, so a huge bake doesn't permanently inflate it.
-        BufferBuilder builder = new BufferBuilder((int) (vertices * INTS_PER_VERTEX) + INTS_PER_VERTEX);
+        // A reused private scratch builder, not the shared Tessellator, so repeated bakes don't churn direct memory.
+        BufferBuilder builder = scratch((int) vertices);
         builder.begin(glMode, DefaultVertexFormats.POSITION_COLOR);
         emitter.accept(new Forge12BoxRenderer(builder, anchorX, anchorY, anchorZ, mode));
         builder.finishDrawing();
@@ -232,7 +243,7 @@ public final class Forge12CachedBoxGeometry {
     private void writeVerts(VertexBuffer vbo, int globalVertexOffset, int glMode, BoxRenderer.Mode mode,
                             int vertexCount, Consumer<BoxRenderer> emit) {
         if (vbo == null || vertexCount == 0) return;
-        BufferBuilder builder = new BufferBuilder(vertexCount * INTS_PER_VERTEX + INTS_PER_VERTEX);
+        BufferBuilder builder = scratch(vertexCount);
         builder.begin(glMode, DefaultVertexFormats.POSITION_COLOR);
         emit.accept(new Forge12BoxRenderer(builder, anchorX, anchorY, anchorZ, mode));
         builder.finishDrawing();
@@ -328,6 +339,8 @@ public final class Forge12CachedBoxGeometry {
 
     public void close() {
         release();
+        scratch = null;
+        scratchInts = 0;
         built = false;
         lastGeometryRev = -1;
     }

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/render/Forge8CachedBoxGeometry.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/render/Forge8CachedBoxGeometry.java
@@ -54,6 +54,17 @@ public final class Forge8CachedBoxGeometry {
     private int reachLineVerts;
     private int lastBakeVertices;
     private Set<Integer> bakedSelection = new HashSet<Integer>();
+    private WorldRenderer scratch;
+    private int scratchInts;
+
+    private WorldRenderer scratch(int vertexCount) {
+        int ints = vertexCount * INTS_PER_VERTEX + INTS_PER_VERTEX;
+        if (scratch == null || ints > scratchInts) {
+            scratch = new WorldRenderer(ints);
+            scratchInts = ints;
+        }
+        return scratch;
+    }
 
     public void ensureBuilt(BoxController boxController, PathRenderPlan plan) {
         long rev = boxController.getGeometryRev();
@@ -167,8 +178,8 @@ public final class Forge8CachedBoxGeometry {
         lastBakeVertices = (int) vertices;
         if (vertices == 0) return null;
 
-        // A private buffer, not the shared Tessellator, so a huge bake doesn't permanently inflate it.
-        WorldRenderer builder = new WorldRenderer((int) (vertices * INTS_PER_VERTEX) + INTS_PER_VERTEX);
+        // A reused private scratch buffer, not the shared Tessellator, so repeated bakes don't churn direct memory.
+        WorldRenderer builder = scratch((int) vertices);
         builder.begin(glMode, DefaultVertexFormats.POSITION_COLOR);
         emitter.accept(new Forge8BoxRenderer(builder, anchorX, anchorY, anchorZ, mode));
         builder.finishDrawing();
@@ -228,7 +239,7 @@ public final class Forge8CachedBoxGeometry {
 
     private void writeVerts(VertexBuffer vbo, int globalVertexOffset, int glMode, BoxRenderer.Mode mode,  int vertexCount, Consumer<BoxRenderer> emit) {
         if (vbo == null || vertexCount == 0) return;
-        WorldRenderer builder = new WorldRenderer(vertexCount * INTS_PER_VERTEX + INTS_PER_VERTEX);
+        WorldRenderer builder = scratch(vertexCount);
         builder.begin(glMode, DefaultVertexFormats.POSITION_COLOR);
         emit.accept(new Forge8BoxRenderer(builder, anchorX, anchorY, anchorZ, mode));
         builder.finishDrawing();
@@ -320,6 +331,8 @@ public final class Forge8CachedBoxGeometry {
 
     public void close() {
         release();
+        scratch = null;
+        scratchInts = 0;
         built = false;
         lastGeometryRev = -1;
     }


### PR DESCRIPTION
Fixes #311

## Problem

On Forge 1.8.9, roughly 50 Optimize solves on a large (5k tick) save degrade the game to 1 fps whenever a yaw is edited (table or in-game drag), corrupt HUD textures, and eventually crash with an out-of-memory screen. Regressed in 1.8.0.

## Cause

Every path geometry bake on the LWJGL2 loaders allocates a fresh `WorldRenderer`/`BufferBuilder`, and each of those allocates a direct `ByteBuffer` (`GLAllocation.createDirectByteBuffer`). Direct buffers are only released when the GC happens to collect the wrapper, and the JVM does not feel direct-memory pressure on the heap, so churned buffers pile up against the direct-memory cap (defaults to `-Xmx`).

1.8.0 turned this churn pathological: the live best-path overlay bumps its revision on every adopted improvement (up to every 150 ms while solving), each bump changes `PathRenderPlan.structuralHash`, and a changed hash fails `TailPatchGate`, forcing a full rebake of the entire path. A 1 second Optimize solve on a 5k tick save therefore rebakes multi-megabyte direct buffers ~7 times per second. Across ~50 solves that sums to gigabytes of outstanding direct allocations; once the cap is reached, every later direct allocation (any yaw edit rebake) stalls in `Bits.reserveMemory`'s GC-and-sleep retry loop (the observed 1 fps) until an `OutOfMemoryError` lands. This also explains why it is instance-dependent: JVM flags and view settings change both the cap and the per-rebake size.

## Fix

`Forge8CachedBoxGeometry` and `Forge12CachedBoxGeometry` now keep one private scratch builder each, grown to the largest bake seen and reused for every bake and in-place vertex write, mirroring the vanilla Tessellator cycle (`begin` -> `finishDrawing` -> upload -> `reset`). Steady-state direct allocations from rebakes drop to zero; the scratch is dropped in `close()` when the path is cleared. The Fabric loader already frees its allocators deterministically (`ByteBufferBuilder` with try-with-resources) and needs no change.

Exact pre-sizing is preserved: the 1.8.9 `WorldRenderer` cannot grow on the `pos()`/`endVertex()` path, and `bufferData`/`glBufferSubData` read only up to the limit set by `finishDrawing`, so a larger-than-needed scratch uploads exactly the used bytes.

## Testing

- `:loader-forge-1.8.9:compileJava` and `:loader-forge-1.12.2:compileJava` pass.
- `:core:test` (fast suite) green; no core code touched.
- Headless stress run of 30 consecutive 1-second Optimize solves on a synthetic 5k tick document confirmed the core engine itself retains no memory (flat heap, flat thread count), isolating the leak to the loader render path.
- In-game QA pending: needs a large save plus repeated solves to reproduce the original degradation.