### PR TITLE
fix: select the first tick when tapping the start box

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
@@ -430,7 +430,7 @@ public final class Application {
 
     private void commitStartTap() {
         if (boxController.size() == 0) return;
-        selection.handleClick(0);
+        selection.handleClick(boxController.size() >= 2 ? 1 : 0);
         selection.requestScrollIntoView();
     }
 


### PR DESCRIPTION
Closes #330.

## Bug
Left-clicking the dot of the very first tick showed the blue highlight but was not treated as selected: the constraint hotkey and the solver start/goal hotkeys did nothing.

## Root cause
The start box owns box 0, and a tap on it routed through `commitStartTap()` -> `selection.handleClick(0)`, selecting the **Start** row (path 0). Every tick-oriented consumer uses `getSelectedRows()`, which drops path 0 (`if (p >= 1) rows.add(p - 1)`), so `firstSelectedRow()` returned -1 and the hotkeys reported "No tick selected". The highlight still showed because box 0 was tinted for the Start selection.

## Fix
`commitStartTap()` now selects **Tick 1** (path 1) when the path has at least one movement tick, matching the `box k -> Tick k+1` mapping already used for every other box in `commitWorldTap()`. Because Tick 1 and the Start both map to box 0 (`SelectionManager.boxIndexForSelection`), the on-screen highlight is identical; the difference is that the selection is now one the constraint and solver-start/goal hotkeys accept. It falls back to selecting the Start only when there are no ticks yet.

Trade-off: tapping the start box in the world no longer selects the **Start** table row (it selects Tick 1). The Start row remains selectable from its dedicated row in the input table.

## Test plan
- `:core:test` passes.
- In-game QA pending: click the first tick's dot, then press the constraint hotkey and the solver-start/goal hotkeys and confirm they now apply to Tick 1.