### PR TITLE
fix: keep constraint ticks inside the route so none land past the last row

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
@@ -184,7 +184,7 @@ public final class Application {
         ExactJumpModel forwardModel = ExactJumpModel.forMcVersion(mcVersion);
         constraintKeyController = new ConstraintKeyController(
                 mc, angleSolverState, selection, constraintSelection, saveController::markDirty,
-                forwardModel.modern());
+                forwardModel.modern(), inputData::size);
         saveController.setAngleSolver(angleSolverState);
         saveController.setDebugSource(boxController, settings);
         AngleSolverTable angleSolverTable = new AngleSolverTable(angleSolverState, settings, selection, constraintSelection, inputData::size);

--- a/core/src/main/java/de/legoshi/parkourcalc/core/SaveController.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/SaveController.java
@@ -265,7 +265,7 @@ public final class SaveController {
         SaveFile.Start s = result.value.start;
         if (solverEngine != null) solverEngine.onProblemReplaced();
         SaveIO.applyRowsTo(result.value, inputData);
-        SaveIO.applyAngleSolverTo(result.value, angleSolver);
+        SaveIO.applyAngleSolverTo(result.value, angleSolver, inputData.size());
         resolveGraphPreset();
         // Must precede the setStart* calls: invalidate clears pending*, which they then refill.
         runner.invalidate();

--- a/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveIO.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveIO.java
@@ -174,6 +174,10 @@ public final class SaveIO {
 
     /** Rebuilds the Angle Solver problem from the save. Always resets first, so a pre-feature save yields an empty solver. */
     public static void applyAngleSolverTo(SaveFile file, AngleSolverState state) {
+        applyAngleSolverTo(file, state, 0);
+    }
+
+    public static void applyAngleSolverTo(SaveFile file, AngleSolverState state, int rowCount) {
         if (state == null) return;
         state.reset();
         SaveFile.AngleSolver a = file.angleSolver;
@@ -201,10 +205,13 @@ public final class SaveIO {
             }
         }
 
+        if (rowCount > 0) state.clampTicks(rowCount);
+
         if (a.ticks != null) {
             for (SaveFile.Tick t : a.ticks) {
                 if (t == null) continue;
-                TickConstraints tc = state.tickConstraints(t.tick);
+                int tick = rowCount > 0 ? Math.min(Math.max(t.tick, 0), rowCount - 1) : t.tick;
+                TickConstraints tc = state.tickConstraints(tick);
                 if (t.constraints != null) {
                     for (SaveFile.Constraint c : t.constraints) {
                         Constraint constraint = toConstraint(c);

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/ConstraintKeyController.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/ConstraintKeyController.java
@@ -12,6 +12,7 @@ import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.function.IntSupplier;
 
 public final class ConstraintKeyController {
 
@@ -21,16 +22,18 @@ public final class ConstraintKeyController {
     private final ConstraintSelection constraintSelection;
     private final Runnable onChanged;
     private final boolean modernCollision;
+    private final IntSupplier rowCount;
 
     public ConstraintKeyController(MinecraftAccess mc, AngleSolverState state, SelectionManager selection,
                                    ConstraintSelection constraintSelection, Runnable onChanged,
-                                   boolean modernCollision) {
+                                   boolean modernCollision, IntSupplier rowCount) {
         this.mc = mc;
         this.state = state;
         this.selection = selection;
         this.constraintSelection = constraintSelection;
         this.onChanged = onChanged;
         this.modernCollision = modernCollision;
+        this.rowCount = rowCount;
     }
 
     public void onKey(boolean enter, boolean remove) {
@@ -132,7 +135,7 @@ public final class ConstraintKeyController {
 
     private int selectedTick() {
         Set<Integer> rows = selection.getSelectedRows();
-        if (!rows.isEmpty()) return rows.iterator().next();
-        return state.getLandingTick();
+        int tick = rows.isEmpty() ? state.getLandingTick() : rows.iterator().next();
+        return Math.min(tick, rowCount.getAsInt() - 1);
     }
 }

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/GhostConstraintLoadHealTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/GhostConstraintLoadHealTest.java
@@ -1,0 +1,66 @@
+package de.legoshi.parkourcalc.anglesolver;
+
+import de.legoshi.parkourcalc.core.anglesolver.AngleSolverState;
+import de.legoshi.parkourcalc.core.save.SaveFile;
+import de.legoshi.parkourcalc.core.save.SaveIO;
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class GhostConstraintLoadHealTest {
+
+    private static SaveFile fileWithConstraintAtTick(int tick, int rowCount, int landingTick) {
+        SaveFile f = new SaveFile();
+        f.rows = new ArrayList<SaveFile.Row>();
+        for (int i = 0; i < rowCount; i++) f.rows.add(new SaveFile.Row());
+        f.angleSolver = new SaveFile.AngleSolver();
+        f.angleSolver.startTick = 0;
+        f.angleSolver.landingTick = landingTick;
+        f.angleSolver.ticks = new ArrayList<SaveFile.Tick>();
+        SaveFile.Tick t = new SaveFile.Tick();
+        t.tick = tick;
+        SaveFile.Constraint c = new SaveFile.Constraint();
+        c.range = false;
+        c.field = "X";
+        c.op = "LE";
+        c.value = 718.7;
+        t.constraints.add(c);
+        f.angleSolver.ticks.add(t);
+        return f;
+    }
+
+    @Test
+    public void constraintPastTheLastRowClampsOntoTheLastRowOnLoad() {
+        SaveFile f = fileWithConstraintAtTick(84, 84, 61);
+        AngleSolverState state = new AngleSolverState();
+        SaveIO.applyAngleSolverTo(f, state, 84);
+
+        assertNull("ghost slot is gone", state.tickConstraintsOrNull(84));
+        assertNotNull("constraint healed onto the last row", state.tickConstraintsOrNull(83));
+        assertEquals(1, state.tickConstraintsOrNull(83).getConstraints().size());
+        assertEquals(61, state.getLandingTick());
+    }
+
+    @Test
+    public void staleStartAndLandingTicksClampOnLoad() {
+        SaveFile f = fileWithConstraintAtTick(2, 4, 9);
+        AngleSolverState state = new AngleSolverState();
+        SaveIO.applyAngleSolverTo(f, state, 4);
+
+        assertEquals(3, state.getLandingTick());
+        assertNotNull(state.tickConstraintsOrNull(2));
+    }
+
+    @Test
+    public void withoutRowCountTicksApplyUnclamped() {
+        SaveFile f = fileWithConstraintAtTick(84, 84, 61);
+        AngleSolverState state = new AngleSolverState();
+        SaveIO.applyAngleSolverTo(f, state);
+
+        assertNotNull(state.tickConstraintsOrNull(84));
+    }
+}

--- a/core/src/test/java/de/legoshi/parkourcalc/ui/ConstraintKeyControllerTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/ui/ConstraintKeyControllerTest.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 public class ConstraintKeyControllerTest {
 
@@ -38,7 +39,7 @@ public class ConstraintKeyControllerTest {
         state = new AngleSolverState();
         state.setLandingTick(TICK);
         controller = new ConstraintKeyController(
-                mc, state, new SelectionManager(mc), new ConstraintSelection(), () -> { }, false);
+                mc, state, new SelectionManager(mc), new ConstraintSelection(), () -> { }, false, () -> TICK + 1);
     }
 
     private List<Constraint> constraints() {
@@ -106,6 +107,21 @@ public class ConstraintKeyControllerTest {
         assertNotNull(wall);
         assertEquals(Constraint.Op.GE, wall.getOp());
         assertEquals("wall sits on the inset collision face, not the outline hit", 5.9375 + HALF, wall.getValue(), EPS);
+    }
+
+    @Test
+    public void staleLandingTickPastTheLastRowClampsToTheLastRow() {
+        state.setLandingTick(9);
+        mc.worldBoxes.add(box(5.0, 64.0, 5.0, 6.0, 65.0, 6.0));
+        mc.lookedAtBlock = new int[] {5, 64, 5};
+        mc.lookedAtFace = Face.POS_X;
+        mc.lookedAtHitVec = new Vec3dCore(6.0, 64.5, 5.5);
+
+        controller.onKey(false, false);
+
+        assertNull("no ghost entry past the route", state.tickConstraintsOrNull(9));
+        assertNotNull("wall clamped onto the last row", state.tickConstraintsOrNull(TICK));
+        assertEquals(1, state.tickConstraintsOrNull(TICK).getConstraints().size());
     }
 
     @Test


### PR DESCRIPTION
Fixes #348

## Diagnosis
The attached comp1.json holds a constraint entry at tick 84 with exactly 84 rows. The tick domain everywhere in the UI is 0..rowCount-1: the table has no row for tick 84, and the world tap handler rejects picks on the final preview box, so the plate rendered but could never be selected or removed.

The creation hole is the constraint hotkey's fallback: with no row selected, B targets state.getLandingTick(), and clampTicks only runs while the solver window is open. Deleting trailing rows with the solver view closed leaves landingTick == rowCount; the next B press with an empty selection then writes a constraint one past the route. Row selection itself cannot produce this (SelectionManager already shifts path indices back to row indices).

## Change
- ConstraintKeyController clamps the target tick to the last row (new rowCount supplier from Application), so the stale-landing fallback can no longer write past the route.
- SaveIO.applyAngleSolverTo gains a rowCount overload used by SaveController.load: out-of-range constraint ticks clamp onto the last row and stale start/landing ticks clamp on load. The reporter's file heals into a visible, deletable chip on the last row instead of an unselectable plate.
- Undo/temp snapshots (applySnapshotJson) intentionally stay unclamped so snapshot round-trips remain byte-stable; the 2-arg overload keeps its old behavior for the slice path and tests.

## Tests
- ConstraintKeyControllerTest: stale landing tick past the route clamps onto the last row.
- GhostConstraintLoadHealTest: load-time clamping of constraints and start/landing ticks, plus unclamped behavior without a rowCount.
- Full :core:test -PslowTests passes.