### PR TITLE
fix: no start box or unsaved state before a TAS is opened or created

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
@@ -321,6 +321,7 @@ public final class Application {
 
     private void runSimulation(int dirtyTick) {
         if (!mc.isReady()) return;
+        if (!saveController.isSessionActive()) return;
         long t0 = Perf.now();
         boolean incremental = dirtyTick > 0 && runner.canResumeFrom(dirtyTick)
                 && boxController.size() > dirtyTick && !DebugFlags.COMPARE_PARTIAL_SIM;
@@ -374,7 +375,7 @@ public final class Application {
         runner.invalidate();
         boxController.clearAll();
         inputData.clear();
-        saveController.discardCurrent();
+        saveController.endSession();
         if (undoController != null) undoController.onDocumentReplaced(null);
         startInitialized = false;
     }
@@ -482,7 +483,6 @@ public final class Application {
         if (!mc.isReady()) return;
         if (!startInitialized) {
             runner.setStartPosition(mc.getPlayerPosition());
-            runSimulation();
             startInitialized = true;
             saveController.tryReopenLastSave();
         }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/SaveController.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/SaveController.java
@@ -56,6 +56,7 @@ public final class SaveController {
 
     private String currentName;
     private boolean dirty;
+    private boolean sessionActive;
     private String preTempSnapshotJson;
     private boolean tempActive;
     private volatile String pendingWriteError;
@@ -102,7 +103,17 @@ public final class SaveController {
     }
 
     void markDirty() {
+        if (!sessionActive) return;
         this.dirty = true;
+    }
+
+    public boolean isSessionActive() {
+        return sessionActive;
+    }
+
+    public void endSession() {
+        sessionActive = false;
+        discardCurrent();
     }
 
     public boolean isTempActive() {
@@ -215,6 +226,7 @@ public final class SaveController {
         });
         currentName = sanitized;
         dirty = false;
+        sessionActive = true;
         if (undo != null) undo.bindJournal(journalFor(currentName));
         writeLastOpen(currentName);
         return Result.success(sanitized);
@@ -263,6 +275,7 @@ public final class SaveController {
         if (!result.ok) return result;
 
         SaveFile.Start s = result.value.start;
+        sessionActive = true;
         if (solverEngine != null) solverEngine.onProblemReplaced();
         SaveIO.applyRowsTo(result.value, inputData);
         SaveIO.applyAngleSolverTo(result.value, angleSolver);
@@ -361,6 +374,7 @@ public final class SaveController {
     }
 
     public void newSession() {
+        sessionActive = true;
         inputData.clear();
         if (solverEngine != null) solverEngine.onProblemReplaced();
         if (angleSolver != null) angleSolver.reset();

--- a/core/src/test/java/de/legoshi/parkourcalc/core/AutoSaveTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/AutoSaveTest.java
@@ -69,6 +69,8 @@ public class AutoSaveTest {
     public void autoSaveIgnoresUnnamedSessions() throws Exception {
         // Unnamed: never opens a popup or writes anything.
         Rig unnamed = new Rig(Files.createTempDirectory("pkc-autosave3"));
+        assertTrue(unnamed.controller.save("seed").ok);
+        assertTrue(unnamed.controller.delete("seed"));
         unnamed.controller.markDirty();
         unnamed.menu.tickAutoSave();
         Thread.sleep(1);

--- a/core/src/test/java/de/legoshi/parkourcalc/core/SessionActivationTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/SessionActivationTest.java
@@ -1,0 +1,63 @@
+package de.legoshi.parkourcalc.core;
+
+import de.legoshi.parkourcalc.core.save.FileSystemSaveStore;
+import de.legoshi.parkourcalc.core.sim.SimulationRunner;
+import de.legoshi.parkourcalc.core.ui.InputData;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class SessionActivationTest {
+
+    private static final class Rig {
+        final InputData data = new InputData();
+        final SaveController controller;
+        final FileSystemSaveStore store;
+
+        Rig(Path dir) {
+            SimulationRunner runner = new SimulationRunner(new FakeSimulator());
+            controller = new SaveController(data, runner, new FakeMinecraftAccess(), () -> { });
+            store = new FileSystemSaveStore(dir, "test", "1.8.9", () -> null);
+            controller.setSaveStore(store);
+        }
+    }
+
+    @Test
+    public void markDirtyIsIgnoredWithoutASession() throws Exception {
+        Rig rig = new Rig(Files.createTempDirectory("pkc-session1"));
+        assertFalse(rig.controller.isSessionActive());
+        rig.controller.markDirty();
+        assertFalse(rig.controller.isDirty());
+    }
+
+    @Test
+    public void newSessionActivatesAndEndSessionDeactivates() throws Exception {
+        Rig rig = new Rig(Files.createTempDirectory("pkc-session2"));
+        rig.controller.newSession();
+        assertTrue(rig.controller.isSessionActive());
+        rig.controller.markDirty();
+        assertTrue(rig.controller.isDirty());
+        rig.controller.endSession();
+        assertFalse(rig.controller.isSessionActive());
+        assertFalse(rig.controller.isDirty());
+        rig.controller.markDirty();
+        assertFalse(rig.controller.isDirty());
+    }
+
+    @Test
+    public void loadAndSaveActivateTheSession() throws Exception {
+        Path dir = Files.createTempDirectory("pkc-session3");
+        Rig writer = new Rig(dir);
+        assertFalse(writer.controller.isSessionActive());
+        assertTrue(writer.controller.save("run").ok);
+        assertTrue(writer.controller.isSessionActive());
+
+        Rig reader = new Rig(dir);
+        assertTrue(reader.controller.load("run").ok);
+        assertTrue(reader.controller.isSessionActive());
+    }
+}


### PR DESCRIPTION
Fixes #350

## Problem
On world join with no TAS loaded, a start box appeared at the spawn position. Dragging it marked the (nonexistent) document dirty: the main pane title showed the unsaved asterisk, New/Open warned about unsaved changes, and Ctrl+S opened Save TAS As.

## Change
SaveController now tracks an explicit session state. A session starts on load, save, or New TAS and ends on world change. Application.runSimulation is gated on the active session, so no boxes exist before a TAS is opened or created (matching the empty-state CTA in the main pane), and markDirty is ignored while no session is active.

The initial simulation kick in tickDrag is removed; it could only run sessionless. Reopening the last save still activates the session and shows the path as before.

## Tests
- SessionActivationTest: markDirty ignored without a session; newSession/load/save activate; endSession deactivates and clears dirty.
- AutoSaveTest updated: the unnamed-session case now reaches that state through save + delete, the only way an unnamed editable session arises under the session model.
- :core:test passes.