### PR TITLE
fix: add dX comparison checkbox to dZ constraints

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/AngleSolverEngine.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/AngleSolverEngine.java
@@ -1296,12 +1296,13 @@ public final class AngleSolverEngine {
                 break;
             case DX:
                 if (segTick < 1) break; // velocity needs t-1
-                addRelative(out, c.isVsDz() ? JumpConstraint.Mode.DXZ : JumpConstraint.Mode.X,
+                addRelative(out, c.isVsOther() ? JumpConstraint.Mode.DXZ : JumpConstraint.Mode.X,
                         segTick, segTick - 1, c, tag);
                 break;
             case DZ:
                 if (segTick < 1) break;
-                addRelative(out, JumpConstraint.Mode.Z, segTick, segTick - 1, c, tag);
+                addRelative(out, c.isVsOther() ? JumpConstraint.Mode.DZX : JumpConstraint.Mode.Z,
+                        segTick, segTick - 1, c, tag);
                 break;
             case DF:
                 if (segTick >= numTicks) break;
@@ -1416,11 +1417,15 @@ public final class AngleSolverEngine {
             case Z: return refSeg != null ? path.posZ[segTick] - path.posZ[refSeg] : path.posZ[segTick];
             case F: return segTick < numTicks ? Angles.wrap(gameFacings[segTick]) : null;
             case DX: return segTick >= 1
-                    ? (c.isVsDz()
-                        ? Math.abs(path.posX[segTick] - path.posX[segTick - 1])
-                            - Math.abs(path.posZ[segTick] - path.posZ[segTick - 1])
-                        : path.posX[segTick] - path.posX[segTick - 1]) : null;
-            case DZ: return segTick >= 1 ? path.posZ[segTick] - path.posZ[segTick - 1] : null;
+                    ? (c.isVsOther()
+                    ? Math.abs(path.posX[segTick] - path.posX[segTick - 1])
+                    - Math.abs(path.posZ[segTick] - path.posZ[segTick - 1])
+                    : path.posX[segTick] - path.posX[segTick - 1]) : null;
+            case DZ: return segTick >= 1
+                    ? (c.isVsOther()
+                    ? Math.abs(path.posZ[segTick] - path.posZ[segTick - 1])
+                    - Math.abs(path.posX[segTick] - path.posX[segTick - 1])
+                    : path.posZ[segTick] - path.posZ[segTick - 1]) : null;
             case DF:
                 if (segTick >= numTicks) return null;
                 return segTick >= 1

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/Constraint.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/Constraint.java
@@ -45,7 +45,7 @@ public final class Constraint {
     private boolean loInclusive;
     private boolean hiInclusive;
     private Integer refTick;
-    private boolean vsDz;
+    private boolean vsOther;
     /** A disabled constraint keeps its definition but is invisible to the solver. */
     private boolean enabled = true;
 
@@ -75,7 +75,7 @@ public final class Constraint {
     public void setField(Field next) {
         this.field = next;
         if (next != Field.X && next != Field.Z) refTick = null;
-        if (next != Field.DX) vsDz = false;
+        if (next != Field.DX && next != Field.DZ) vsOther = false;
         if (next == Field.DF) {
             op = Op.EQ;
             value = 0.0;
@@ -94,12 +94,20 @@ public final class Constraint {
         return refTick != null;
     }
 
+    public boolean isVsOther() {
+        return vsOther;
+    }
+
+    public void setVsOther(boolean vsOther) {
+        this.vsOther = vsOther && (field == Field.DX || field == Field.DZ);
+    }
+
     public boolean isVsDz() {
-        return vsDz;
+        return isVsOther();
     }
 
     public void setVsDz(boolean vsDz) {
-        this.vsDz = vsDz && field == Field.DX;
+        setVsOther(vsDz);
     }
 
     public Op getOp() {
@@ -179,7 +187,7 @@ public final class Constraint {
         c.hiInclusive = hiInclusive;
         c.enabled = enabled;
         c.refTick = refTick;
-        c.vsDz = vsDz;
+        c.vsOther = vsOther;
         return c;
     }
 }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/ConstraintText.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/ConstraintText.java
@@ -41,16 +41,17 @@ public final class ConstraintText {
     }
 
     public static String chip(Constraint c) {
+        String other = c.getField() == Constraint.Field.DX ? "dZ" : "dX";
         if (c.isRange()) {
             String lb = c.isLoInclusive() ? "[" : "(";
             String rb = c.isHiInclusive() ? "]" : ")";
             String body = lb + num(c.getLo()) + ", " + num(c.getHi()) + rb;
-            return c.isVsDz() ? "dZ+" + body : body;
+            return c.isVsOther() ? other + "+" + body : body;
         }
-        if (c.isVsDz()) {
+        if (c.isVsOther()) {
             double v = c.getValue();
-            if (v == 0.0) return "dZ";
-            return v > 0.0 ? "dZ+" + num(v) : "dZ-" + num(-v);
+            if (v == 0.0) return other;
+            return v > 0.0 ? other + "+" + num(v) : other + "-" + num(-v);
         }
         return num(c.getValue());
     }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/JumpConstraint.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/JumpConstraint.java
@@ -16,7 +16,8 @@ public final class JumpConstraint {
         X,
         Z,
         F,
-        DXZ
+        DXZ,
+        DZX
     }
 
     public enum Op {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/JumpConstraintCompiler.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/JumpConstraintCompiler.java
@@ -55,8 +55,8 @@ public final class JumpConstraintCompiler {
         for (JumpConstraint c : spec.constraints) {
             validateTick(c.t1, n, c.name);
             if (c.t2 != null) validateTick(c.t2, n, c.name);
-            if (c.mode == JumpConstraint.Mode.DXZ && c.t2 == null) {
-                throw new IllegalArgumentException("constraint " + c.name + ": DXZ requires t2");
+            if ((c.mode == JumpConstraint.Mode.DXZ || c.mode == JumpConstraint.Mode.DZX) && c.t2 == null) {
+                throw new IllegalArgumentException("constraint " + c.name + ": " + c.mode + " requires t2");
             }
             if (c.cmp == JumpConstraint.Cmp.EQ) {
                 eq.add(c);
@@ -81,6 +81,9 @@ public final class JumpConstraintCompiler {
             case DXZ:
                 return Math.abs(path.posX[c.t1] - path.posX[c.t2])
                         - Math.abs(path.posZ[c.t1] - path.posZ[c.t2]) - c.rhs;
+            case DZX:
+                return Math.abs(path.posZ[c.t1] - path.posZ[c.t2])
+                        - Math.abs(path.posX[c.t1] - path.posX[c.t2]) - c.rhs;
             default:
                 throw new IllegalStateException("unknown mode: " + c.mode);
         }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverTable.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverTable.java
@@ -1044,14 +1044,17 @@ public final class AngleSolverTable {
                 ImGui.sameLine();
             }
         }
-        if (c.getField() == Constraint.Field.DX) {
-            if (ImGui.checkbox("dZ##vs", c.isVsDz())) c.setVsDz(!c.isVsDz());
+        if (c.getField() == Constraint.Field.DX || c.getField() == Constraint.Field.DZ) {
+            String otherLabel = c.getField() == Constraint.Field.DX ? "dZ##vs" : "dX##vs";
+            String otherName = c.getField() == Constraint.Field.DX ? "dZ" : "dX";
+            String selfName = c.getField() == Constraint.Field.DX ? "dX" : "dZ";
+            if (ImGui.checkbox(otherLabel, c.isVsOther())) c.setVsOther(!c.isVsOther());
             if (ImGui.isItemHovered()) {
-                ImGui.setTooltip("Compare against dZ as magnitudes: |dX| vs |dZ| + value."
+                ImGui.setTooltip("Compare against " + otherName + " as magnitudes: |" + selfName + "| vs |" + otherName + "| + value."
                         + " Collision resolves the larger-delta axis first (26.x).");
             }
             ImGui.sameLine();
-            if (c.isVsDz()) {
+            if (c.isVsOther()) {
                 ThemeManager.pushTextColor(ThemeManager.textMutedColor());
                 ImGui.alignTextToFramePadding();
                 ImGui.text("+");


### PR DESCRIPTION
- Added the `dX` checkbox when `dZ` is selected in constraints, allowing cross-axis comparison both ways (`|dZ| vs |dX|` and `|dX| vs |dZ|`).