### PR TITLE
feat: add custom target angle objective to angle solver

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
@@ -217,6 +217,7 @@ public final class Application {
         GraphEditorWindow graphEditorWindow = new GraphEditorWindow(angleSolverEngine);
         AngleSolverWindow angleSolverWindow = new AngleSolverWindow(angleSolverState, settings, inputData::size, angleSolverEngine, velocityMapController.widget(), graphStore, graphEditorWindow);
         angleSolverWindow.setApplySurfaceState(this::applyPathSurfaceState);
+        angleSolverWindow.setPlayerYawSupplier(mc::getPlayerYaw);
 
         // In-world constraint visualization (gh-145): plates appear while the solver view is open.
         constraintSource = new de.legoshi.parkourcalc.core.ui.anglesolver.AngleSolverConstraintSource(

--- a/core/src/main/java/de/legoshi/parkourcalc/core/PlaybackController.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/PlaybackController.java
@@ -48,6 +48,7 @@ public final class PlaybackController {
     // Lerp endpoints displayedYaw chases; congruent to currentTickYaw mod 360.
     private float prevTickYaw;
     private float displayTargetYaw;
+    private float prevPrevTickYaw;
     private long tickEndNanos;
 
     // displayedYaw is the camera yaw; it equals the ideal lerp value when the
@@ -178,6 +179,7 @@ public final class PlaybackController {
         // A carried checkpoint is already post-settle; warm up only a from-the-top start that has none.
         warmupRemaining = (from == 0 && carry == null) ? WARMUP_TICKS : 0;
         prevTickYaw = yaw;
+        prevPrevTickYaw = yaw;
         currentTickYaw = yaw;
         displayTargetYaw = yaw;
         displayedYaw = yaw;
@@ -300,6 +302,7 @@ public final class PlaybackController {
             bridge.setHotbarSlot(hotbarSlot - 1);
         }
         Float yaw = row.getYaw();
+        prevPrevTickYaw = prevTickYaw;
         prevTickYaw = displayTargetYaw;
         if (yaw != null) {
             if (row.isYawLocked()) {
@@ -348,6 +351,25 @@ public final class PlaybackController {
         return d;
     }
 
+    private static float nextDisplayYaw(float base, InputRow row) {
+        Float yaw = row.getYaw();
+        if (yaw == null) return base;
+        if (row.isYawLocked()) return base + shortestDelta(base, yaw);
+        if (yaw != 0f) return base + yaw;
+        return base;
+    }
+
+    private static float catmullRom(float p0, float p1, float p2, float p3, float t) {
+        if (t <= 0f) return p1;
+        if (t >= 1f) return p2;
+        float t2 = t * t;
+        float t3 = t2 * t;
+        return 0.5f * ((2f * p1)
+                + (-p0 + p2) * t
+                + (2f * p0 - 5f * p1 + 4f * p2 - p3) * t2
+                + (-p0 + 3f * p1 - 3f * p2 + p3) * t3);
+    }
+
     /** Loader calls after MC's physics tick so the snap value never reaches a render. */
     public void postTick() {
         if (!running || bridge == null) return;
@@ -392,7 +414,10 @@ public final class PlaybackController {
         float partial = elapsed / (float) TICK_NANOS;
         if (partial < 0f) partial = 0f;
         if (partial > 1f) partial = 1f;
-        float idealYaw = prevTickYaw + (displayTargetYaw - prevTickYaw) * partial;
+        float nextTickYaw = nextTick < inputData.size()
+                ? nextDisplayYaw(displayTargetYaw, inputData.get(nextTick))
+                : displayTargetYaw;
+        float idealYaw = catmullRom(prevPrevTickYaw, prevTickYaw, displayTargetYaw, nextTickYaw, partial);
 
         float delta = idealYaw - displayedYaw;
         float maxStep = settings.yawFlickSpeed * dt;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/AngleSolverEngine.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/AngleSolverEngine.java
@@ -40,10 +40,7 @@ import de.legoshi.parkourcalc.core.anglesolver.solver.StartBox;
 import de.legoshi.parkourcalc.core.anglesolver.solver.SupportOverlap;
 import de.legoshi.parkourcalc.core.anglesolver.solver.SurfaceKind;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.IntConsumer;
@@ -405,8 +402,9 @@ public final class AngleSolverEngine {
         }
 
         List<JumpConstraint> constraints = new ArrayList<>();
-        Objective objective = new Objective(axis(state.getAxis()), sense(state.getGoal()), numTicks,
-                state.getSmoothLambda());
+        Objective objective = state.isCustomAngle()
+                ? new Objective(state.getCustomAngleDeg(), numTicks, state.getSmoothLambda())
+                : new Objective(axis(state.getAxis()), sense(state.getGoal()), numTicks, state.getSmoothLambda());
         for (ConstraintAt ca : uiCons) {
             if (footprintCons != null && footprintCons.contains(ca.c)) continue;
             addMapped(constraints, ca.c, ca.absTick, ca.segTick, numTicks, ph.inputs.startYaw);
@@ -1108,7 +1106,7 @@ public final class AngleSolverEngine {
         }
         if (ctx.cmaesEvals.get() > 0) addCmaBudget(result, job, ctx.cmaesEvals.get());
         if (ctx.smoothingEvals.get() > 0) result.addDetail("Smoothing evals", Long.toString(ctx.smoothingEvals.get()));
-        double finalObjective = path.getPos(spec.objective.tick, spec.objective.axis);
+        double finalObjective = spec.objective.evaluate(path);
         double finalViolation = JumpConstraintCompiler.compile(spec).maxViolation(gameFacings, path);
         if (finalViolation <= FEAS_TOL && JumpLinearModel.hasFacingWall(spec.constraints)) {
             result.setNotice(DF_DIRECTION_NOTICE);
@@ -1128,7 +1126,7 @@ public final class AngleSolverEngine {
     /** The byte-exact objective value the given facings realize (for comparing two feasible candidates). */
     private double exactObjective(JumpPhysicsInputs sc, JumpSpec spec, double[] yawsAbsWrapped) {
         ForwardPath p = model.forward(sc, sc.toGameFacings(yawsAbsWrapped));
-        return p.getPos(spec.objective.tick, spec.objective.axis);
+        return spec.objective.evaluate(p);
     }
 
     private double violationOf(JumpPhysicsInputs sc, JumpSpec spec, double[] yawsAbsWrapped) {
@@ -1156,7 +1154,7 @@ public final class AngleSolverEngine {
 
     private SolveResult buildResultWithObjective(Job job, double[] yaws, double[] gameFacings, ForwardPath path) {
         SolveResult result = buildResult(job, yaws, gameFacings, path);
-        result.setObjective(path.getPos(job.spec.objective.tick, job.spec.objective.axis));
+        result.setObjective(job.spec.objective.evaluate(path));
         result.getOutcomes().add(0, objectiveOutcome(result, job.spec.objective, job.startTick));
         return result;
     }
@@ -1204,6 +1202,11 @@ public final class AngleSolverEngine {
 
     /** The objective as the leading Solved-values row: axis @ tick, max/min as the relation, achieved value. */
     private static SolveResult.Outcome objectiveOutcome(SolveResult r, Objective o, int startTick) {
+        if (o.isCustomAngle()) {
+            return new SolveResult.Outcome("Angle", "T" + (startTick + o.tick + 1),
+                    String.format(Locale.ROOT, "%.1f°", o.customYaw),
+                    ConstraintText.fixedStat(r.getObjectiveValue()), "");
+        }
         String field = o.axis == JumpPhysicsInputs.Axis.X ? "X" : "Z";
         String sense = o.sense == Objective.Sense.MAX ? "max" : "min";
         return new SolveResult.Outcome(field, "T" + (startTick + o.tick + 1), sense,

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/AngleSolverEngine.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/AngleSolverEngine.java
@@ -1874,7 +1874,10 @@ public final class AngleSolverEngine {
         }
         for (Objective alt : alternateObjectives(spec.objective)) {
             if (cancel.get()) return null;
-            if (SolverTrace.on()) SolverTrace.log("CHAIN", "alt seed %s %s start", alt.axis, alt.sense);
+            if (SolverTrace.on()) {
+                if (alt.isCustomAngle()) SolverTrace.log("CHAIN", "alt seed %.1f deg start", alt.customYaw);
+                else SolverTrace.log("CHAIN", "alt seed %s %s start", alt.axis, alt.sense);
+            }
             double[] seed = ClosedFormSolve.optimize(em, new JumpSpec(sc, spec.constraints, alt), FEAS_TOL, cancel, cfCfg);
             if (seed == null) continue;
             yaws = SlpSolve.optimize(em, spec, FEAS_TOL, cancel, seed, slpCfg);
@@ -1906,6 +1909,13 @@ public final class AngleSolverEngine {
      *  (a certified optimum of any direction is feasible for all of them), never the returned result. */
     private static List<Objective> alternateObjectives(Objective o) {
         List<Objective> out = new ArrayList<>(3);
+        if (o.isCustomAngle()) {
+            double base = o.customYaw;
+            for (double offset : new double[]{180.0, 90.0, -90.0}) {
+                out.add(new Objective(Angles.wrap(base + offset), o.tick, o.smoothLambda));
+            }
+            return out;
+        }
         JumpPhysicsInputs.Axis[] axisOrder = (o.axis == JumpPhysicsInputs.Axis.X)
                 ? new JumpPhysicsInputs.Axis[]{JumpPhysicsInputs.Axis.X, JumpPhysicsInputs.Axis.Z}
                 : new JumpPhysicsInputs.Axis[]{JumpPhysicsInputs.Axis.Z, JumpPhysicsInputs.Axis.X};

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/AngleSolverState.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/AngleSolverState.java
@@ -160,6 +160,8 @@ public final class AngleSolverState {
     private int landingTick;
     private Axis axis = Axis.X;
     private Goal goal = Goal.MAX;
+    private boolean customAngle = false;
+    private double customAngleDeg = 0.0;
     private Effort effort = Effort.FAST;
     private boolean stopOnFeasible;
     private boolean legalMode;
@@ -220,6 +222,24 @@ public final class AngleSolverState {
 
     public void setGoal(Goal goal) {
         this.goal = goal;
+    }
+
+    public boolean isCustomAngle() {
+        return customAngle;
+    }
+
+    public void setCustomAngle(boolean customAngle) {
+        this.customAngle = customAngle;
+    }
+
+    public double getCustomAngleDeg() {
+        return customAngleDeg;
+    }
+
+    public void setCustomAngleDeg(double customAngleDeg) {
+        while (customAngleDeg <= -180.0) customAngleDeg += 360.0;
+        while (customAngleDeg > 180.0) customAngleDeg -= 360.0;
+        this.customAngleDeg = customAngleDeg;
     }
 
     public Effort getEffort() {
@@ -721,6 +741,8 @@ public final class AngleSolverState {
         landingTick = 0;
         axis = Axis.X;
         goal = Goal.MAX;
+        customAngle = false;
+        customAngleDeg = 0.0;
         effort = Effort.FAST;
         stopOnFeasible = false;
         legalMode = false;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/Scoring.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/Scoring.java
@@ -38,7 +38,7 @@ public final class Scoring {
 
     public static double exactObjective(ForwardModel model, JumpPhysicsInputs sc, JumpSpec spec, double[] yawsAbsWrapped) {
         ForwardPath p = model.forward(sc, sc.toGameFacings(yawsAbsWrapped));
-        return p.getPos(spec.objective.tick, spec.objective.axis);
+        return spec.objective.evaluate(p);
     }
 
     public static double violationOf(ForwardModel model, JumpPhysicsInputs sc, JumpSpec spec, double[] yawsAbsWrapped) {
@@ -83,6 +83,7 @@ public final class Scoring {
     }
 
     public static double objectiveCap(JumpSpec spec) {
+        if (spec.objective.isCustomAngle()) return Double.NaN;
         Objective o = spec.objective;
         JumpConstraint.Mode mode = o.axis == JumpPhysicsInputs.Axis.X ? JumpConstraint.Mode.X : JumpConstraint.Mode.Z;
         boolean max = o.sense == Objective.Sense.MAX;
@@ -126,7 +127,7 @@ public final class Scoring {
         ForwardPath p = model.forward(sc, gf);
         JumpConstraintCompiler.Compiled compiled = JumpConstraintCompiler.compile(spec);
         double curViol = compiled.maxViolation(gf, p);
-        double curObj = p.getPos(spec.objective.tick, spec.objective.axis);
+        double curObj = spec.objective.evaluate(p);
         double[] d = translationDomain(sc, freeBox);
         boolean objX = spec.objective.axis == JumpPhysicsInputs.Axis.X;
         boolean objMax = spec.objective.sense == Objective.Sense.MAX;
@@ -173,7 +174,7 @@ public final class Scoring {
         ForwardPath p = model.forward(cand, gf);
         if (JumpConstraintCompiler.compile(spec).maxViolation(gf, p) > feasTol) return false;
         if (curViol <= feasTol) {
-            double obj = p.getPos(spec.objective.tick, spec.objective.axis);
+            double obj = spec.objective.evaluate(p);
             if (!(objMax ? obj > curObj : obj < curObj)) return false;
         }
         sc.startPos = new Vec3dCore(x, sc.startPos.y, z);

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/BoundPrunedRecovery.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/BoundPrunedRecovery.java
@@ -231,6 +231,7 @@ public final class BoundPrunedRecovery {
     }
 
     private static boolean isTargetWall(JumpConstraint c, JumpSpec spec, boolean max) {
+        if (spec.objective.isCustomAngle()) return false;
         JumpConstraint.Mode objMode = spec.objective.axis == JumpPhysicsInputs.Axis.X
                 ? JumpConstraint.Mode.X : JumpConstraint.Mode.Z;
         return c.mode == objMode && c.t1 == spec.objective.tick && c.t2 == null
@@ -263,7 +264,7 @@ public final class BoundPrunedRecovery {
         double[] gf = sc.toGameFacings(Angles.wrapAll(yawsAbs));
         ForwardPath path = exact.forward(sc, gf);
         if (compiled.maxViolation(gf, path) > 0.0) return Double.NaN;
-        double v = path.getPos(spec.objective.tick, spec.objective.axis);
+        double v = spec.objective.evaluate(path);
         return max ? v : -v;
     }
 
@@ -371,8 +372,14 @@ public final class BoundPrunedRecovery {
         CostateDualSolver.Result r = new CostateDualSolver(n, cx, cz, lin.mMagAll(), walls).solve(0.0, null);
         if (r == null) return null;
         boolean max = spec.objective.sense == Objective.Sense.MAX;
-        int axisIdx = spec.objective.axis == JumpPhysicsInputs.Axis.X ? 0 : 1;
-        double cp = lin.constPos(spec.objective.tick, axisIdx);
+        double cp;
+        if (spec.objective.isCustomAngle()) {
+            double rad = Math.toRadians(spec.objective.customYaw);
+            cp = -Math.sin(rad) * lin.constPos(spec.objective.tick, 0) + Math.cos(rad) * lin.constPos(spec.objective.tick, 1);
+        } else {
+            int axisIdx = spec.objective.axis == JumpPhysicsInputs.Axis.X ? 0 : 1;
+            cp = lin.constPos(spec.objective.tick, axisIdx);
+        }
         double bound = r.value + (max ? cp : -cp);
         return Double.isNaN(bound) ? null : bound;
     }
@@ -506,8 +513,14 @@ public final class BoundPrunedRecovery {
             this.cz = cz;
             this.mMag = lin.mMagAll();
             this.max = spec.objective.sense == Objective.Sense.MAX;
-            int axisIdx = spec.objective.axis == JumpPhysicsInputs.Axis.X ? 0 : 1;
-            double cp = lin.constPos(spec.objective.tick, axisIdx);
+            double cp;
+            if (spec.objective.isCustomAngle()) {
+                double rad = Math.toRadians(spec.objective.customYaw);
+                cp = -Math.sin(rad) * lin.constPos(spec.objective.tick, 0) + Math.cos(rad) * lin.constPos(spec.objective.tick, 1);
+            } else {
+                int axisIdx = spec.objective.axis == JumpPhysicsInputs.Axis.X ? 0 : 1;
+                cp = lin.constPos(spec.objective.tick, axisIdx);
+            }
             this.normConst = max ? cp : -cp;
             this.canonical = canonical;
             this.baseWalls = baseWalls;
@@ -1093,7 +1106,11 @@ public final class BoundPrunedRecovery {
                 double gx = r.gx[t];
                 double gz = r.gz[t];
                 if (gx * gx + gz * gz < 1.0e-18) {
-                    if (spec.objective.axis == JumpPhysicsInputs.Axis.X) {
+                    if (spec.objective.isCustomAngle()) {
+                        double rad = Math.toRadians(spec.objective.customYaw);
+                        gx = (max ? 1.0 : -1.0) * -Math.sin(rad);
+                        gz = (max ? 1.0 : -1.0) * Math.cos(rad);
+                    } else if (spec.objective.axis == JumpPhysicsInputs.Axis.X) {
                         gx = max ? 1.0 : -1.0;
                         gz = 0.0;
                     } else {
@@ -1130,7 +1147,7 @@ public final class BoundPrunedRecovery {
         }
 
         private double normObjective(ForwardPath path) {
-            double v = path.getPos(spec.objective.tick, spec.objective.axis);
+            double v = spec.objective.evaluate(path);
             return max ? v : -v;
         }
 

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/BucketAscentPolish.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/BucketAscentPolish.java
@@ -161,6 +161,6 @@ public final class BucketAscentPolish {
         ForwardPath pr = model.forward(scenario, gf);
         double viol = c.maxViolation(gf, pr);
         if (viol > FEAS_TOL) return Double.POSITIVE_INFINITY;
-        return sign * pr.getPos(obj.tick, obj.axis) + obj.smoothPenalty(scenario.startYaw, abs);
+        return sign * obj.evaluate(pr) + obj.smoothPenalty(scenario.startYaw, abs);
     }
 }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/ClosedFormSolve.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/ClosedFormSolve.java
@@ -102,7 +102,6 @@ public final class ClosedFormSolve {
 
     private static Result optimizeReturning(ExactJumpModel exact, JumpSpec spec, double feasTol, AtomicBoolean cancel,
                                             double[] margins, boolean ascending, Config cfg) {
-        if (spec.objective.isCustomAngle()) return null;
         JumpPhysicsInputs sc = spec.asScenario();
 
         // The linear model represents only position (X/Z) walls. Facing pins and dF chains prefold into
@@ -284,7 +283,7 @@ public final class ClosedFormSolve {
     }
 
     private static double scanScore(ExactJumpModel exact, JumpSpec spec, JumpPhysicsInputs sc, double[] yaws) {
-        double o = exact.forward(sc, sc.toGameFacings(yaws)).getPos(spec.objective.tick, spec.objective.axis);
+        double o = spec.objective.evaluate(exact.forward(sc, sc.toGameFacings(yaws)));
         return spec.objective.scored(o, sc.startYaw, yaws);
     }
 
@@ -397,7 +396,7 @@ public final class ClosedFormSolve {
             }
             if (DEBUG) {
                 double[] gf = sc.toGameFacings(yaws);
-                double o = exact.forward(sc, gf).getPos(spec.objective.tick, spec.objective.axis);
+                double o = spec.objective.evaluate(exact.forward(sc, gf));
                 System.out.printf("  CLOSED margin=%.2e iters=%d pg=%.3e viol=%.2e obj=%.6f%n",
                         margin, solver.lastIters, solver.lastPgres, viol, o);
             }
@@ -436,7 +435,7 @@ public final class ClosedFormSolve {
      *  it. Valid even where the dual's recovery degenerates, so it certifies a primally-found solution
      *  without a search. {@code NaN} when no bound applies (facing walls, violated constant, unbounded). */
     public static double dualBound(JumpSpec spec) {
-        if (spec.objective.isCustomAngle() || JumpLinearModel.hasFacingWall(spec.constraints)) return Double.NaN;
+        if (JumpLinearModel.hasFacingWall(spec.constraints)) return Double.NaN;
         JumpPhysicsInputs sc = spec.asScenario();
         JumpLinearModel lin = new JumpLinearModel(sc);
         double[] cx = new double[lin.n];
@@ -448,8 +447,15 @@ public final class ClosedFormSolve {
         CostateDualSolver.Result r = new CostateDualSolver(lin.n, cx, cz, lin.mMagAll(), walls).solve(0.0, null);
         if (r == null) return Double.NaN;
         // r.value bounds max c·u with c MAX-normalized; fold the constant part back in (MIN is negated).
-        int axis = spec.objective.axis == JumpPhysicsInputs.Axis.X ? 0 : 1;
-        double constPos = lin.constPos(spec.objective.tick, axis);
+        double constPos;
+        if (spec.objective.isCustomAngle()) {
+            double rad = Math.toRadians(spec.objective.customYaw);
+            constPos = -Math.sin(rad) * lin.constPos(spec.objective.tick, 0)
+                    + Math.cos(rad) * lin.constPos(spec.objective.tick, 1);
+        } else {
+            int axis = spec.objective.axis == JumpPhysicsInputs.Axis.X ? 0 : 1;
+            constPos = lin.constPos(spec.objective.tick, axis);
+        }
         return spec.objective.sense == Objective.Sense.MAX ? constPos + r.value : constPos - r.value;
     }
 

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/ClosedFormSolve.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/ClosedFormSolve.java
@@ -102,6 +102,7 @@ public final class ClosedFormSolve {
 
     private static Result optimizeReturning(ExactJumpModel exact, JumpSpec spec, double feasTol, AtomicBoolean cancel,
                                             double[] margins, boolean ascending, Config cfg) {
+        if (spec.objective.isCustomAngle()) return null;
         JumpPhysicsInputs sc = spec.asScenario();
 
         // The linear model represents only position (X/Z) walls. Facing pins and dF chains prefold into
@@ -435,7 +436,7 @@ public final class ClosedFormSolve {
      *  it. Valid even where the dual's recovery degenerates, so it certifies a primally-found solution
      *  without a search. {@code NaN} when no bound applies (facing walls, violated constant, unbounded). */
     public static double dualBound(JumpSpec spec) {
-        if (JumpLinearModel.hasFacingWall(spec.constraints)) return Double.NaN;
+        if (spec.objective.isCustomAngle() || JumpLinearModel.hasFacingWall(spec.constraints)) return Double.NaN;
         JumpPhysicsInputs sc = spec.asScenario();
         JumpLinearModel lin = new JumpLinearModel(sc);
         double[] cx = new double[lin.n];

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/CmaesJumpHarness.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/CmaesJumpHarness.java
@@ -98,10 +98,14 @@ public final class CmaesJumpHarness {
             double smooth = feasibilityOnly ? 0.0 : obj.smoothPenalty(scenario.startYaw, F);
             if (free) {
                 double[] d = FreeStartSolve.bestTranslate(spec, gf, pr, box);
-                double o = sign * (pr.getPos(obj.tick, obj.axis) + (objAxis == 0 ? d[0] : d[1]));
+                double baseObj = obj.evaluate(pr);
+                double transObj = obj.customYaw != null
+                        ? -Math.sin(Math.toRadians(obj.customYaw)) * d[0] + Math.cos(Math.toRadians(obj.customYaw)) * d[1]
+                        : (objAxis == 0 ? d[0] : d[1]);
+                double o = sign * (baseObj + transObj);
                 return o + smooth + c.translatedPenalty(gf, pr, d[0], d[1], cfg.muIneq, cfg.muEq);
             }
-            double o = sign * pr.getPos(obj.tick, obj.axis);
+            double o = sign * obj.evaluate(pr);
             double pen = c.penalty(gf, pr, cfg.muIneq, cfg.muEq);
             return o + smooth + pen;
         };
@@ -154,7 +158,11 @@ public final class CmaesJumpHarness {
             dxFinal = d[0];
             dzFinal = d[1];
         }
-        double objectiveValue = finalPath.getPos(obj.tick, obj.axis) + (objAxis == 0 ? dxFinal : dzFinal);
+        double baseFinal = obj.evaluate(finalPath);
+        double transFinal = free ? (obj.customYaw != null
+                ? -Math.sin(Math.toRadians(obj.customYaw)) * dxFinal + Math.cos(Math.toRadians(obj.customYaw)) * dzFinal
+                : (objAxis == 0 ? dxFinal : dzFinal)) : 0.0;
+        double objectiveValue = baseFinal + transFinal;
         double[] ineqSlack = new double[c.ineq.size()];
         for (int i = 0; i < c.ineq.size(); i++) {
             ineqSlack[i] = free ? JumpConstraintCompiler.translatedSlack(c.ineq.get(i), gf, finalPath, dxFinal, dzFinal)
@@ -220,7 +228,7 @@ public final class CmaesJumpHarness {
         ForwardPath pr = model.forward(scenario, gf);
         // score folds ONLY the eq squared-penalty (muIneq=0 zeroes the ineq term); ineq is reported separately.
         double smooth = feasibilityOnly ? 0.0 : obj.smoothPenalty(scenario.startYaw, abs);
-        double score = sign * pr.getPos(obj.tick, obj.axis) + smooth + c.penalty(gf, pr, 0.0, cfg.muEq);
+        double score = sign * obj.evaluate(pr) + smooth + c.penalty(gf, pr, 0.0, cfg.muEq);
         double ineqViol = 0.0;
         for (JumpConstraint cc : c.ineq) ineqViol = Math.max(ineqViol, JumpConstraintCompiler.slack(cc, gf, pr));
         return new double[]{score, ineqViol};

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/FacingPrefold.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/FacingPrefold.java
@@ -325,7 +325,11 @@ public final class FacingPrefold {
             double gz = r.gz[v];
             if (gx * gx + gz * gz < 1.0e-18) {
                 boolean max = obj.sense == Objective.Sense.MAX;
-                if (obj.axis == JumpPhysicsInputs.Axis.X) {
+                if (obj.isCustomAngle()) {
+                    double rad = Math.toRadians(obj.customYaw);
+                    gx = (max ? 1.0 : -1.0) * -Math.sin(rad);
+                    gz = (max ? 1.0 : -1.0) * Math.cos(rad);
+                } else if (obj.axis == JumpPhysicsInputs.Axis.X) {
                     gx = max ? 1.0 : -1.0;
                     gz = 0.0;
                 } else {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/IlsPolish.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/IlsPolish.java
@@ -109,6 +109,6 @@ public final class IlsPolish {
         double[] gf = sc.toGameFacings(Angles.wrapAll(absWrapped));
         ForwardPath pr = model.forward(sc, gf);
         if (c.maxViolation(gf, pr) > FEAS_TOL) return Double.POSITIVE_INFINITY;
-        return sign * pr.getPos(obj.tick, obj.axis) + obj.smoothPenalty(sc.startYaw, absWrapped);
+        return sign * obj.evaluate(pr) + obj.smoothPenalty(sc.startYaw, absWrapped);
     }
 }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/JumpLinearModel.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/JumpLinearModel.java
@@ -205,8 +205,17 @@ public final class JumpLinearModel {
         int objTick = obj.tick;
         double dx, dz;
         boolean max = obj.sense == Objective.Sense.MAX;
-        if (obj.axis == JumpPhysicsInputs.Axis.X) { dx = max ? 1.0 : -1.0; dz = 0.0; }
-        else { dx = 0.0; dz = max ? 1.0 : -1.0; }
+        if (obj.isCustomAngle()) {
+            double rad = Math.toRadians(obj.customYaw);
+            dx = (max ? 1.0 : -1.0) * -Math.sin(rad);
+            dz = (max ? 1.0 : -1.0) * Math.cos(rad);
+        } else if (obj.axis == JumpPhysicsInputs.Axis.X) {
+            dx = max ? 1.0 : -1.0;
+            dz = 0.0;
+        } else {
+            dx = 0.0;
+            dz = max ? 1.0 : -1.0;
+        }
         for (int t = 0; t < n; t++) {
             cx[t] = coefAxis(0, t, objTick) * dx;
             cz[t] = coefAxis(1, t, objTick) * dz;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/LevelSetAscent.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/LevelSetAscent.java
@@ -32,6 +32,7 @@ public final class LevelSetAscent {
     public static double[] improve(ExactJumpModel exact, JumpSpec spec, double[] witness,
                                    double feasTol, AtomicBoolean cancel, Config cfg) {
         if (witness == null) return null;
+        if (spec.objective.isCustomAngle()) return null;
         if (JumpLinearModel.hasFacingWall(spec.constraints)) return null;
         double bound = ClosedFormSolve.dualBound(spec);
         if (Double.isNaN(bound)) return null;
@@ -73,6 +74,6 @@ public final class LevelSetAscent {
 
     private static double objectiveOf(ExactJumpModel exact, JumpPhysicsInputs sc, JumpSpec spec, double[] yawsAbs) {
         double[] gf = sc.toGameFacings(Angles.wrapAll(yawsAbs));
-        return exact.forward(sc, gf).getPos(spec.objective.tick, spec.objective.axis);
+        return spec.objective.evaluate(exact.forward(sc, gf));
     }
 }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/Objective.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/Objective.java
@@ -10,12 +10,21 @@ public final class Objective {
     public final Sense sense;
     public final int tick;
     public final double smoothLambda;
+    public final Double customYaw;
 
     public Objective(JumpPhysicsInputs.Axis axis, Sense sense, int tick) {
-        this(axis, sense, tick, 0.0);
+        this(axis, sense, tick, 0.0, null);
     }
 
     public Objective(JumpPhysicsInputs.Axis axis, Sense sense, int tick, double smoothLambda) {
+        this(axis, sense, tick, smoothLambda, null);
+    }
+
+    public Objective(double customYaw, int tick, double smoothLambda) {
+        this(JumpPhysicsInputs.Axis.X, Sense.MAX, tick, smoothLambda, customYaw);
+    }
+
+    public Objective(JumpPhysicsInputs.Axis axis, Sense sense, int tick, double smoothLambda, Double customYaw) {
         if (axis == JumpPhysicsInputs.Axis.Y) {
             throw new IllegalArgumentException("Y objective unsupported; use X or Z");
         }
@@ -23,6 +32,19 @@ public final class Objective {
         this.sense = sense;
         this.tick = tick;
         this.smoothLambda = smoothLambda;
+        this.customYaw = customYaw;
+    }
+
+    public boolean isCustomAngle() {
+        return customYaw != null;
+    }
+
+    public double evaluate(ForwardPath path) {
+        if (customYaw != null) {
+            double rad = Math.toRadians(customYaw);
+            return -Math.sin(rad) * path.posX[tick] + Math.cos(rad) * path.posZ[tick];
+        }
+        return path.getPos(tick, axis);
     }
 
     public double smoothPenalty(double anchorYaw, double[] yawsAbs) {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/SeamSweepRecovery.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/SeamSweepRecovery.java
@@ -453,6 +453,15 @@ public final class SeamSweepRecovery {
     }
 
     private Band preferredBand(Seam seam) {
+        if (obj.isCustomAngle()) {
+            double rad = Math.toRadians(obj.customYaw);
+            JumpConstraint.Mode preferred = Math.abs(Math.sin(rad)) > Math.abs(Math.cos(rad))
+                    ? JumpConstraint.Mode.X : JumpConstraint.Mode.Z;
+            for (Band band : seam.bands) {
+                if (band.mode == preferred) return band;
+            }
+            return seam.bands.get(0);
+        }
         JumpConstraint.Mode objMode = obj.axis == JumpPhysicsInputs.Axis.X
                 ? JumpConstraint.Mode.X : JumpConstraint.Mode.Z;
         for (Band band : seam.bands) {
@@ -518,7 +527,7 @@ public final class SeamSweepRecovery {
         double[] gf = sc.toGameFacings(wrapped);
         ForwardPath path = exact.forward(sc, gf);
         if (compiled.maxViolation(gf, path) > feasTol) return null;
-        double v = path.getPos(obj.tick, obj.axis);
+        double v = obj.evaluate(path);
         return new Best(wrapped, maxSense ? v : -v, path);
     }
 

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/SlpSolve.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/SlpSolve.java
@@ -105,7 +105,6 @@ public final class SlpSolve {
     private static double[] optimize(ExactJumpModel exact, JumpSpec spec, double feasTol, AtomicBoolean cancel,
                                      double targetClearance, boolean hugObjective, double[] seedAbsWrapped,
                                      boolean bestEffort, boolean inertiaAware, Config cfg) {
-        if (spec.objective.isCustomAngle()) return null;
         List<JumpConstraint> constraints = spec.constraints;
         if (JumpLinearModel.hasFacingWall(constraints)) return null; // not position-linear
         for (JumpConstraint c : constraints) {
@@ -145,8 +144,17 @@ public final class SlpSolve {
                 double gx = r.gx[t], gz = r.gz[t];
                 if (gx * gx + gz * gz < 1.0e-18) {
                     boolean max = spec.objective.sense == Objective.Sense.MAX;
-                    if (spec.objective.axis == JumpPhysicsInputs.Axis.X) { gx = max ? 1.0 : -1.0; gz = 0.0; }
-                    else { gx = 0.0; gz = max ? 1.0 : -1.0; }
+                    if (spec.objective.isCustomAngle()) {
+                        double rad = Math.toRadians(spec.objective.customYaw);
+                        gx = (max ? 1.0 : -1.0) * -Math.sin(rad);
+                        gz = (max ? 1.0 : -1.0) * Math.cos(rad);
+                    } else if (spec.objective.axis == JumpPhysicsInputs.Axis.X) {
+                        gx = max ? 1.0 : -1.0;
+                        gz = 0.0;
+                    } else {
+                        gx = 0.0;
+                        gz = max ? 1.0 : -1.0;
+                    }
                 }
                 theta[t] = lin.recoverYawDeg(t, gx, gz);
             }
@@ -312,10 +320,10 @@ public final class SlpSolve {
         ForwardPath path = exact.forward(sc, gf);
         double finalViol = compiled.maxViolation(gf, path);
         if (DEBUG) System.out.printf("  SLP viol=%.3e obj=%.7f lps=%d (%.1f ms)%n", finalViol,
-                path.getPos(spec.objective.tick, spec.objective.axis), lpCalls, (System.nanoTime() - t0) / 1e6);
+                spec.objective.evaluate(path), lpCalls, (System.nanoTime() - t0) / 1e6);
         if (SolverTrace.on()) {
             SolverTrace.log("SLP", "end viol=%.3e obj=%.9f lps=%d ms=%.1f %s", finalViol,
-                    path.getPos(spec.objective.tick, spec.objective.axis), lpCalls,
+                    spec.objective.evaluate(path), lpCalls,
                     (System.nanoTime() - t0) / 1e6, finalViol <= feasTol ? "feasible" : (bestEffort ? "best effort" : "null"));
         }
         if (finalViol <= feasTol) return yaws;
@@ -348,7 +356,7 @@ public final class SlpSolve {
 
     /** Objective normalized so bigger is always better (MIN is negated), read off the byte-exact path. */
     private static double normObjective(ForwardPath path, Objective obj, boolean max) {
-        double v = path.getPos(obj.tick, obj.axis);
+        double v = obj.evaluate(path);
         return max ? v : -v;
     }
 }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/SlpSolve.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/SlpSolve.java
@@ -105,6 +105,7 @@ public final class SlpSolve {
     private static double[] optimize(ExactJumpModel exact, JumpSpec spec, double feasTol, AtomicBoolean cancel,
                                      double targetClearance, boolean hugObjective, double[] seedAbsWrapped,
                                      boolean bestEffort, boolean inertiaAware, Config cfg) {
+        if (spec.objective.isCustomAngle()) return null;
         List<JumpConstraint> constraints = spec.constraints;
         if (JumpLinearModel.hasFacingWall(constraints)) return null; // not position-linear
         for (JumpConstraint c : constraints) {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/SmoothingPolish.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/SmoothingPolish.java
@@ -189,7 +189,7 @@ public final class SmoothingPolish {
             double[] gf = sc.toGameFacings(absWrapped);
             ForwardPath path = model.forward(sc, gf);
             if (compiled.maxViolation(gf, path) > FEAS_TOL) return Double.POSITIVE_INFINITY;
-            return sign * path.getPos(obj.tick, obj.axis);
+            return sign * obj.evaluate(path);
         }
 
         boolean accepts(double[] absWrapped) {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/SolveCore.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/SolveCore.java
@@ -141,7 +141,8 @@ public final class SolveCore {
                 SolverRunResult best = null;
                 double bestS = 0.0;
                 for (SolverRunResult r : results) {
-                    double s = spec.objective.scored(r.objectiveValue, sc.startYaw, r.yawAbsDeg);
+                    double objVal = objectiveOf(model, sc, spec.objective, r.yawAbsDeg);
+                    double s = spec.objective.scored(objVal, sc.startYaw, r.yawAbsDeg);
                     if (best == null || (max ? s > bestS : s < bestS)) {
                         best = r;
                         bestS = s;
@@ -152,8 +153,8 @@ public final class SolveCore {
             }
 
             feasible.sort((a, b) -> {
-                double sa = spec.objective.scored(a.objectiveValue, sc.startYaw, a.yawAbsDeg);
-                double sb = spec.objective.scored(b.objectiveValue, sc.startYaw, b.yawAbsDeg);
+                double sa = spec.objective.scored(objectiveOf(model, sc, spec.objective, a.yawAbsDeg), sc.startYaw, a.yawAbsDeg);
+                double sb = spec.objective.scored(objectiveOf(model, sc, spec.objective, b.yawAbsDeg), sc.startYaw, b.yawAbsDeg);
                 return max ? Double.compare(sb, sa) : Double.compare(sa, sb);
             });
             if (stopOnFeasible) return Angles.wrapAll(feasible.get(0).yawAbsDeg);
@@ -244,7 +245,7 @@ public final class SolveCore {
     }
 
     public static double objectiveOf(ForwardModel model, JumpPhysicsInputs sc, Objective obj, double[] absWrapped) {
-        return model.forward(sc, sc.toGameFacings(absWrapped)).getPos(obj.tick, obj.axis);
+        return obj.evaluate(model.forward(sc, sc.toGameFacings(absWrapped)));
     }
 
     public static double maxViolation(SolverRunResult r) {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveFile.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveFile.java
@@ -66,6 +66,8 @@ public final class SaveFile {
         public Boolean legalMode;                        // absent in old files -> false
         public Integer optimizeSeconds;                  // absent in old files -> default
         public Double smoothLambda;
+        public Boolean customAngle;
+        public Double customAngleDeg;
         public SolveBudget customBudget;
         public String graphPreset;
         public String defaultInputs;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveIO.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveIO.java
@@ -188,6 +188,8 @@ public final class SaveIO {
         state.setLegalMode(a.legalMode != null && a.legalMode);
         if (a.optimizeSeconds != null) state.setOptimizeSeconds(a.optimizeSeconds);
         state.setSmoothLambda(a.smoothLambda != null ? a.smoothLambda : 0.0);
+        if (a.customAngle != null) state.setCustomAngle(a.customAngle);
+        if (a.customAngleDeg != null) state.setCustomAngleDeg(a.customAngleDeg);
         applyCustomBudget(a.customBudget, state.getSolveBudget());
         state.setGraphPresetName(a.graphPreset);
         state.setDefaultInputs(parseEnum(AngleSolverState.InputMode.class, a.defaultInputs, AngleSolverState.InputMode.FORCE_45));
@@ -513,6 +515,8 @@ public final class SaveIO {
         a.legalMode = s.isLegalMode();
         a.optimizeSeconds = s.getOptimizeSeconds();
         a.smoothLambda = s.getSmoothLambda() > 0.0 ? s.getSmoothLambda() : null;
+        a.customAngle = s.isCustomAngle();
+        a.customAngleDeg = s.getCustomAngleDeg();
         a.customBudget = toSaveCustomBudget(s.getSolveBudget());
         a.graphPreset = s.getGraphPresetName();
         a.defaultInputs = s.getDefaultInputs().name();

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverWindow.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverWindow.java
@@ -63,7 +63,7 @@ public final class AngleSolverWindow implements RenderInterface {
     private static final String LEGACY_PRESET_ITEM = "Legacy budget";
 
     private static final String[] FORM_LABELS =
-            {"Start tick", "Goal tick", "Axis", "Goal", "Inputs", "Sprint", "Slipperiness", "Potion"};
+            {"Start tick", "Goal tick", "Axis", "Goal", "Target angle", "Inputs", "Sprint", "Slipperiness", "Potion"};
 
     /** Unscaled; lines the details table up under the toggle title and sets it off from the solved values. */
     private static final float DETAIL_INDENT = 13f;
@@ -109,6 +109,11 @@ public final class AngleSolverWindow implements RenderInterface {
     private boolean defaultStateExpanded = true;
     private boolean advancedExpanded;
     private int doseToRemove;
+    private java.util.function.DoubleSupplier playerYawSupplier = () -> 0.0;
+
+    public void setPlayerYawSupplier(java.util.function.DoubleSupplier supplier) {
+        this.playerYawSupplier = supplier != null ? supplier : () -> 0.0;
+    }
 
     private static final float IMPROVE_FADE_SECS = 1.6f;
     private double improveTrackValue = Double.NaN;
@@ -186,10 +191,46 @@ public final class AngleSolverWindow implements RenderInterface {
 
         solveForExpanded = sectionToggle("Solve for", "solvefor", solveForExpanded, scale);
         if (solveForExpanded) {
-            int ax = segmentedRow("Axis", "axis", AXES, state.getAxis().ordinal(), labelW);
-            if (ax >= 0) state.setAxis(AngleSolverState.Axis.values()[ax]);
-            int gl = segmentedRow("Goal", "goal", GOALS, state.getGoal().ordinal(), labelW);
-            if (gl >= 0) state.setGoal(AngleSolverState.Goal.values()[gl]);
+            if (!state.isCustomAngle()) {
+                int ax = segmentedRow("Axis", "axis", AXES, state.getAxis().ordinal(), labelW);
+                if (ax >= 0) state.setAxis(AngleSolverState.Axis.values()[ax]);
+                int gl = segmentedRow("Goal", "goal", GOALS, state.getGoal().ordinal(), labelW);
+                if (gl >= 0) state.setGoal(AngleSolverState.Goal.values()[gl]);
+            } else {
+                Controls.pushInputFrameHeight();
+                ImGui.beginGroup();
+                SolverWidgets.rowLabel("Target angle", labelW);
+
+                float btnW = ImGui.getFrameHeight();
+                float spacing = ImGui.getStyle().getItemInnerSpacing().x;
+                float inputW = ImGui.getContentRegionAvail().x - btnW - spacing;
+
+                ImGui.setNextItemWidth(inputW);
+                imgui.type.ImString angStr = new imgui.type.ImString(ConstraintText.num(state.getCustomAngleDeg()), 32);
+                if (ImGui.inputText("##customAngleInput", angStr, imgui.flag.ImGuiInputTextFlags.CharsDecimal)) {
+                    try {
+                        state.setCustomAngleDeg(Double.parseDouble(angStr.get().trim()));
+                    } catch (NumberFormatException ignored) {}
+                }
+                TooltipUtil.onHover("Target facing angle in degrees to maximize distance towards (e.g. 45.0° for diagonal).");
+
+                ImGui.sameLine(0, spacing);
+                if (ImGui.button("P##setPlayerFacing", btnW, btnW)) {
+                    state.setCustomAngleDeg(playerYawSupplier.getAsDouble());
+                }
+                TooltipUtil.onHover("Set target angle to player's current facing yaw.");
+
+                ImGui.endGroup();
+                Controls.popInputFrameHeight();
+            }
+
+            ImGui.spacing();
+            if (Controls.checkbox("Custom angle##customAngleToggle", state.isCustomAngle())) {
+                state.setCustomAngle(!state.isCustomAngle());
+            }
+            TooltipUtil.onHover("Optimize trajectory distance towards a custom facing angle instead of a fixed X/Z axis.\n"
+                    + "NOTE: The fast closed-form solver is position-axis only; custom angle solves rely on the search optimizer.\n"
+                    + "Using 'Optimize' effort is recommended for maximum reach.");
 
             ImGui.spacing();
             boolean fastTier = state.getEffort() == AngleSolverState.Effort.FAST;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverWindow.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverWindow.java
@@ -229,7 +229,6 @@ public final class AngleSolverWindow implements RenderInterface {
                 state.setCustomAngle(!state.isCustomAngle());
             }
             TooltipUtil.onHover("Optimize trajectory distance towards a custom facing angle instead of a fixed X/Z axis.\n"
-                    + "NOTE: The fast closed-form solver is position-axis only; custom angle solves rely on the search optimizer.\n"
                     + "Using 'Optimize' effort is recommended for maximum reach.");
 
             ImGui.spacing();
@@ -873,9 +872,15 @@ public final class AngleSolverWindow implements RenderInterface {
             rows.add(new SolveResult.Detail("Finished", r.getFinishedAt()));
         }
         if (r.hasObjective()) {
-            String goal = state.getGoal() == AngleSolverState.Goal.MAX ? "max" : "min";
-            rows.add(new SolveResult.Detail("Objective",
-                    goal + " " + state.getAxis().name() + " = " + ConstraintText.fixedStat(r.getObjectiveValue())));
+            if (state.isCustomAngle()) {
+                rows.add(new SolveResult.Detail("Objective",
+                        String.format(Locale.ROOT, "yaw %.1f° = ", state.getCustomAngleDeg())
+                                + ConstraintText.fixedStat(r.getObjectiveValue())));
+            } else {
+                String goal = state.getGoal() == AngleSolverState.Goal.MAX ? "max" : "min";
+                rows.add(new SolveResult.Detail("Objective",
+                        goal + " " + state.getAxis().name() + " = " + ConstraintText.fixedStat(r.getObjectiveValue())));
+            }
         }
         return rows;
     }
@@ -950,7 +955,7 @@ public final class AngleSolverWindow implements RenderInterface {
         }
         double v = panel.getObjectiveValue();
         if (!Double.isNaN(improveTrackValue) && v != improveTrackValue) {
-            boolean max = state.getGoal() == AngleSolverState.Goal.MAX;
+            boolean max = state.isCustomAngle() || state.getGoal() == AngleSolverState.Goal.MAX;
             double delta = v - improveTrackValue;
             if (max ? delta > 0 : delta < 0) {
                 improveFlashStart = ImGui.getTime();

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
 # Gradle 9 requires JVM 17+; pin to installed JDK 21 so gradlew works even when JAVA_HOME/PATH points at JDK 8.
-org.gradle.java.home=C\:\\Program Files\\Eclipse Adoptium\\jdk-21.0.5.11-hotspot
+org.gradle.java.home=C\:\\Program Files\\Java\\jdk-21
 
 # Mod Properties (shared across modules)
 mod_version=1.9.0 # x-release-please-version

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
 # Gradle 9 requires JVM 17+; pin to installed JDK 21 so gradlew works even when JAVA_HOME/PATH points at JDK 8.
-org.gradle.java.home=C\:\\Program Files\\Java\\jdk-21
+org.gradle.java.home=C\:\\Program Files\\Eclipse Adoptium\\jdk-21.0.5.11-hotspot
 
 # Mod Properties (shared across modules)
 mod_version=1.9.0 # x-release-please-version


### PR DESCRIPTION
- **Custom Angle Objective:** Allows optimizing jump trajectories directly towards any custom facing angle (e.g. 45.0° for diagonal jumps) instead of only 1D X/Z axes.
- **Dynamic UI:** Checkbox in the Angle Solver window swaps between standard Axis/Goal selectors and the target angle input field.
- **Player Yaw Button:** Added a `[ P ]` button next to the input to instantly set the target angle to the player's current facing.