### PR TITLE
feat: Catmull-Rom interpolation across tick yaws in playback

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/PlaybackController.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/PlaybackController.java
@@ -48,6 +48,7 @@ public final class PlaybackController {
     // Lerp endpoints displayedYaw chases; congruent to currentTickYaw mod 360.
     private float prevTickYaw;
     private float displayTargetYaw;
+    private float prevPrevTickYaw;
     private long tickEndNanos;
 
     // displayedYaw is the camera yaw; it equals the ideal lerp value when the
@@ -178,6 +179,7 @@ public final class PlaybackController {
         // A carried checkpoint is already post-settle; warm up only a from-the-top start that has none.
         warmupRemaining = (from == 0 && carry == null) ? WARMUP_TICKS : 0;
         prevTickYaw = yaw;
+        prevPrevTickYaw = yaw;
         currentTickYaw = yaw;
         displayTargetYaw = yaw;
         displayedYaw = yaw;
@@ -300,6 +302,7 @@ public final class PlaybackController {
             bridge.setHotbarSlot(hotbarSlot - 1);
         }
         Float yaw = row.getYaw();
+        prevPrevTickYaw = prevTickYaw;
         prevTickYaw = displayTargetYaw;
         if (yaw != null) {
             if (row.isYawLocked()) {
@@ -348,6 +351,25 @@ public final class PlaybackController {
         return d;
     }
 
+    private static float nextDisplayYaw(float base, InputRow row) {
+        Float yaw = row.getYaw();
+        if (yaw == null) return base;
+        if (row.isYawLocked()) return base + shortestDelta(base, yaw);
+        if (yaw != 0f) return base + yaw;
+        return base;
+    }
+
+    private static float catmullRom(float p0, float p1, float p2, float p3, float t) {
+        if (t <= 0f) return p1;
+        if (t >= 1f) return p2;
+        float t2 = t * t;
+        float t3 = t2 * t;
+        return 0.5f * ((2f * p1)
+                + (-p0 + p2) * t
+                + (2f * p0 - 5f * p1 + 4f * p2 - p3) * t2
+                + (-p0 + 3f * p1 - 3f * p2 + p3) * t3);
+    }
+
     /** Loader calls after MC's physics tick so the snap value never reaches a render. */
     public void postTick() {
         if (!running || bridge == null) return;
@@ -392,7 +414,10 @@ public final class PlaybackController {
         float partial = elapsed / (float) TICK_NANOS;
         if (partial < 0f) partial = 0f;
         if (partial > 1f) partial = 1f;
-        float idealYaw = prevTickYaw + (displayTargetYaw - prevTickYaw) * partial;
+        float nextTickYaw = nextTick < inputData.size()
+                ? nextDisplayYaw(displayTargetYaw, inputData.get(nextTick))
+                : displayTargetYaw;
+        float idealYaw = catmullRom(prevPrevTickYaw, prevTickYaw, displayTargetYaw, nextTickYaw, partial);
 
         float delta = idealYaw - displayedYaw;
         float maxStep = settings.yawFlickSpeed * dt;


### PR DESCRIPTION
Closes #47.

## What
Replaces the per-tick **linear** yaw interpolation in `PlaybackController.renderFrame()` with a **uniform Catmull-Rom** spline through neighbouring tick yaws. Each tick yaw is still hit exactly, but the curve through them has a continuous first derivative, so the visual angular velocity no longer steps at tick boundaries.

## Why
The linear lerp hit each tick's yaw exactly, then switched to a new slope at the next boundary. When consecutive tick deltas differ in magnitude (e.g. 5 deg then 30 deg) the kink is visible. Catmull-Rom passes through the same control points with C1 continuity, removing the kink while preserving the "each tick retains its exact value" invariant.

## How
- New `prevPrevTickYaw` field tracks `yaw[N-1]`; the look-ahead `yaw[N+2]` is derived from `inputData` via `nextDisplayYaw`, which mirrors `advanceTick`'s `displayTargetYaw` update (locked vs relative rows), so the spline stays in the same raw, non-wrapped yaw frame.
- `catmullRom(p0,p1,p2,p3,t)` clamps to `p1` at `t<=0` and `p2` at `t>=1`, guaranteeing exact tick values at `partial` 0 and 1 (and keeping the exact-boundary stop condition intact).
- Endpoints duplicate the missing neighbour (`p0=p1` at the first window, `p3=p2` at the last), degenerating to a smooth start/stop.

## Non-goals (unchanged)
- Physics/position parity: physics still snaps to `currentTickYaw` each tick.
- The `Max yaw turn rate` cap still applies to the chase toward the ideal value.
- No new user setting; uniform parameterisation (centripetal noted as a fallback in the issue if extreme deltas spike).

## Test plan
- `:core:test` passes (this path had no prior tests).
- In-game QA pending: replay a TAS with sharply varying per-tick yaw deltas and confirm the camera rotation is smooth across tick boundaries with each tick yaw still hit exactly.