### PR TITLE
fix(ui): make Tick Info settings rows as tall as the widgets they contain

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/TickInfoStatsEditor.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/TickInfoStatsEditor.java
@@ -91,6 +91,8 @@ public final class TickInfoStatsEditor {
         String label = stat != null ? stat.label() : setting.id;
         String tooltip = stat != null ? stat.tooltip() : "";
 
+        boolean hasDecimals = usesDecimals(stat);
+
         Controls.pushInputFrameHeight();
         float rowH = ThemeManager.tableRowHeight();
         ImGui.tableNextRow(0, rowH);
@@ -98,6 +100,8 @@ public final class TickInfoStatsEditor {
         if (draggingIndex == index) {
             ThemeManager.paintTableRowTint(ThemeManager.selectedTintColor(0.5f));
         }
+
+        float cellPadX = ImGui.getStyle().getCellPadding().x;
 
         ImGui.tableNextColumn();
         float rowTopScreen = ImGui.getCursorScreenPos().y - ImGui.getStyle().getCellPadding().y;
@@ -108,20 +112,21 @@ public final class TickInfoStatsEditor {
         ThemeManager.leftAlignedSelectable("stat" + index, label, draggingIndex == index, selFlags,
                 0f, ImGui.getFrameHeight());
         ThemeManager.popTextColor();
-        TooltipUtil.onHover(tooltip.isEmpty() ? TT_GRIP : tooltip);
-        if (ImGui.isItemHovered()) ImGui.setMouseCursor(ImGuiMouseCursor.Hand);
+        float spanMinX = ImGui.getItemRectMin().x;
+        float spanMaxX = ImGui.getItemRectMax().x;
 
         handleRowDragDrop(index, rowTopScreen, rowH);
 
         ImGui.tableNextColumn();
+        float onCellX = ImGui.getCursorScreenPos().x;
         if (Controls.checkbox("##on" + index, setting.enabled)) {
             setting.enabled = !setting.enabled;
             onChanged.run();
         }
-        TooltipUtil.onHover(TT_TOGGLE);
 
         ImGui.tableNextColumn();
-        if (usesDecimals(stat)) {
+        float decCellX = ImGui.getCursorScreenPos().x;
+        if (hasDecimals) {
             decimalsBuf[0] = setting.decimals;
             ImGui.setNextItemWidth(-(2f * ThemeManager.tableEdgeCellInset()));
             if (Controls.sliderInt("##dec" + index, decimalsBuf,
@@ -129,10 +134,21 @@ public final class TickInfoStatsEditor {
                 setting.decimals = decimalsBuf[0];
             }
             if (ImGui.isItemDeactivatedAfterEdit()) onChanged.run();
-            TooltipUtil.onHover(TT_DECIMALS);
         }
         ThemeManager.tableRightmostCellTrailingPad();
         Controls.popInputFrameHeight();
+
+        if (!ImGui.isWindowHovered()) return;
+        if (!ImGui.isMouseHoveringRect(spanMinX, rowTopScreen, spanMaxX, rowTopScreen + rowH, false)) return;
+        float mouseX = ImGui.getMousePos().x;
+        if (mouseX < onCellX - cellPadX) {
+            ImGui.setMouseCursor(ImGuiMouseCursor.Hand);
+            TooltipUtil.wrappedTooltip(tooltip.isEmpty() ? TT_GRIP : tooltip);
+        } else if (mouseX < decCellX - cellPadX) {
+            TooltipUtil.wrappedTooltip(TT_TOGGLE);
+        } else if (hasDecimals) {
+            TooltipUtil.wrappedTooltip(TT_DECIMALS);
+        }
     }
 
     private void handleRowDragDrop(int index, float rowTopScreen, float rowH) {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/TickInfoStatsEditor.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/TickInfoStatsEditor.java
@@ -105,7 +105,8 @@ public final class TickInfoStatsEditor {
         ThemeManager.pushTextColor(draggingIndex == index ? ThemeManager.textColor() : ThemeManager.textMutedColor());
         int selFlags = ImGuiSelectableFlags.SpanAllColumns | ImGuiSelectableFlags.AllowItemOverlap
                 | ImGuiSelectableFlags.DontClosePopups;
-        ThemeManager.leftAlignedSelectable("stat" + index, label, draggingIndex == index, selFlags);
+        ThemeManager.leftAlignedSelectable("stat" + index, label, draggingIndex == index, selFlags,
+                0f, ImGui.getFrameHeight());
         ThemeManager.popTextColor();
         TooltipUtil.onHover(tooltip.isEmpty() ? TT_GRIP : tooltip);
         if (ImGui.isItemHovered()) ImGui.setMouseCursor(ImGuiMouseCursor.Hand);

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/theme/ThemeManager.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/theme/ThemeManager.java
@@ -457,11 +457,17 @@ public final class ThemeManager {
 
     public static boolean leftAlignedSelectable(String idSuffix, String label, boolean selected, int flags, float sizeX, float sizeY) {
         ImVec2 cellOrigin = ImGui.getCursorScreenPos();
-        ImGui.alignTextToFramePadding();
+        float textOffsetY;
+        if (sizeY > 0f) {
+            textOffsetY = (sizeY - ImGui.getFontSize()) * 0.5f;
+        } else {
+            ImGui.alignTextToFramePadding();
+            textOffsetY = ImGui.getStyle().getFramePadding().y;
+        }
         boolean clicked = ImGui.selectable("##" + idSuffix, selected, flags, sizeX, sizeY);
         if (label != null && !label.isEmpty()) {
             float tx = cellOrigin.x + tableEdgeCellInset();
-            float ty = cellOrigin.y + ImGui.getStyle().getFramePadding().y;
+            float ty = cellOrigin.y + textOffsetY;
             ImGui.getWindowDrawList().addText(tx, ty, ImGui.getColorU32(ImGuiCol.Text), label);
         }
         return clicked;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/theme/ThemeManager.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/theme/ThemeManager.java
@@ -452,9 +452,13 @@ public final class ThemeManager {
     }
 
     public static boolean leftAlignedSelectable(String idSuffix, String label, boolean selected, int flags) {
+        return leftAlignedSelectable(idSuffix, label, selected, flags, 0f, 0f);
+    }
+
+    public static boolean leftAlignedSelectable(String idSuffix, String label, boolean selected, int flags, float sizeX, float sizeY) {
         ImVec2 cellOrigin = ImGui.getCursorScreenPos();
         ImGui.alignTextToFramePadding();
-        boolean clicked = ImGui.selectable("##" + idSuffix, selected, flags);
+        boolean clicked = ImGui.selectable("##" + idSuffix, selected, flags, sizeX, sizeY);
         if (label != null && !label.isEmpty()) {
             float tx = cellOrigin.x + tableEdgeCellInset();
             float ty = cellOrigin.y + ImGui.getStyle().getFramePadding().y;


### PR DESCRIPTION
Fixes #346

## Problem
The row hover target in Settings > Tick Info is a span-all-columns selectable whose height defaults to the text height, while the checkbox and the decimals slider in the same row are frame-height. Hovering the top or bottom edge of a widget leaves the selectable's rect, so the row description line flickers out of the tooltip while the mouse is still visually inside the row.

## Change
ThemeManager.leftAlignedSelectable gains a size overload (mirroring rightAlignedSelectable), and TickInfoStatsEditor passes the current frame height so the row's hover rect covers the full widget height. Rendering is unchanged otherwise; drag-to-reorder keeps using the row rect it already computed.

## Verify
:core:build passes (includes tableStyleCheck). In-game QA: hover across a Tick Info settings row and onto the checkbox top edge; the row description should stay in the tooltip.