### PR TITLE
feat(solver): teach SlpSolve facing constraints via tie folding and exact yaw rows

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/FreeStartSolve.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/FreeStartSolve.java
@@ -96,6 +96,32 @@ public final class FreeStartSolve {
             p0x = nx;
             p0z = nz;
         }
+        return slpAnchorGrid(exact, spec, base, box, feasTol, cancel);
+    }
+
+    private static final double[] ANCHOR_GRID_FRACTIONS = {0.5, 0.25, 0.75, 0.0, 1.0};
+
+    private static Result slpAnchorGrid(ExactJumpModel exact, JumpSpec spec, JumpPhysicsInputs base, StartBox box,
+                                        double feasTol, AtomicBoolean cancel) {
+        double seedX = clamp(box.px, box.pxLo, box.pxHi);
+        double seedZ = clamp(box.pz, box.pzLo, box.pzHi);
+        for (double fx : ANCHOR_GRID_FRACTIONS) {
+            for (double fz : ANCHOR_GRID_FRACTIONS) {
+                if (cancel != null && cancel.get()) return null;
+                double px = box.pxLo + (box.pxHi - box.pxLo) * fx;
+                double pz = box.pzLo + (box.pzHi - box.pzLo) * fz;
+                if (Math.abs(px - seedX) < 1.0e-9 && Math.abs(pz - seedZ) < 1.0e-9) continue;
+                JumpSpec at = specAtStart(base, spec, px, pz);
+                double[] yaws = SlpSolve.optimize(exact, at, feasTol, cancel);
+                if (yaws != null && violationAt(exact, spec, yaws, px, pz) <= feasTol) {
+                    if (SolverTrace.on()) {
+                        SolverTrace.log("FREE", "anchor grid solved at (%.4f,%.4f)", px, pz);
+                    }
+                    return new Result(Angles.wrapAll(yaws.clone()), px, pz, true);
+                }
+            }
+        }
+        if (SolverTrace.on()) SolverTrace.log("FREE", "anchor grid miss");
         return null;
     }
 

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/SlpSolve.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/SlpSolve.java
@@ -106,12 +106,28 @@ public final class SlpSolve {
                                      double targetClearance, boolean hugObjective, double[] seedAbsWrapped,
                                      boolean bestEffort, boolean inertiaAware, Config cfg) {
         List<JumpConstraint> constraints = spec.constraints;
-        if (JumpLinearModel.hasFacingWall(constraints)) return null; // not position-linear
+        JumpPhysicsInputs sc = spec.asScenario();
+        YawTies ties = null;
+        List<JumpConstraint> yawIneq = new ArrayList<>();
+        if (JumpLinearModel.hasFacingWall(constraints)) {
+            ties = YawTies.of(constraints, sc.numTicks);
+            for (JumpConstraint c : constraints) {
+                if (c.mode != JumpConstraint.Mode.F) continue;
+                if (c.t1 < 0 || c.t1 >= sc.numTicks) continue;
+                boolean delta = c.t2 != null;
+                if (delta && !(c.op == JumpConstraint.Op.MINUS && c.t2 == c.t1 - 1 && c.t1 >= 1)) return null;
+                boolean absorbed = ties != null
+                        && (delta ? ties.groupOf(c.t1) == ties.groupOf(c.t1 - 1) : ties.varOf(c.t1) < 0);
+                if (absorbed) continue;
+                if (c.cmp == JumpConstraint.Cmp.EQ) return null;
+                yawIneq.add(c);
+            }
+        }
         for (JumpConstraint c : constraints) {
+            if (c.mode == JumpConstraint.Mode.F) continue;
             if (c.cmp == JumpConstraint.Cmp.EQ) return null; // UI maps EQ to a corridor; a true EQ cannot hold strict clearance
         }
 
-        JumpPhysicsInputs sc = spec.asScenario();
         JumpLinearModel lin = new JumpLinearModel(sc);
         int n = lin.n;
 
@@ -120,11 +136,14 @@ public final class SlpSolve {
         List<JumpConstraint> ineq = new ArrayList<>();
         List<JumpLinearModel.Wall> walls = new ArrayList<>();
         for (JumpConstraint c : constraints) {
+            if (c.mode == JumpConstraint.Mode.F) continue;
             JumpLinearModel.Wall w = lin.compileWall(c, 0.0, trivialInfeasible);
             if (trivialInfeasible[0]) return null; // a violated constant is unfixable
             if (w != null) { ineq.add(c); walls.add(w); }
         }
-        int m = walls.size();
+        int mPos = walls.size();
+        ineq.addAll(yawIneq);
+        int m = ineq.size();
         if (m == 0) return null; // nothing to restore; the closed form already handles the unconstrained case
 
         double[] cx = new double[n];
@@ -151,10 +170,13 @@ public final class SlpSolve {
             }
         }
 
+        if (ties != null) theta = ties.expand(ties.reduce(theta));
+
         long t0 = System.nanoTime();
         if (SolverTrace.on()) {
-            SolverTrace.log("SLP", "start n=%d m=%d seed=%s budget=%d/%d bestEffort=%s inertiaAware=%s",
-                    n, m, seedAbsWrapped != null ? "given" : "dual", cfg.phase1Calls, cfg.totalCalls, bestEffort, inertiaAware);
+            SolverTrace.log("SLP", "start n=%d m=%d seed=%s budget=%d/%d bestEffort=%s inertiaAware=%s fold=%s",
+                    n, m, seedAbsWrapped != null ? "given" : "dual", cfg.phase1Calls, cfg.totalCalls, bestEffort,
+                    inertiaAware, ties == null ? "-" : String.valueOf(ties.dims()));
         }
         JumpConstraintCompiler.Compiled compiled = JumpConstraintCompiler.compile(spec);
         double[] viol = new double[m];
@@ -164,6 +186,9 @@ public final class SlpSolve {
         boolean max = spec.objective.sense == Objective.Sense.MAX;
         int lpCalls = 0;
         double tr = cfg.trStartDeg;
+        int dims = ties == null ? n : ties.dims();
+        int[] col = new int[n];
+        for (int t = 0; t < n; t++) col[t] = ties == null ? t : ties.varOf(t);
 
         boolean[] zeroX = new boolean[n];
         boolean[] zeroZ = new boolean[n];
@@ -188,8 +213,8 @@ public final class SlpSolve {
                     List<JumpLinearModel.Wall> rebuilt = null;
                     if (anySet(zeroX) || anySet(zeroZ)) {
                         JumpLinearModel patterned = new JumpLinearModel(sc, zeroX.clone(), zeroZ.clone());
-                        rebuilt = new ArrayList<>(m);
-                        for (JumpConstraint c : ineq) {
+                        rebuilt = new ArrayList<>(mPos);
+                        for (JumpConstraint c : ineq.subList(0, mPos)) {
                             JumpLinearModel.Wall w = patterned.compileWall(c, 0.0, null);
                             if (w == null) { rebuilt = null; break; }
                             rebuilt.add(w);
@@ -215,33 +240,50 @@ public final class SlpSolve {
                     ux[t] = lin.mMag(t) * Math.cos(phi);
                     uz[t] = lin.mMag(t) * Math.sin(phi);
                 }
-                int nv = n + 1; // facing deltas (deg) + worst-slack variable s
-                List<LinearConstraint> cons = new ArrayList<>(m + 2 * n + 1);
+                int nv = dims + 1; // facing deltas (deg) + worst-slack variable s
+                List<LinearConstraint> cons = new ArrayList<>(m + 2 * dims + 1);
                 for (int j = 0; j < m; j++) {
-                    JumpLinearModel.Wall wall = lpWalls.get(j);
                     double[] row = new double[nv];
-                    for (int t = 0; t < n; t++) {
-                        double du = wall.axis == 0 ? -uz[t] : ux[t]; // d(u.axis)/dyaw, deg-scaled below
-                        row[t] = wall.coef[t] * du * RAD;
+                    if (j < mPos) {
+                        JumpLinearModel.Wall wall = lpWalls.get(j);
+                        for (int t = 0; t < n; t++) {
+                            int v = col[t];
+                            if (v < 0) continue;
+                            double du = wall.axis == 0 ? -uz[t] : ux[t]; // d(u.axis)/dyaw, deg-scaled below
+                            row[v] += wall.coef[t] * du * RAD;
+                        }
+                    } else {
+                        JumpConstraint c = ineq.get(j);
+                        double sgn = c.cmp == JumpConstraint.Cmp.GE ? -1.0 : 1.0;
+                        int v1 = col[c.t1];
+                        if (v1 >= 0) row[v1] += sgn;
+                        if (c.t2 != null) {
+                            int v2 = col[c.t2];
+                            if (v2 >= 0) row[v2] -= sgn;
+                        }
                     }
-                    row[n] = -1.0;
+                    row[dims] = -1.0;
                     cons.add(new LinearConstraint(row, Relationship.LEQ, -viol[j]));
                 }
-                for (int t = 0; t < n; t++) {
+                for (int v = 0; v < dims; v++) {
                     double[] lo = new double[nv];
-                    lo[t] = 1.0;
+                    lo[v] = 1.0;
                     cons.add(new LinearConstraint(lo, Relationship.LEQ, tr));
                     double[] hi = new double[nv];
-                    hi[t] = -1.0;
+                    hi[v] = -1.0;
                     cons.add(new LinearConstraint(hi, Relationship.LEQ, tr));
                 }
                 double[] objRow = new double[nv];
                 if (phase == 1) {
-                    objRow[n] = 1.0; // minimize the worst linearized slack
+                    objRow[dims] = 1.0; // minimize the worst linearized slack
                 } else {
-                    for (int t = 0; t < n; t++) objRow[t] = -(lpCx[t] * -uz[t] + lpCz[t] * ux[t]) * RAD; // maximize c.du
+                    for (int t = 0; t < n; t++) {
+                        int v = col[t];
+                        if (v < 0) continue;
+                        objRow[v] += -(lpCx[t] * -uz[t] + lpCz[t] * ux[t]) * RAD; // maximize c.du
+                    }
                     double[] sCap = new double[nv];
-                    sCap[n] = 1.0;
+                    sCap[dims] = 1.0;
                     // Stay strictly inside, but never demand deeper clearance than the point already has,
                     // or ascending along a wall that must stay hugged would make the LP infeasible.
                     cons.add(new LinearConstraint(sCap, Relationship.LEQ, Math.max(-CLEARANCE, maxViol)));
@@ -261,9 +303,10 @@ public final class SlpSolve {
                 double[] cand = new double[n];
                 double step = 0.0;
                 for (int t = 0; t < n; t++) {
-                    cand[t] = theta[t] + d[t];
-                    step = Math.max(step, Math.abs(d[t]));
+                    int v = col[t];
+                    cand[t] = v < 0 ? theta[t] : theta[t] + d[v];
                 }
+                for (int v = 0; v < dims; v++) step = Math.max(step, Math.abs(d[v]));
                 double[] cgf = sc.toGameFacings(Angles.wrapAll(cand));
                 ForwardPath cpath = exact.forward(sc, cgf);
                 double cViol = exactSlacks(ineq, cgf, cpath, candViol);
@@ -275,7 +318,7 @@ public final class SlpSolve {
                         : cViol <= feasTol && cObj > objNorm;
                 if (SolverTrace.on()) {
                     SolverTrace.log("SLP", "lp#%d phase=%d tr=%.3g step=%.3g pred=%.3e viol=%.3e->%.3e obj=%.9f->%.9f %s",
-                            lpCalls, phase, tr, step, d[n], maxViol, cViol, objNorm, cObj,
+                            lpCalls, phase, tr, step, d[dims], maxViol, cViol, objNorm, cObj,
                             accept ? "accept" : "reject");
                 }
                 if (accept) {
@@ -298,6 +341,10 @@ public final class SlpSolve {
                     if (SolverTrace.on()) {
                         SolverTrace.log("SLP", "phase1 infeasible viol=%.3e lps=%d ms=%.1f%s",
                                 endViol, lpCalls, (System.nanoTime() - t0) / 1e6, bestEffort ? " (best effort kept)" : "");
+                    }
+                    if (!inertiaAware && !bestEffort) {
+                        return optimize(exact, spec, feasTol, cancel, targetClearance, hugObjective,
+                                Angles.wrapAll(theta), false, true, cfg);
                     }
                     return bestEffort ? Angles.wrapAll(theta) : null;
                 }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/YawTies.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/YawTies.java
@@ -14,18 +14,28 @@ public final class YawTies {
     private final double[] offset;
     private final double[] pinYaw;
     private final int[] repTick;
+    private final int[] group;
 
-    private YawTies(int n, int dims, int[] varOf, double[] offset, double[] pinYaw, int[] repTick) {
+    private YawTies(int n, int dims, int[] varOf, double[] offset, double[] pinYaw, int[] repTick, int[] group) {
         this.n = n;
         this.dims = dims;
         this.varOf = varOf;
         this.offset = offset;
         this.pinYaw = pinYaw;
         this.repTick = repTick;
+        this.group = group;
     }
 
     public int dims() {
         return dims;
+    }
+
+    public int varOf(int t) {
+        return varOf[t];
+    }
+
+    public int groupOf(int t) {
+        return group[t];
     }
 
     public int fullLength() {
@@ -142,7 +152,7 @@ public final class YawTies {
             varOf[t] = v;
         }
         if (dims == n) return null;
-        return new YawTies(n, dims, varOf, offset, pinYaw, Arrays.copyOf(rep, dims));
+        return new YawTies(n, dims, varOf, offset, pinYaw, Arrays.copyOf(rep, dims), group);
     }
 
     private static void tighten(double[] lo, double[] hi, int t, JumpConstraint.Cmp cmp, double rhs) {


### PR DESCRIPTION
Part of #360: the SlpSolve piece, which its design names as load-bearing. Stacked on #367 (the two were verified together; this PR shows only the SlpSolve/YawTies diff and retargets to dev when #367 merges).

## Problem

`SlpSolve` blanket-refuses any spec containing an F-mode constraint, so the whole dF class runs with the strongest deterministic closer disabled and falls through to the CMA race. This is the top gate on the CMA retirement path: of the four captures that still need CMA on the current stack, two (gh283-j925-farseed, gh313-j121-dfneo) are dF specs SlpSolve refuses on sight.

## Change

Three mechanisms, all inside SlpSolve/YawTies:

1. Tie folding: tight facing pins and dF equality chains fold through `YawTies` (the same fold the CMA harness already consumes) into group-shared LP columns. Pinned ticks drop out of the LP, linked ticks share one delta variable, and the seed is projected onto the tie manifold, so the folded F constraints hold by construction. On gh283-j925-farseed the LP shrinks from 24 yaw variables to 12.
2. Exact yaw rows: loose one-sided F/dF constraints (for example gh313-j121-dfneo's dF LE walls) become LP rows with coefficients +-1 on the delta variables and byte-exact slacks via the existing compiled evaluation. Facing constraints are linear in the deltas, so unlike the position walls these rows carry no linearization error. Wide bands that are neither tight nor row-representable (non-consecutive deltas, PLUS ops) stay refused, as do unabsorbed F equalities.
3. Inertia-aware retry: when plain phase 1 ends infeasible, one strictly additive retry runs from the stalled point with the inertia-aware linearization. Measured basis: at j925-farseed's certified start the plain clamp-free linearization floors at viol 0.84 while the inertia-aware model reaches 2.7e-5 in 16 ms.

## Status against the CMA captures (honest)

This is groundwork, not a capture flip on its own:

- gh283-j925-farseed: SLP now runs and folds, but the feasible-start set is a sliver (box z-range 0.19, certified start on the x-boundary; inertia-aware SLP gets close only within about 0.01 of it and LatticeRepair cannot close the 2.7e-5 tail). The remaining lever is the free-start (theta, derived-pattern) ladder with this folded SLP as its inner solver.
- gh313-j121-dfneo: SLP now runs on its windows (first LP step drops violation 30.9 to 8.8e-3) but every window floors at 4.066e-3 under both linearizations, so the block is the window/seam choice, not SLP.

## Tests

- :core:check and full :core:test -PslowTests green on the stacked state; shifted sweep stays 52/52 with zero losses; budgets unchanged (farseed 15.7 s, nix-full-t1 74 s of 240 s).
