### PR TITLE
fix(solver): rescue free starts with a pinned SLP anchor grid

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/FreeStartSolve.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/FreeStartSolve.java
@@ -96,6 +96,32 @@ public final class FreeStartSolve {
             p0x = nx;
             p0z = nz;
         }
+        return slpAnchorGrid(exact, spec, base, box, feasTol, cancel);
+    }
+
+    private static final double[] ANCHOR_GRID_FRACTIONS = {0.5, 0.25, 0.75, 0.0, 1.0};
+
+    private static Result slpAnchorGrid(ExactJumpModel exact, JumpSpec spec, JumpPhysicsInputs base, StartBox box,
+                                        double feasTol, AtomicBoolean cancel) {
+        double seedX = clamp(box.px, box.pxLo, box.pxHi);
+        double seedZ = clamp(box.pz, box.pzLo, box.pzHi);
+        for (double fx : ANCHOR_GRID_FRACTIONS) {
+            for (double fz : ANCHOR_GRID_FRACTIONS) {
+                if (cancel != null && cancel.get()) return null;
+                double px = box.pxLo + (box.pxHi - box.pxLo) * fx;
+                double pz = box.pzLo + (box.pzHi - box.pzLo) * fz;
+                if (Math.abs(px - seedX) < 1.0e-9 && Math.abs(pz - seedZ) < 1.0e-9) continue;
+                JumpSpec at = specAtStart(base, spec, px, pz);
+                double[] yaws = SlpSolve.optimize(exact, at, feasTol, cancel);
+                if (yaws != null && violationAt(exact, spec, yaws, px, pz) <= feasTol) {
+                    if (SolverTrace.on()) {
+                        SolverTrace.log("FREE", "anchor grid solved at (%.4f,%.4f)", px, pz);
+                    }
+                    return new Result(Angles.wrapAll(yaws.clone()), px, pz, true);
+                }
+            }
+        }
+        if (SolverTrace.on()) SolverTrace.log("FREE", "anchor grid miss");
         return null;
     }
 


### PR DESCRIPTION
Fixes #366. Closes the shifted-sweep corpus: with this, all 52 seed-shifted hpk variants solve at engine FAST within 35 s.

## Root cause

Every deterministic stage of a free-start solve anchors at exactly one position, the corner-clamped seed: the engine re-references an outside seed to the box corner, and `FreeStartSolve.solve`'s shape-translate alternation starts there and only moves by translating its current shape. On j718 the alternation dies at iter 0 (`pinTranslate` nulls on conflicting translation intervals), and a repaired alternation still stalls in a joint local minimum at 2.27e-3. Meanwhile pinned `SlpSolve` cold-solves j718 at the certified start in 40 ms, and its solve basin is wide: 22 of 81 points of a 9x9 grid over the start box (box center included, about 23 ms per call). The machinery is capable; it is never anchored where the solutions are. The near-miss family the joint dual reaches is provably the wrong strategy family (mean yaw delta 18.9 deg vs the solution, 134 deg at t15), so no local repair could close it.

## Change

`slpAnchorGrid` as the final fallback of `FreeStartSolve.solve`: a fixed center-first 5x5 grid of anchors spanning the start box, pinned `SlpSolve.optimize` at each, certified via `violationAt`, first feasible returned. It only runs after everything else failed, skips the already-tried seed anchor, and the caller's cancel token (node deadlines) bounds its cost. Specs SlpSolve refuses fall through in microseconds.

## Results (engine FAST, farseed shifted sweep protocol, at 54950a6)

- j718-2bm__Z__Pane_to_Pane_Neo: fails at 120 s -> solves in 3.1 s (grid hit at the box center feeds the receding-horizon free window: `receding horizon -> free window -> closed form -> SLP -> level set`).
- Full 52-variant shifted sweep: 52/52 at 35 s with zero losses, the first complete closure of the corpus. j828 becomes deterministic (no race needed), j129/j335/j347 drop from 120 s class to under 35 s.
- CMA-kill audit on this stack: base sweep 52/52 and shifted sweep 51/52 solve with `SolveCore.optimize` disabled entirely; only j816 still needs the race on the shifted corpus.
- gh283-j925-farseed 15.3 s and gh283-j990-cold 0.31 s, inside their 20 s budgets; nix-full-t1 68 s of 240 s.
- Standalone joint checks unchanged: j155 dual 43 ms, j990 solveJoint feasible 363 ms.

## Tests

- :core:check (fast suite + tableStyleCheck) and full :core:test -PslowTests green.
