### PR TITLE
fix(fabric): sync player attribute base values into the simulation

### DIFF
--- a/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/sim/FabricSimulator.java
+++ b/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/sim/FabricSimulator.java
@@ -141,6 +141,8 @@ public final class FabricSimulator extends LazyEntitySimulator<SimulatorEntity> 
     }
 
     @Override protected void resetEntity(SimulatorEntity e, StartResumeState resume) {
+        Player player = Minecraft.getInstance().player;
+        if (player != null) e.getAttributes().assignBaseValues(player.getAttributes());
         ensurePair(e);
         if (pair != null) {
             pair.resetForFullRun(e, resume);

--- a/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/sim/paired/PairedServerSim.java
+++ b/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/sim/paired/PairedServerSim.java
@@ -20,6 +20,7 @@ import net.minecraft.network.protocol.game.ServerboundPlayerInputPacket;
 import net.minecraft.network.protocol.game.ServerboundUseItemOnPacket;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.Mth;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.damagesource.DamageSource;
@@ -130,6 +131,8 @@ public final class PairedServerSim {
     }
 
     private void resetServerSide(SimulatorEntity e) {
+        ServerPlayer real = level.getServer().getPlayerList().getPlayer(e.getUUID());
+        if (real != null) sp.getAttributes().assignBaseValues(real.getAttributes());
         sp.absMoveTo(e.getX(), e.getY(), e.getZ(), e.getYRot(), 0.0F);
         sp.setDeltaMovement(e.getDeltaMovement());
         sp.fallDistance = 0.0F;

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/sim/FabricSimulator.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/sim/FabricSimulator.java
@@ -141,6 +141,8 @@ public final class FabricSimulator extends LazyEntitySimulator<SimulatorEntity> 
     }
 
     @Override protected void resetEntity(SimulatorEntity e, StartResumeState resume) {
+        Player player = Minecraft.getInstance().player;
+        if (player != null) e.getAttributes().assignBaseValues(player.getAttributes());
         ensurePair(e);
         if (pair != null) {
             pair.resetForFullRun(e, resume);

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/sim/paired/PairedServerSim.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/sim/paired/PairedServerSim.java
@@ -24,6 +24,7 @@ import net.minecraft.network.protocol.game.ServerboundPlayerLoadedPacket;
 import net.minecraft.network.protocol.game.ServerboundUseItemOnPacket;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.Mth;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.damagesource.DamageSource;
@@ -134,6 +135,8 @@ public final class PairedServerSim {
     }
 
     private void resetServerSide(SimulatorEntity e) {
+        ServerPlayer real = level.getServer().getPlayerList().getPlayer(e.getUUID());
+        if (real != null) sp.getAttributes().assignBaseValues(real.getAttributes());
         sp.absSnapTo(e.getX(), e.getY(), e.getZ(), e.getYRot(), 0.0F);
         sp.setDeltaMovement(e.getDeltaMovement());
         sp.fallDistance = 0.0;


### PR DESCRIPTION
Fixes #347

## Problem
The simulator entity and the paired server player are created with default attributes. A mapper's /attribute changes on the real player (the report's case: minecraft:burning_time base 0.001 to reduce fire to a single tick) never reach the simulation, so the paired sim's server events show the full vanilla fire duration.

## Change
On every full-run reset, attribute base values are copied from the real player into the simulation via the vanilla AttributeMap.assignBaseValues:
- FabricSimulator.resetEntity copies from the local player onto the client SimulatorEntity.
- PairedServerSim.resetServerSide copies from the real ServerPlayer (looked up by UUID on the integrated server) onto the paired server player, before the warmup ticks.

Base values only: transient modifiers (potions, equipment) stay under the sim's own control, so InputRow amplifier handling is unaffected. This also covers other attribute-driven divergences of the same kind (ignition scales at igniteForTicks by BURNING_TIME in 26.2), which the reporter suspected exist beyond fire.

Applied to both Fabric loaders (26.2 and 1.21.3, which mirrors the paired sim). The 1.8.9/1.12.2 Forge loaders predate MC attributes of this kind and are untouched.

## Verify
:loader-fabric:build and :loader-fabric-1.21.3:build pass. In-game QA: set burning_time to 0.001, run into lava, confirm the server events window logs a single onFire ruling.