### PR TITLE
fix(solver): race the free-start problem instead of the corner-pinned one

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/nodes/CmaesRaceNode.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/nodes/CmaesRaceNode.java
@@ -12,6 +12,7 @@ import de.legoshi.parkourcalc.core.anglesolver.solver.BucketAscentPolish;
 import de.legoshi.parkourcalc.core.anglesolver.solver.CmaesJumpHarness;
 import de.legoshi.parkourcalc.core.anglesolver.solver.SolveCore;
 import de.legoshi.parkourcalc.core.anglesolver.solver.SolverTrace;
+import de.legoshi.parkourcalc.core.anglesolver.solver.StartBox;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -55,9 +56,19 @@ public final class CmaesRaceNode implements NodeRuntime {
             SolverTrace.log("ENGINE", "race start warm=%s deadlineMs=%d", warm != null,
                     deadlineNanos > 0 ? (deadlineNanos - System.nanoTime()) / 1_000_000L : -1);
         }
-        double[] cma = SolveCore.optimize(counting, ctx.spec, budget, sigmaDeg, ctx.feasTol, nodeToken,
-                warm, deadlineNanos, ctx.sequential, ctx.progress);
-        if (SolverTrace.on()) SolverTrace.log("ENGINE", "race end %s", cma != null ? "solved" : "miss");
+        StartBox savedBox = ctx.scenario.startBox;
+        if (ctx.freeBox != null) ctx.scenario.startBox = ctx.freeBox;
+        double[] cma;
+        try {
+            cma = SolveCore.optimize(counting, ctx.spec, budget, sigmaDeg, ctx.feasTol, nodeToken,
+                    warm, deadlineNanos, ctx.sequential, ctx.progress);
+        } finally {
+            ctx.scenario.startBox = savedBox;
+        }
+        if (SolverTrace.on()) {
+            SolverTrace.log("ENGINE", "race end %s", cma == null ? "miss"
+                    : ctx.scoredViol(cma) <= ctx.feasTol ? "solved" : "near miss");
+        }
         ctx.cmaesEvals.addAndGet(counting.evals());
         if (in == null || in.yaws == null) {
             ctx.chainAppend("CMA-ES");


### PR DESCRIPTION
Fixes #364. Part of the gh-283 free-start work; recovers j828, the second-to-last hard jump of the shifted sweep.

## Root cause

`AngleSolverEngine.runJob` pins the scenario at the corner-clamped seed before the graph runs and carries the free start box only in `ctx.freeBox`; free-start handling is opt-in per node. `freeStartImprove` and the receding-horizon window retry opt in, and `Scoring.scoredViol`/`scoredObjective` always score candidates at their best translation inside `ctx.freeBox`. `CmaesRaceNode` never opted in: it handed `SolveCore` the pinned scenario, so `CmaesJumpHarness` ran with `free=false` and optimized the corner-pinned problem while the engine scored the result translated. On free-start solves whose feasible starts are away from the corner, the race searched a near-infeasible problem by construction. Proof it mattered: standalone `SolveCore` given the free box solves both j718 and j828 with scored violation exactly 0.

A second, cosmetic defect compounded the confusion: `SolveCore.optimize` returns the best-objective near miss when nothing is feasible (by design), and the race trace printed `race end solved` for any non-null return, so failed races read as solves the engine then discarded.

## Changes

- `CmaesRaceNode` swaps `ctx.freeBox` into `ctx.scenario.startBox` around the `SolveCore.optimize` call and restores the previous box in a finally block, the exact pattern `jointRescue` already uses. The harness then runs its `free=true` translated-penalty path, whose accept was made honest by the #358 round-4 anchor fix, so the race optimizes the same problem the engine scores.
- The `race end` trace line is now derived from the scored violation: solved / near miss / miss.

## Results (engine FAST, farseed shifted sweep protocol, at 54950a6)

- j828-1bm_5.3125-1.5: fails at 120 s -> solves in 21 s via `receding horizon -> CMA-ES -> free start -> translated start`, viol 0.
- Full 52-variant shifted sweep: 51/52 with zero losses (only j718 remains). Bonus: j129 and j335 promote from 120 s-class to under 35 s, j347 drops from 90 s to 50 s.
- gh283-j925-farseed 15.1 s (was 16.7 s) and gh283-j990-cold 0.31 s, inside their 20 s problem budgets.
- Standalone joint checks unchanged: j155 dual 42 ms, j990 solveJoint feasible 345 ms.

## Tests

- :core:check (fast suite + tableStyleCheck) and full :core:test -PslowTests green (4 m 30 s).

j718 stays open and is documented in #364's appendix: its deterministic path bottoms out at a 2.408e-4 j925-class span-conflict (translation-conflicting X windows, X GE t25/t37 versus X LE t27/t33), and its race solve needs roughly 90 s of sequential work including SolveCore's small-sigma near-miss rescue, beyond the FAST race batch. Candidate levers there: local shape repair for span-conflict near misses, free-box-aware bnb rescue and momentum assembly (both still run pinned), and enabling polish for free specs (currently skipped in `CmaesJumpHarness`).
