### PR TITLE
fix(solver): append absolute recovery margins to the joint ladder

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/FreeStartSolve.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/FreeStartSolve.java
@@ -446,8 +446,12 @@ public final class FreeStartSolve {
 
         double bestViol = Double.POSITIVE_INFINITY;
         double[] bestYaws = null;
-        for (double frac : JOINT_RECOVERY_FRACTIONS) {
-            double margin = tStar * frac;
+        double[] margins = new double[JOINT_RECOVERY_FRACTIONS.length + cfg.jointMargins.length];
+        int marginCount = 0;
+        for (double frac : JOINT_RECOVERY_FRACTIONS) margins[marginCount++] = tStar * frac;
+        for (double m : cfg.jointMargins) if (m > 0.0 && m <= tStar) margins[marginCount++] = m;
+        for (int mi = 0; mi < marginCount; mi++) {
+            double margin = margins[mi];
             if (cancel != null && cancel.get()) return null;
             CostateDualSolver.Result r = solver.solve(margin, warm);
             if (r == null || solver.lastStalled) continue;


### PR DESCRIPTION
Fixes #362, the two free-start shifted-sweep regressions from #358.

## Root cause
Round 3 of #358 replaced jointLadder's absolute recovery rungs (cfg.jointMargins, 0 to 1.0e-2) with the fractions {0.5, 0.25, 0.75, 0} of the per-branch max feasible margin t*. On knife-edge chains t* is tiny and the fractions land in the old range, which is what solved j990 cold. On wide-margin chains t* saturates near the jointMarginMax cap (traces show 0.199 to 0.250 on every branch), so the smallest nonzero margin tried is about 0.06: one to two orders above the certify basin. Dual recovery that deep inside the feasible region distorts the solution shape enough that neither pin-translate nor recoverStart certifies. Dev certified exactly these jumps by direct pin-translate at the small absolute rungs (j246 at margin 1.0e-2, j424 at 2.5e-3) that the fraction schedule never samples.

Checked and cleared: prefixArcThetas and its empty-array short-circuit are not on the path for either jump (no prefix-arc trace lines; both specs dispatch through FacingPrefold.analyze straight into jointLadder), and issues #360/#361 are not the cause (dev shares those and still solves both).

## Change
jointLadder samples both margin scales: the four t* fraction rungs run first, unchanged, then the absolute cfg.jointMargins rungs are appended (skipping 0.0 and rungs above t*). Strictly additive: every branch that certifies via the fractions follows a bit-identical path, and the appended rungs only run where the ladder currently fails.

## Results (engine FAST, farseed shifted sweep protocol)
- j246__X__1.9375bm_Triple_Neo: fails at 120 s -> solves in 2.9 s (dev 12.8 to 17.1 s), via the receding-horizon free-window retry
- j424_1.4375bm_Double_Winged_Neo__0.25: fails at 120 s -> solves in 3.7 s (dev 12.1 to 26.4 s)
- Full 52-variant shifted sweep: 46/52 -> 50/52 with zero losses. Bonus gains: j1149 and j129, previously unsolved on dev and on the #358 head, now solve; j717 drops from 68 s to under 35 s. j335 (32.5 s) and j347 (90.4 s) stay inside their 120 s budgets; only j718 and j828 remain.
- gh283-j925-farseed 16.7 s and gh283-j990-cold 0.38 s, both inside their 20 s problem budgets.
- Standalone joint checks unchanged: j155 dual 58 ms, j990 solveJoint feasible 544 ms.

## Tests
- :core:check (fast suite + tableStyleCheck) and full :core:test -PslowTests green (5 m).

Side observation, open, recorded in #362's appendix: on both failing head runs the race stage logs "race end solved" yet the engine discards the result (SolveCore internal accept vs Scoring.scoredViol disagreement) and burns the remaining budget in momentum assembly plus a bnb rescue miss; likely relevant to the remaining hard shifted jumps j718 and j828.
