### PR TITLE
fix(fabric): suppress pause on lost focus while the UI is open

### DIFF
--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricParkourCalculator.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricParkourCalculator.java
@@ -561,6 +561,10 @@ public class FabricParkourCalculator implements ClientModInitializer {
         return application.isControlPanelOpen() && Minecraft.getInstance().gui.screen() == null;
     }
 
+    public static boolean isControlPanelOpen() {
+        return application.isControlPanelOpen();
+    }
+
     public static boolean shouldSuppressLeftClick() {
         return application.shouldSuppressLeftClick();
     }

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/mixin/MinecraftMixin.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/mixin/MinecraftMixin.java
@@ -35,4 +35,9 @@ public class MinecraftMixin {
         FabricParkourCalculator.syncFrozenPlayerToServer();
     }
 
+    @Inject(method = "pauseIfInactive", at = @At("HEAD"), cancellable = true)
+    private void pkc$skipLostFocusPauseWhileUiOpen(CallbackInfo ci) {
+        if (FabricParkourCalculator.isControlPanelOpen()) ci.cancel();
+    }
+
 }


### PR DESCRIPTION
Fixes #349

## Problem
With 'pause on lost focus' enabled (F3+P), unfocusing the Minecraft window while the PKC UI is open triggers the vanilla auto-pause. On 26.2 the HUD and screen rasterize in one GuiRenderer pass, and ImGui deliberately draws below that raster whenever a screen is open, so the pause screen also pushes the UI behind the HUD (title/hotbar/crosshair), exactly as in the report's screenshot.

## Change
Minecraft.pauseIfInactive is the only lost-focus pause path in 26.2. A new cancellable HEAD inject in MinecraftMixin skips it while the PKC control panel is open. Esc and other user-initiated pauses are untouched. With no auto-pause there is no screen, so the UI stays on the above-HUD render path.

The one-frame stale lastActiveTime after closing the panel is harmless: the focused branch refreshes it before any pause can trigger.

## Notes
Fabric 26.2 only, matching the report. :loader-fabric:build passes; needs the usual in-game QA pass (F3+P, open UI, alt-tab).