### PR TITLE
feat: add hotkey to re-run the simulation from the first tick

### DIFF
--- a/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/FabricParkourCalculator.java
+++ b/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/FabricParkourCalculator.java
@@ -44,6 +44,7 @@ public class FabricParkourCalculator implements ClientModInitializer {
     private static KeyMapping solveKeyBinding;
     private static KeyMapping solverStartTickKeyBinding;
     private static KeyMapping solverEndTickKeyBinding;
+    private static KeyMapping rerunSimulationKeyBinding;
     private static KeyMapping captureMomentumBlockKeyBinding;
     private static KeyMapping captureCollisionBlockKeyBinding;
     private static KeyMapping captureLandBlockKeyBinding;
@@ -87,6 +88,7 @@ public class FabricParkourCalculator implements ClientModInitializer {
         solveKeyBinding = key("key.parkourcalculator.solve", GLFW.GLFW_KEY_V);
         solverStartTickKeyBinding = key("key.parkourcalculator.set_solver_start", GLFW.GLFW_KEY_I);
         solverEndTickKeyBinding = key("key.parkourcalculator.set_solver_end", GLFW.GLFW_KEY_O);
+        rerunSimulationKeyBinding = key("key.parkourcalculator.rerun_simulation", GLFW.GLFW_KEY_R);
         if (blockCaptureEnabled) {
             captureMomentumBlockKeyBinding = key("key.parkourcalculator.capture_momentum_block", GLFW.GLFW_KEY_M);
             captureCollisionBlockKeyBinding = key("key.parkourcalculator.capture_collision_block", GLFW.GLFW_KEY_N);
@@ -280,6 +282,10 @@ public class FabricParkourCalculator implements ClientModInitializer {
         while (solverEndTickKeyBinding.consumeClick()) {
             solverEndPressed = true;
         }
+        boolean rerunSimulationPressed = false;
+        while (rerunSimulationKeyBinding.consumeClick()) {
+            rerunSimulationPressed = true;
+        }
         boolean captureMomentum = false;
         boolean captureCollision = false;
         boolean captureLand = false;
@@ -336,6 +342,9 @@ public class FabricParkourCalculator implements ClientModInitializer {
         }
         if (solverEndPressed && canDispatch) {
             application.setSolverLandingTickFromSelection();
+        }
+        if (rerunSimulationPressed && canDispatch) {
+            application.runSimulation();
         }
         if (captureMomentum && canDispatch) {
             application.captureAngleSolverBlock(BlockSelection.Kind.MOMENTUM);
@@ -402,6 +411,10 @@ public class FabricParkourCalculator implements ClientModInitializer {
         }
         if (glfwKey == boundKey(solverEndTickKeyBinding)) {
             application.setSolverLandingTickFromSelection();
+            return true;
+        }
+        if (glfwKey == boundKey(rerunSimulationKeyBinding)) {
+            application.runSimulation();
             return true;
         }
         return false;

--- a/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/FabricParkourCalculator.java
+++ b/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/FabricParkourCalculator.java
@@ -88,7 +88,7 @@ public class FabricParkourCalculator implements ClientModInitializer {
         solveKeyBinding = key("key.parkourcalculator.solve", GLFW.GLFW_KEY_V);
         solverStartTickKeyBinding = key("key.parkourcalculator.set_solver_start", GLFW.GLFW_KEY_I);
         solverEndTickKeyBinding = key("key.parkourcalculator.set_solver_end", GLFW.GLFW_KEY_O);
-        rerunSimulationKeyBinding = key("key.parkourcalculator.rerun_simulation", GLFW.GLFW_KEY_R);
+        rerunSimulationKeyBinding = key("key.parkourcalculator.rerun_simulation", GLFW.GLFW_KEY_J);
         if (blockCaptureEnabled) {
             captureMomentumBlockKeyBinding = key("key.parkourcalculator.capture_momentum_block", GLFW.GLFW_KEY_M);
             captureCollisionBlockKeyBinding = key("key.parkourcalculator.capture_collision_block", GLFW.GLFW_KEY_N);

--- a/loader-fabric-1.21.3/src/main/resources/assets/parkourcalculator/lang/en_us.json
+++ b/loader-fabric-1.21.3/src/main/resources/assets/parkourcalculator/lang/en_us.json
@@ -9,6 +9,7 @@
     "key.parkourcalculator.solve": "Solve and apply (Angle Solver)",
     "key.parkourcalculator.set_solver_start": "Set solver start tick",
     "key.parkourcalculator.set_solver_end": "Set solver goal tick",
+    "key.parkourcalculator.rerun_simulation": "Rerun simulation",
     "key.parkourcalculator.capture_momentum_block": "Capture Momentum block",
     "key.parkourcalculator.capture_collision_block": "Capture Collision block",
     "key.parkourcalculator.capture_land_block": "Capture Land block",

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricParkourCalculator.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricParkourCalculator.java
@@ -131,7 +131,7 @@ public class FabricParkourCalculator implements ClientModInitializer {
         rerunSimulationKeyBinding = KeyMappingHelper.registerKeyMapping(new KeyMapping(
                 "key.parkourcalculator.rerun_simulation",
                 InputConstants.Type.KEYSYM,
-                GLFW.GLFW_KEY_R,
+                GLFW.GLFW_KEY_J,
                 category
         ));
 

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricParkourCalculator.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricParkourCalculator.java
@@ -43,6 +43,7 @@ public class FabricParkourCalculator implements ClientModInitializer {
     private static KeyMapping solveKeyBinding;
     private static KeyMapping solverStartTickKeyBinding;
     private static KeyMapping solverEndTickKeyBinding;
+    private static KeyMapping rerunSimulationKeyBinding;
     private static KeyMapping captureMomentumBlockKeyBinding;
     private static KeyMapping captureCollisionBlockKeyBinding;
     private static KeyMapping captureLandBlockKeyBinding;
@@ -125,6 +126,12 @@ public class FabricParkourCalculator implements ClientModInitializer {
                 "key.parkourcalculator.set_solver_end",
                 InputConstants.Type.KEYSYM,
                 GLFW.GLFW_KEY_O,
+                category
+        ));
+        rerunSimulationKeyBinding = KeyMappingHelper.registerKeyMapping(new KeyMapping(
+                "key.parkourcalculator.rerun_simulation",
+                InputConstants.Type.KEYSYM,
+                GLFW.GLFW_KEY_R,
                 category
         ));
 
@@ -316,6 +323,10 @@ public class FabricParkourCalculator implements ClientModInitializer {
         while (solverEndTickKeyBinding.consumeClick()) {
             solverEndPressed = true;
         }
+        boolean rerunSimulationPressed = false;
+        while (rerunSimulationKeyBinding.consumeClick()) {
+            rerunSimulationPressed = true;
+        }
         boolean captureMomentum = false;
         boolean captureCollision = false;
         boolean captureLand = false;
@@ -373,6 +384,9 @@ public class FabricParkourCalculator implements ClientModInitializer {
         }
         if (solverEndPressed && chordFree) {
             application.setSolverLandingTickFromSelection();
+        }
+        if (rerunSimulationPressed && chordFree) {
+            application.runSimulation();
         }
         if (captureMomentum && chordFree) {
             application.captureAngleSolverBlock(BlockSelection.Kind.MOMENTUM);

--- a/loader-fabric/src/client/resources/assets/parkourcalculator/lang/en_us.json
+++ b/loader-fabric/src/client/resources/assets/parkourcalculator/lang/en_us.json
@@ -9,6 +9,7 @@
     "key.parkourcalculator.solve": "Solve and apply (Angle Solver)",
     "key.parkourcalculator.set_solver_start": "Set solver start tick",
     "key.parkourcalculator.set_solver_end": "Set solver goal tick",
+    "key.parkourcalculator.rerun_simulation": "Rerun simulation",
     "key.parkourcalculator.capture_momentum_block": "Capture Momentum block",
     "key.parkourcalculator.capture_collision_block": "Capture Collision block",
     "key.parkourcalculator.capture_land_block": "Capture Land block",

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12ParkourCalculator.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12ParkourCalculator.java
@@ -83,6 +83,7 @@ public class Forge12ParkourCalculator {
     private KeyBinding solveKeyBinding;
     private KeyBinding solverStartTickKeyBinding;
     private KeyBinding solverEndTickKeyBinding;
+    private KeyBinding rerunSimulationKeyBinding;
     private KeyBinding captureMomentumBlockKeyBinding;
     private KeyBinding captureCollisionBlockKeyBinding;
     private KeyBinding captureLandBlockKeyBinding;
@@ -141,6 +142,8 @@ public class Forge12ParkourCalculator {
         ClientRegistry.registerKeyBinding(solverStartTickKeyBinding);
         solverEndTickKeyBinding = new KeyBinding("key.parkourcalculator.set_solver_end", Keyboard.KEY_O, "key.categories.parkourcalculator");
         ClientRegistry.registerKeyBinding(solverEndTickKeyBinding);
+        rerunSimulationKeyBinding = new KeyBinding("key.parkourcalculator.rerun_simulation", Keyboard.KEY_R, "key.categories.parkourcalculator");
+        ClientRegistry.registerKeyBinding(rerunSimulationKeyBinding);
         if (blockCaptureEnabled) {
             captureMomentumBlockKeyBinding = new KeyBinding("key.parkourcalculator.capture_momentum_block", Keyboard.KEY_M, "key.categories.parkourcalculator");
             ClientRegistry.registerKeyBinding(captureMomentumBlockKeyBinding);
@@ -324,6 +327,10 @@ public class Forge12ParkourCalculator {
         while (solverEndTickKeyBinding.isPressed()) {
             solverEndPressed = true;
         }
+        boolean rerunSimulationPressed = false;
+        while (rerunSimulationKeyBinding.isPressed()) {
+            rerunSimulationPressed = true;
+        }
         boolean captureMomentum = false;
         boolean captureCollision = false;
         boolean captureLand = false;
@@ -375,6 +382,9 @@ public class Forge12ParkourCalculator {
             }
             if (solverEndPressed && chordFree) {
                 application.setSolverLandingTickFromSelection();
+            }
+            if (rerunSimulationPressed && chordFree) {
+                application.runSimulation();
             }
             if (captureMomentum && chordFree) {
                 application.captureAngleSolverBlock(BlockSelection.Kind.MOMENTUM);
@@ -443,6 +453,10 @@ public class Forge12ParkourCalculator {
         }
         if (keyCode == solverEndTickKeyBinding.getKeyCode()) {
             application.setSolverLandingTickFromSelection();
+            return true;
+        }
+        if (keyCode == rerunSimulationKeyBinding.getKeyCode()) {
+            application.runSimulation();
             return true;
         }
         return false;

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12ParkourCalculator.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12ParkourCalculator.java
@@ -142,7 +142,7 @@ public class Forge12ParkourCalculator {
         ClientRegistry.registerKeyBinding(solverStartTickKeyBinding);
         solverEndTickKeyBinding = new KeyBinding("key.parkourcalculator.set_solver_end", Keyboard.KEY_O, "key.categories.parkourcalculator");
         ClientRegistry.registerKeyBinding(solverEndTickKeyBinding);
-        rerunSimulationKeyBinding = new KeyBinding("key.parkourcalculator.rerun_simulation", Keyboard.KEY_R, "key.categories.parkourcalculator");
+        rerunSimulationKeyBinding = new KeyBinding("key.parkourcalculator.rerun_simulation", Keyboard.KEY_J, "key.categories.parkourcalculator");
         ClientRegistry.registerKeyBinding(rerunSimulationKeyBinding);
         if (blockCaptureEnabled) {
             captureMomentumBlockKeyBinding = new KeyBinding("key.parkourcalculator.capture_momentum_block", Keyboard.KEY_M, "key.categories.parkourcalculator");

--- a/loader-forge-1.12.2/src/main/resources/assets/parkourcalculator/lang/en_us.lang
+++ b/loader-forge-1.12.2/src/main/resources/assets/parkourcalculator/lang/en_us.lang
@@ -8,6 +8,7 @@ key.parkourcalculator.apply_surface_state=Apply surface state from path
 key.parkourcalculator.solve=Solve and apply (Angle Solver)
 key.parkourcalculator.set_solver_start=Set solver start tick
 key.parkourcalculator.set_solver_end=Set solver goal tick
+key.parkourcalculator.rerun_simulation=Rerun simulation
 key.parkourcalculator.capture_momentum_block=Capture Momentum block
 key.parkourcalculator.capture_collision_block=Capture Collision block
 key.parkourcalculator.capture_land_block=Capture Land block

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8ParkourCalculator.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8ParkourCalculator.java
@@ -143,7 +143,7 @@ public class Forge8ParkourCalculator {
         ClientRegistry.registerKeyBinding(solverStartTickKeyBinding);
         solverEndTickKeyBinding = new KeyBinding("key.parkourcalculator.set_solver_end", Keyboard.KEY_O, "key.categories.parkourcalculator");
         ClientRegistry.registerKeyBinding(solverEndTickKeyBinding);
-        rerunSimulationKeyBinding = new KeyBinding("key.parkourcalculator.rerun_simulation", Keyboard.KEY_R, "key.categories.parkourcalculator");
+        rerunSimulationKeyBinding = new KeyBinding("key.parkourcalculator.rerun_simulation", Keyboard.KEY_J, "key.categories.parkourcalculator");
         ClientRegistry.registerKeyBinding(rerunSimulationKeyBinding);
         if (blockCaptureEnabled) {
             captureMomentumBlockKeyBinding = new KeyBinding("key.parkourcalculator.capture_momentum_block", Keyboard.KEY_M, "key.categories.parkourcalculator");

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8ParkourCalculator.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8ParkourCalculator.java
@@ -84,6 +84,7 @@ public class Forge8ParkourCalculator {
     private KeyBinding solveKeyBinding;
     private KeyBinding solverStartTickKeyBinding;
     private KeyBinding solverEndTickKeyBinding;
+    private KeyBinding rerunSimulationKeyBinding;
     private KeyBinding captureMomentumBlockKeyBinding;
     private KeyBinding captureCollisionBlockKeyBinding;
     private KeyBinding captureLandBlockKeyBinding;
@@ -142,6 +143,8 @@ public class Forge8ParkourCalculator {
         ClientRegistry.registerKeyBinding(solverStartTickKeyBinding);
         solverEndTickKeyBinding = new KeyBinding("key.parkourcalculator.set_solver_end", Keyboard.KEY_O, "key.categories.parkourcalculator");
         ClientRegistry.registerKeyBinding(solverEndTickKeyBinding);
+        rerunSimulationKeyBinding = new KeyBinding("key.parkourcalculator.rerun_simulation", Keyboard.KEY_R, "key.categories.parkourcalculator");
+        ClientRegistry.registerKeyBinding(rerunSimulationKeyBinding);
         if (blockCaptureEnabled) {
             captureMomentumBlockKeyBinding = new KeyBinding("key.parkourcalculator.capture_momentum_block", Keyboard.KEY_M, "key.categories.parkourcalculator");
             ClientRegistry.registerKeyBinding(captureMomentumBlockKeyBinding);
@@ -325,6 +328,10 @@ public class Forge8ParkourCalculator {
         while (solverEndTickKeyBinding.isPressed()) {
             solverEndPressed = true;
         }
+        boolean rerunSimulationPressed = false;
+        while (rerunSimulationKeyBinding.isPressed()) {
+            rerunSimulationPressed = true;
+        }
         boolean captureMomentum = false;
         boolean captureCollision = false;
         boolean captureLand = false;
@@ -376,6 +383,9 @@ public class Forge8ParkourCalculator {
             }
             if (solverEndPressed && chordFree) {
                 application.setSolverLandingTickFromSelection();
+            }
+            if (rerunSimulationPressed && chordFree) {
+                application.runSimulation();
             }
             if (captureMomentum && chordFree) {
                 application.captureAngleSolverBlock(BlockSelection.Kind.MOMENTUM);
@@ -444,6 +454,10 @@ public class Forge8ParkourCalculator {
         }
         if (keyCode == solverEndTickKeyBinding.getKeyCode()) {
             application.setSolverLandingTickFromSelection();
+            return true;
+        }
+        if (keyCode == rerunSimulationKeyBinding.getKeyCode()) {
+            application.runSimulation();
             return true;
         }
         return false;

--- a/loader-forge-1.8.9/src/main/resources/assets/parkourcalculator/lang/en_US.lang
+++ b/loader-forge-1.8.9/src/main/resources/assets/parkourcalculator/lang/en_US.lang
@@ -8,6 +8,7 @@ key.parkourcalculator.apply_surface_state=Apply surface state from path
 key.parkourcalculator.solve=Solve and apply (Angle Solver)
 key.parkourcalculator.set_solver_start=Set solver start tick
 key.parkourcalculator.set_solver_end=Set solver goal tick
+key.parkourcalculator.rerun_simulation=Rerun simulation
 key.parkourcalculator.capture_momentum_block=Capture Momentum block
 key.parkourcalculator.capture_collision_block=Capture Collision block
 key.parkourcalculator.capture_land_block=Capture Land block


### PR DESCRIPTION
Closes #325.

## What
Adds a rebindable **Rerun simulation** keybind (default **R**) that re-runs the full simulation from tick 0.

## Why
When a world edit invalidates the TAS path (placing/breaking a block, opening a trapdoor), the simulation does not auto-update. The current workaround is to select a tick before the change, open the table, and toggle an input back and forth to force a re-sim. This hotkey does it in one press. Re-simulating from the top is cheap, so it is not gated on the selected tick.

## Scope
- New `rerunSimulationKeyBinding` wired in all four MC loaders (Fabric 26.2, Fabric 1.21.3, Forge 1.8.9, Forge 1.12.2), dispatched both in-world and through the in-overlay hotkey path (Forge `dispatchHotkey`, Fabric 1.21.3 `dispatchOverlayHotkey`).
- Action calls the existing `Application.runSimulation()`; no new core logic.
- Translation strings added to each loader's lang file.

Chord-free (ignored while Ctrl is held), consistent with the other action keybinds.

## Test plan
- No `core` changes, so `:core:test` is unaffected.
- In-game QA pending on the touched loaders: press R after a block edit and confirm the path re-simulates; confirm the bind is listed and rebindable under Controls.