### PR TITLE
feat: add custom target angle objective to angle solver

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
@@ -218,6 +218,7 @@ public final class Application {
         GraphEditorWindow graphEditorWindow = new GraphEditorWindow(angleSolverEngine);
         AngleSolverWindow angleSolverWindow = new AngleSolverWindow(angleSolverState, settings, inputData::size, angleSolverEngine, velocityMapController.widget(), graphStore, graphEditorWindow);
         angleSolverWindow.setApplySurfaceState(this::applyPathSurfaceState);
+        angleSolverWindow.setPlayerYawSupplier(mc::getPlayerYaw);
         runTicks = new RunTicksController(angleSolverState, angleSolverEngine, inputData, constraintSelection,
                 hudMessages, this::runSimulation, saveController::markDirty, this::pushHudMessage);
         angleSolverWindow.setRunTicksControls(runTicks);

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/AngleSolverEngine.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/AngleSolverEngine.java
@@ -377,7 +377,12 @@ public final class AngleSolverEngine {
         }
 
         List<JumpConstraint> constraints = new ArrayList<>();
-        Objective objective = new Objective(axis(state.getAxis()), sense(state.getGoal()), numTicks,
+        Objective objective = state.isCustomAngle()
+                ? new Objective(state.getCustomAngleDeg(),
+                state.getCustomAngleType() == AngleSolverState.CustomAngleType.MOTION
+                        ? Objective.Type.MOTION : Objective.Type.POSITION,
+                numTicks, state.getSmoothLambda())
+                : new Objective(axis(state.getAxis()), sense(state.getGoal()), numTicks,
                 state.getSmoothLambda());
         for (ConstraintAt ca : uiCons) {
             if (footprintCons != null && footprintCons.contains(ca.c)) continue;
@@ -924,7 +929,7 @@ public final class AngleSolverEngine {
                     "%.9e short of %s", shortfall, job.legalGoal.name));
         }
         if (ctx.smoothingEvals.get() > 0) result.addDetail("Smoothing evals", Long.toString(ctx.smoothingEvals.get()));
-        double finalObjective = path.getPos(spec.objective.tick, spec.objective.axis);
+        double finalObjective = spec.objective.evaluate(path);
         double finalViolation = JumpConstraintCompiler.compile(spec).maxViolation(gameFacings, path);
         if (finalViolation <= FEAS_TOL && JumpLinearModel.hasFacingWall(spec.constraints)) {
             result.setNotice(DF_DIRECTION_NOTICE);
@@ -997,7 +1002,7 @@ public final class AngleSolverEngine {
     private SolveResult buildResultWithObjective(Job job, double[] yaws, double[] gameFacings, ForwardPath path,
                                                  boolean feasible) {
         SolveResult result = buildResult(job, yaws, gameFacings, path, feasible);
-        result.setObjective(path.getPos(job.spec.objective.tick, job.spec.objective.axis));
+        result.setObjective(job.spec.objective.evaluate(path));
         result.getOutcomes().add(0, objectiveOutcome(result, job.spec.objective, job.startTick));
         return result;
     }
@@ -1037,6 +1042,12 @@ public final class AngleSolverEngine {
 
     /** The objective as the leading Solved-values row: axis @ tick, max/min as the relation, achieved value. */
     private static SolveResult.Outcome objectiveOutcome(SolveResult r, Objective o, int startTick) {
+        if (o.isCustomAngle()) {
+            String field = o.isMotion() ? "dAngle" : "Angle";
+            return new SolveResult.Outcome(field, "T" + (startTick + o.tick + 1),
+                    String.format(java.util.Locale.ROOT, "%.1f°", o.customYaw),
+                    ConstraintText.fixedStat(r.getObjectiveValue()), "");
+        }
         String field = o.axis == JumpPhysicsInputs.Axis.X ? "X" : "Z";
         String sense = o.sense == Objective.Sense.MAX ? "max" : "min";
         return new SolveResult.Outcome(field, "T" + (startTick + o.tick + 1), sense,

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/AngleSolverState.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/AngleSolverState.java
@@ -2,6 +2,7 @@ package de.legoshi.parkourcalc.core.anglesolver;
 
 import de.legoshi.parkourcalc.core.anglesolver.graph.SolverGraph;
 import de.legoshi.parkourcalc.core.anglesolver.runticks.RunTicksSettings;
+import de.legoshi.parkourcalc.core.anglesolver.solver.Angles;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -116,10 +117,24 @@ public final class AngleSolverState {
         return v < lo ? lo : (v > hi ? hi : v);
     }
 
+    public enum CustomAngleType {
+        POSITION("Pos"),
+        MOTION("Mot");
+
+        public final String label;
+
+        CustomAngleType(String label) {
+            this.label = label;
+        }
+    }
+
     private int startTick;
     private int landingTick;
     private Axis axis = Axis.X;
     private Goal goal = Goal.MAX;
+    private boolean customAngle = false;
+    private double customAngleDeg = 0.0;
+    private CustomAngleType customAngleType = CustomAngleType.POSITION;
     private Effort effort = Effort.FAST;
     private boolean stopOnFeasible;
     private boolean legalMode;
@@ -181,6 +196,30 @@ public final class AngleSolverState {
 
     public void setGoal(Goal goal) {
         this.goal = goal;
+    }
+
+    public boolean isCustomAngle() {
+        return customAngle;
+    }
+
+    public void setCustomAngle(boolean customAngle) {
+        this.customAngle = customAngle;
+    }
+
+    public double getCustomAngleDeg() {
+        return customAngleDeg;
+    }
+
+    public void setCustomAngleDeg(double customAngleDeg) {
+        this.customAngleDeg = Angles.wrap(customAngleDeg);
+    }
+
+    public CustomAngleType getCustomAngleType() {
+        return customAngleType;
+    }
+
+    public void setCustomAngleType(CustomAngleType type) {
+        this.customAngleType = type != null ? type : CustomAngleType.POSITION;
     }
 
     public Effort getEffort() {
@@ -686,6 +725,9 @@ public final class AngleSolverState {
         landingTick = 0;
         axis = Axis.X;
         goal = Goal.MAX;
+        customAngle = false;
+        customAngleDeg = 0.0;
+        customAngleType = CustomAngleType.POSITION;
         effort = Effort.FAST;
         stopOnFeasible = false;
         legalMode = false;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/Scoring.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/Scoring.java
@@ -38,7 +38,7 @@ public final class Scoring {
 
     public static double exactObjective(ForwardModel model, JumpPhysicsInputs sc, JumpSpec spec, double[] yawsAbsWrapped) {
         ForwardPath p = model.forward(sc, sc.toGameFacings(yawsAbsWrapped));
-        return p.getPos(spec.objective.tick, spec.objective.axis);
+        return spec.objective.evaluate(p);
     }
 
     public static double violationOf(ForwardModel model, JumpPhysicsInputs sc, JumpSpec spec, double[] yawsAbsWrapped) {
@@ -88,6 +88,7 @@ public final class Scoring {
     }
 
     public static double objectiveCap(JumpSpec spec) {
+        if (spec.objective.isCustomAngle()) return Double.NaN;
         Objective o = spec.objective;
         JumpConstraint.Mode mode = o.axis == JumpPhysicsInputs.Axis.X ? JumpConstraint.Mode.X : JumpConstraint.Mode.Z;
         boolean max = o.sense == Objective.Sense.MAX;
@@ -131,7 +132,7 @@ public final class Scoring {
         double[] gf = at.toGameFacings(yaws);
         ForwardPath path = model.forward(at, gf);
         if (JumpConstraintCompiler.compile(spec).maxViolation(gf, path) > feasTol) return Double.NaN;
-        return path.getPos(spec.objective.tick, spec.objective.axis);
+        return spec.objective.evaluate(path);
     }
 
     public static void adoptPinnedStart(JumpPhysicsInputs sc, double px, double pz) {
@@ -147,7 +148,7 @@ public final class Scoring {
         ForwardPath p = model.forward(sc, gf);
         JumpConstraintCompiler.Compiled compiled = JumpConstraintCompiler.compile(spec);
         double curViol = compiled.maxViolation(gf, p);
-        double curObj = p.getPos(spec.objective.tick, spec.objective.axis);
+        double curObj = spec.objective.evaluate(p);
         double[] d = translationDomain(sc, freeBox);
         boolean objX = spec.objective.axis == JumpPhysicsInputs.Axis.X;
         boolean objMax = spec.objective.sense == Objective.Sense.MAX;
@@ -194,7 +195,7 @@ public final class Scoring {
         ForwardPath p = model.forward(cand, gf);
         if (JumpConstraintCompiler.compile(spec).maxViolation(gf, p) > feasTol) return false;
         if (curViol <= feasTol) {
-            double obj = p.getPos(spec.objective.tick, spec.objective.axis);
+            double obj = spec.objective.evaluate(p);
             if (!(objMax ? obj > curObj : obj < curObj)) return false;
         }
         sc.startPos = new Vec3dCore(x, sc.startPos.y, z);

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/BoundPrunedRecovery.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/BoundPrunedRecovery.java
@@ -269,6 +269,7 @@ public final class BoundPrunedRecovery {
     }
 
     private static boolean isTargetWall(JumpConstraint c, JumpSpec spec, boolean max) {
+        if (spec.objective.isCustomAngle()) return false;
         JumpConstraint.Mode objMode = spec.objective.axis == JumpPhysicsInputs.Axis.X
                 ? JumpConstraint.Mode.X : JumpConstraint.Mode.Z;
         return c.mode == objMode && c.t1 == spec.objective.tick && c.t2 == null
@@ -301,7 +302,7 @@ public final class BoundPrunedRecovery {
         double[] gf = sc.toGameFacings(Angles.wrapAll(yawsAbs));
         ForwardPath path = exact.forward(sc, gf);
         if (compiled.maxViolation(gf, path) > 0.0) return Double.NaN;
-        double v = path.getPos(spec.objective.tick, spec.objective.axis);
+        double v = spec.objective.evaluate(path);
         return max ? v : -v;
     }
 
@@ -457,8 +458,23 @@ public final class BoundPrunedRecovery {
         CostateDualSolver.Result r = new CostateDualSolver(n, cx, cz, lin.mMagAll(), walls).solve(0.0, null);
         if (r == null) return null;
         boolean max = spec.objective.sense == Objective.Sense.MAX;
-        int axisIdx = spec.objective.axis == JumpPhysicsInputs.Axis.X ? 0 : 1;
-        double cp = lin.constPos(spec.objective.tick, axisIdx);
+        double cp;
+        if (spec.objective.isCustomAngle()) {
+            double rad = Math.toRadians(spec.objective.customYaw);
+            double dx = -Math.sin(rad);
+            double dz = Math.cos(rad);
+            if (spec.objective.isMotion()) {
+                int t = spec.objective.tick;
+                double c0 = lin.constPos(t, 0) - (t > 0 ? lin.constPos(t - 1, 0) : 0.0);
+                double c1 = lin.constPos(t, 1) - (t > 0 ? lin.constPos(t - 1, 1) : 0.0);
+                cp = dx * c0 + dz * c1;
+            } else {
+                cp = dx * lin.constPos(spec.objective.tick, 0) + dz * lin.constPos(spec.objective.tick, 1);
+            }
+        } else {
+            int axisIdx = spec.objective.axis == JumpPhysicsInputs.Axis.X ? 0 : 1;
+            cp = lin.constPos(spec.objective.tick, axisIdx);
+        }
         double bound = r.value + (max ? cp : -cp);
         return Double.isNaN(bound) ? null : bound;
     }
@@ -594,8 +610,23 @@ public final class BoundPrunedRecovery {
             this.cz = cz;
             this.mMag = lin.mMagAll();
             this.max = spec.objective.sense == Objective.Sense.MAX;
-            int axisIdx = spec.objective.axis == JumpPhysicsInputs.Axis.X ? 0 : 1;
-            double cp = lin.constPos(spec.objective.tick, axisIdx);
+            double cp;
+            if (spec.objective.isCustomAngle()) {
+                double rad = Math.toRadians(spec.objective.customYaw);
+                double dx = -Math.sin(rad);
+                double dz = Math.cos(rad);
+                if (spec.objective.isMotion()) {
+                    int t = spec.objective.tick;
+                    double c0 = lin.constPos(t, 0) - (t > 0 ? lin.constPos(t - 1, 0) : 0.0);
+                    double c1 = lin.constPos(t, 1) - (t > 0 ? lin.constPos(t - 1, 1) : 0.0);
+                    cp = dx * c0 + dz * c1;
+                } else {
+                    cp = dx * lin.constPos(spec.objective.tick, 0) + dz * lin.constPos(spec.objective.tick, 1);
+                }
+            } else {
+                int axisIdx = spec.objective.axis == JumpPhysicsInputs.Axis.X ? 0 : 1;
+                cp = lin.constPos(spec.objective.tick, axisIdx);
+            }
             this.normConst = max ? cp : -cp;
             this.canonical = canonical;
             this.baseWalls = baseWalls;
@@ -1187,7 +1218,7 @@ public final class BoundPrunedRecovery {
         }
 
         private double normObjective(ForwardPath path) {
-            double v = path.getPos(spec.objective.tick, spec.objective.axis);
+            double v = spec.objective.evaluate(path);
             return max ? v : -v;
         }
 

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/BucketAscentPolish.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/BucketAscentPolish.java
@@ -168,7 +168,7 @@ public final class BucketAscentPolish {
         ForwardPath pr = model.forward(scenario, gf);
         double viol = c.maxViolation(gf, pr);
         if (viol > FEAS_TOL) return Double.POSITIVE_INFINITY;
-        return sign * pr.getPos(obj.tick, obj.axis) + obj.smoothPenalty(scenario.startYaw, abs);
+        return sign * obj.evaluate(pr) + obj.smoothPenalty(scenario.startYaw, abs);
     }
 
     private static final class TailScorer {
@@ -210,7 +210,7 @@ public final class BucketAscentPolish {
             model.stepRange(scenario, gf, from, path);
             double viol = c.maxViolation(gf, path);
             if (viol > FEAS_TOL) return Double.POSITIVE_INFINITY;
-            return sign * path.getPos(obj.tick, obj.axis) + obj.smoothPenalty(startYaw, y);
+            return sign * obj.evaluate(path) + obj.smoothPenalty(startYaw, y);
         }
     }
 }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/ClosedFormSolve.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/ClosedFormSolve.java
@@ -283,7 +283,7 @@ public final class ClosedFormSolve {
     }
 
     private static double scanScore(ExactJumpModel exact, JumpSpec spec, JumpPhysicsInputs sc, double[] yaws) {
-        double o = exact.forward(sc, sc.toGameFacings(yaws)).getPos(spec.objective.tick, spec.objective.axis);
+        double o = spec.objective.evaluate(exact.forward(sc, sc.toGameFacings(yaws)));
         return spec.objective.scored(o, sc.startYaw, yaws);
     }
 
@@ -396,7 +396,7 @@ public final class ClosedFormSolve {
             }
             if (DEBUG) {
                 double[] gf = sc.toGameFacings(yaws);
-                double o = exact.forward(sc, gf).getPos(spec.objective.tick, spec.objective.axis);
+                double o = spec.objective.evaluate(exact.forward(sc, gf));
                 System.out.printf("  CLOSED margin=%.2e iters=%d pg=%.3e viol=%.2e obj=%.6f%n",
                         margin, solver.lastIters, solver.lastPgres, viol, o);
             }
@@ -447,8 +447,23 @@ public final class ClosedFormSolve {
         CostateDualSolver.Result r = new CostateDualSolver(lin.n, cx, cz, lin.mMagAll(), walls).solve(0.0, null);
         if (r == null) return Double.NaN;
         // r.value bounds max c·u with c MAX-normalized; fold the constant part back in (MIN is negated).
-        int axis = spec.objective.axis == JumpPhysicsInputs.Axis.X ? 0 : 1;
-        double constPos = lin.constPos(spec.objective.tick, axis);
+        double constPos;
+        if (spec.objective.isCustomAngle()) {
+            double rad = Math.toRadians(spec.objective.customYaw);
+            double dx = -Math.sin(rad);
+            double dz = Math.cos(rad);
+            if (spec.objective.isMotion()) {
+                int t = spec.objective.tick;
+                double c0 = lin.constPos(t, 0) - (t > 0 ? lin.constPos(t - 1, 0) : 0.0);
+                double c1 = lin.constPos(t, 1) - (t > 0 ? lin.constPos(t - 1, 1) : 0.0);
+                constPos = dx * c0 + dz * c1;
+            } else {
+                constPos = dx * lin.constPos(spec.objective.tick, 0) + dz * lin.constPos(spec.objective.tick, 1);
+            }
+        } else {
+            int axis = spec.objective.axis == JumpPhysicsInputs.Axis.X ? 0 : 1;
+            constPos = lin.constPos(spec.objective.tick, axis);
+        }
         return spec.objective.sense == Objective.Sense.MAX ? constPos + r.value : constPos - r.value;
     }
 

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/DeWiggle.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/DeWiggle.java
@@ -310,7 +310,7 @@ public final class DeWiggle {
     }
 
     private static double objAt(ForwardModel model, JumpPhysicsInputs sc, Objective obj, double[] y) {
-        return model.forward(sc, sc.toGameFacings(Angles.wrapAll(y))).getPos(obj.tick, obj.axis);
+        return obj.evaluate(model.forward(sc, sc.toGameFacings(Angles.wrapAll(y))));
     }
 
     private static double delta(double anchor, double[] y, int t) {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/FacingPrefold.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/FacingPrefold.java
@@ -337,7 +337,11 @@ public final class FacingPrefold {
             double gz = costateZ[v];
             if (gx * gx + gz * gz < 1.0e-18) {
                 boolean max = obj.sense == Objective.Sense.MAX;
-                if (obj.axis == JumpPhysicsInputs.Axis.X) {
+                if (obj.isCustomAngle()) {
+                    double rad = Math.toRadians(obj.customYaw);
+                    gx = (max ? 1.0 : -1.0) * -Math.sin(rad);
+                    gz = (max ? 1.0 : -1.0) * Math.cos(rad);
+                } else if (obj.axis == JumpPhysicsInputs.Axis.X) {
                     gx = max ? 1.0 : -1.0;
                     gz = 0.0;
                 } else {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/IlsPolish.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/IlsPolish.java
@@ -80,7 +80,7 @@ public final class IlsPolish {
                     }
                     if (progress != null) {
                         double[] rgf = sc.toGameFacings(Angles.wrapAll(best));
-                        progress.report(best, model.forward(sc, rgf).getPos(obj.tick, obj.axis), 0.0, true);
+                        progress.report(best, obj.evaluate(model.forward(sc, rgf)), 0.0, true);
                     }
                 }
             }
@@ -103,6 +103,6 @@ public final class IlsPolish {
         double[] gf = sc.toGameFacings(Angles.wrapAll(absWrapped));
         ForwardPath pr = model.forward(sc, gf);
         if (c.maxViolation(gf, pr) > FEAS_TOL) return Double.POSITIVE_INFINITY;
-        return sign * pr.getPos(obj.tick, obj.axis) + obj.smoothPenalty(sc.startYaw, absWrapped);
+        return sign * obj.evaluate(pr) + obj.smoothPenalty(sc.startYaw, absWrapped);
     }
 }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/JumpLinearModel.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/JumpLinearModel.java
@@ -211,11 +211,30 @@ public final class JumpLinearModel {
         int objTick = obj.tick;
         double dx, dz;
         boolean max = obj.sense == Objective.Sense.MAX;
-        if (obj.axis == JumpPhysicsInputs.Axis.X) { dx = max ? 1.0 : -1.0; dz = 0.0; }
-        else { dx = 0.0; dz = max ? 1.0 : -1.0; }
-        for (int t = 0; t < n; t++) {
-            cx[t] = coefAxis(0, t, objTick) * dx;
-            cz[t] = coefAxis(1, t, objTick) * dz;
+        if (obj.isCustomAngle()) {
+            double rad = Math.toRadians(obj.customYaw);
+            dx = (max ? 1.0 : -1.0) * -Math.sin(rad);
+            dz = (max ? 1.0 : -1.0) * Math.cos(rad);
+        } else if (obj.axis == JumpPhysicsInputs.Axis.X) {
+            dx = max ? 1.0 : -1.0;
+            dz = 0.0;
+        } else {
+            dx = 0.0;
+            dz = max ? 1.0 : -1.0;
+        }
+
+        if (obj.isMotion()) {
+            for (int t = 0; t < n; t++) {
+                double k0 = coefAxis(0, t, objTick) - (objTick > 0 ? coefAxis(0, t, objTick - 1) : 0.0);
+                double k1 = coefAxis(1, t, objTick) - (objTick > 0 ? coefAxis(1, t, objTick - 1) : 0.0);
+                cx[t] = k0 * dx;
+                cz[t] = k1 * dz;
+            }
+        } else {
+            for (int t = 0; t < n; t++) {
+                cx[t] = coefAxis(0, t, objTick) * dx;
+                cz[t] = coefAxis(1, t, objTick) * dz;
+            }
         }
     }
 
@@ -378,8 +397,14 @@ public final class JumpLinearModel {
             double x = gx[t];
             double z = gz[t];
             if (x * x + z * z < 1.0e-18) {
-                x = axisX ? (max ? 1.0 : -1.0) : 0.0;
-                z = axisX ? 0.0 : (max ? 1.0 : -1.0);
+                if (obj.isCustomAngle()) {
+                    double rad = Math.toRadians(obj.customYaw);
+                    x = (max ? 1.0 : -1.0) * -Math.sin(rad);
+                    z = (max ? 1.0 : -1.0) * Math.cos(rad);
+                } else {
+                    x = axisX ? (max ? 1.0 : -1.0) : 0.0;
+                    z = axisX ? 0.0 : (max ? 1.0 : -1.0);
+                }
             }
             yaws[t] = recoverYawDeg(t, x, z);
         }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/Objective.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/Objective.java
@@ -5,17 +5,32 @@ package de.legoshi.parkourcalc.core.anglesolver.solver;
 public final class Objective {
 
     public enum Sense { MAX, MIN }
+    public enum Type { POSITION, MOTION }
 
     public final JumpPhysicsInputs.Axis axis;
     public final Sense sense;
     public final int tick;
     public final double smoothLambda;
+    public final Double customYaw;
+    public final Type type;
 
     public Objective(JumpPhysicsInputs.Axis axis, Sense sense, int tick) {
         this(axis, sense, tick, 0.0);
     }
 
     public Objective(JumpPhysicsInputs.Axis axis, Sense sense, int tick, double smoothLambda) {
+        this(axis, sense, tick, smoothLambda, null, Type.POSITION);
+    }
+
+    public Objective(double customYaw, int tick, double smoothLambda) {
+        this(customYaw, Type.POSITION, tick, smoothLambda);
+    }
+
+    public Objective(double customYaw, Type type, int tick, double smoothLambda) {
+        this(JumpPhysicsInputs.Axis.X, Sense.MAX, tick, smoothLambda, customYaw, type);
+    }
+
+    public Objective(JumpPhysicsInputs.Axis axis, Sense sense, int tick, double smoothLambda, Double customYaw, Type type) {
         if (axis == JumpPhysicsInputs.Axis.Y) {
             throw new IllegalArgumentException("Y objective unsupported; use X or Z");
         }
@@ -23,11 +38,38 @@ public final class Objective {
         this.sense = sense;
         this.tick = tick;
         this.smoothLambda = smoothLambda;
+        this.customYaw = customYaw;
+        this.type = type != null ? type : Type.POSITION;
+    }
+
+    public boolean isCustomAngle() {
+        return customYaw != null;
+    }
+
+    public boolean isMotion() {
+        return type == Type.MOTION;
+    }
+
+    public double evaluate(ForwardPath path) {
+        if (customYaw != null) {
+            double rad = Math.toRadians(customYaw);
+            double dx = -Math.sin(rad);
+            double dz = Math.cos(rad);
+            if (type == Type.MOTION) {
+                double vx = tick > 0 ? path.posX[tick] - path.posX[tick - 1] : path.posX[tick];
+                double vz = tick > 0 ? path.posZ[tick] - path.posZ[tick - 1] : path.posZ[tick];
+                return dx * vx + dz * vz;
+            } else {
+                return dx * path.posX[tick] + dz * path.posZ[tick];
+            }
+        }
+        return path.getPos(tick, axis);
     }
 
     public double smoothPenalty(double anchorYaw, double[] yawsAbs) {
         if (smoothLambda <= 0.0 || yawsAbs == null || yawsAbs.length < 2) return 0.0;
-        return smoothLambda * Angles.turnCost(anchorYaw, yawsAbs);
+        double lambda = (isCustomAngle() && isMotion()) ? smoothLambda * 0.05 : smoothLambda;
+        return lambda * Angles.turnCost(anchorYaw, yawsAbs);
     }
 
     public double scored(double raw, double anchorYaw, double[] yawsAbs) {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/SlpSolve.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/SlpSolve.java
@@ -316,10 +316,10 @@ public final class SlpSolve {
         ForwardPath path = exact.forward(sc, gf);
         double finalViol = compiled.maxViolation(gf, path);
         if (DEBUG) System.out.printf("  SLP viol=%.3e obj=%.7f lps=%d (%.1f ms)%n", finalViol,
-                path.getPos(spec.objective.tick, spec.objective.axis), lpCalls, (System.nanoTime() - t0) / 1e6);
+                spec.objective.evaluate(path), lpCalls, (System.nanoTime() - t0) / 1e6);
         if (SolverTrace.on()) {
             SolverTrace.log("SLP", "end viol=%.3e obj=%.9f lps=%d ms=%.1f %s", finalViol,
-                    path.getPos(spec.objective.tick, spec.objective.axis), lpCalls,
+                    spec.objective.evaluate(path), lpCalls,
                     (System.nanoTime() - t0) / 1e6, finalViol <= feasTol ? "feasible" : (bestEffort ? "best effort" : "null"));
         }
         if (finalViol <= feasTol) return yaws;
@@ -361,7 +361,7 @@ public final class SlpSolve {
 
     /** Objective normalized so bigger is always better (MIN is negated), read off the byte-exact path. */
     private static double normObjective(ForwardPath path, Objective obj, boolean max) {
-        double v = path.getPos(obj.tick, obj.axis);
+        double v = obj.evaluate(path);
         return max ? v : -v;
     }
 }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/TrendFilterSmooth.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/TrendFilterSmooth.java
@@ -30,7 +30,7 @@ public final class TrendFilterSmooth {
         if (comp.maxViolation(seedGf, exact.forward(sc, seedGf)) > FEAS_TOL) return seedAbsWrapped;
 
         boolean max = spec.objective.sense == Objective.Sense.MAX;
-        double reference = exact.forward(sc, seedGf).getPos(spec.objective.tick, spec.objective.axis);
+        double reference = spec.objective.evaluate(exact.forward(sc, seedGf));
         JumpSpec guarded = guard(sc, spec, max, reference, giveBack);
         JumpConstraintCompiler.Compiled guardedComp = JumpConstraintCompiler.compile(guarded);
         boolean[] frozen = frozenPins(sc, spec);
@@ -70,7 +70,7 @@ public final class TrendFilterSmooth {
                 if (cand == null) continue;
                 double[] cgf = sc.toGameFacings(cand);
                 if (comp.maxViolation(cgf, exact.forward(sc, cgf)) > FEAS_TOL) continue;
-                double obj = exact.forward(sc, cgf).getPos(spec.objective.tick, spec.objective.axis);
+                double obj = spec.objective.evaluate(exact.forward(sc, cgf));
                 if (max ? obj < reference - giveBack : obj > reference + giveBack) continue;
                 int rev = Angles.reversals(anchor, cand, Angles.REVERSAL_FLOOR_DEG);
                 double jk = jerk(anchor, cand);
@@ -89,6 +89,7 @@ public final class TrendFilterSmooth {
     private static final int MAX_PASSES = 6;
 
     private static JumpSpec guard(JumpPhysicsInputs sc, JumpSpec spec, boolean max, double reference, double giveBack) {
+        if (spec.objective.isCustomAngle()) return spec;
         JumpConstraint.Mode axisMode = spec.objective.axis == JumpPhysicsInputs.Axis.X ? JumpConstraint.Mode.X
                 : spec.objective.axis == JumpPhysicsInputs.Axis.Z ? JumpConstraint.Mode.Z : null;
         if (axisMode == null) return spec;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveFile.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveFile.java
@@ -61,6 +61,9 @@ public final class SaveFile {
         public int landingTick;
         public String axis;
         public String goal;
+        public Boolean customAngle;
+        public Double customAngleDeg;
+        public String customAngleType;
         public String effort;                            // absent in old files -> FAST
         public Boolean stopOnFeasible;                   // absent in old files -> false
         public Boolean legalMode;                        // absent in old files -> false

--- a/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveIO.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveIO.java
@@ -188,6 +188,9 @@ public final class SaveIO {
         state.setLandingTick(a.landingTick);
         state.setAxis(parseEnum(AngleSolverState.Axis.class, a.axis, AngleSolverState.Axis.X));
         state.setGoal(parseEnum(AngleSolverState.Goal.class, a.goal, AngleSolverState.Goal.MAX));
+        state.setCustomAngle(a.customAngle != null && a.customAngle);
+        if (a.customAngleDeg != null) state.setCustomAngleDeg(a.customAngleDeg);
+        state.setCustomAngleType(parseEnum(AngleSolverState.CustomAngleType.class, a.customAngleType, AngleSolverState.CustomAngleType.POSITION));
         state.setEffort(parseEnum(AngleSolverState.Effort.class, a.effort, AngleSolverState.Effort.FAST));
         state.setStopOnFeasible(a.stopOnFeasible != null && a.stopOnFeasible);
         state.setLegalMode(a.legalMode != null && a.legalMode);
@@ -526,6 +529,9 @@ public final class SaveIO {
         a.landingTick = s.getLandingTick();
         a.axis = s.getAxis().name();
         a.goal = s.getGoal().name();
+        a.customAngle = s.isCustomAngle();
+        a.customAngleDeg = s.getCustomAngleDeg();
+        a.customAngleType = s.getCustomAngleType().name();
         a.effort = s.getEffort().name();
         a.stopOnFeasible = s.isStopOnFeasible();
         a.legalMode = s.isLegalMode();

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverWindow.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverWindow.java
@@ -13,6 +13,7 @@ import de.legoshi.parkourcalc.core.anglesolver.graph.GraphPresetIO;
 import de.legoshi.parkourcalc.core.anglesolver.graph.SolverGraph;
 import de.legoshi.parkourcalc.core.anglesolver.runticks.RunTicksControls;
 import de.legoshi.parkourcalc.core.anglesolver.runticks.RunTicksSettings;
+import de.legoshi.parkourcalc.core.anglesolver.solver.Angles;
 import de.legoshi.parkourcalc.core.imgui.RenderInterface;
 import de.legoshi.parkourcalc.core.save.FileSystemSaveStore;
 import de.legoshi.parkourcalc.core.save.Result;
@@ -65,7 +66,7 @@ public final class AngleSolverWindow implements RenderInterface {
     private static final String LEGACY_PRESET_ITEM = "Legacy budget";
 
     private static final String[] FORM_LABELS =
-            {"Start tick", "Goal tick", "Axis", "Goal", "Inputs", "Sprint", "Slipperiness", "Potion",
+            {"Start tick", "Goal tick", "Axis", "Goal", "Target angle", "Inputs", "Sprint", "Slipperiness", "Potion",
              "Enabled", "Max ticks", "Step timeout", "Step growth", "Safety factor", "Safety margin"};
 
     /** Unscaled; lines the details table up under the toggle title and sets it off from the solved values. */
@@ -103,6 +104,8 @@ public final class AngleSolverWindow implements RenderInterface {
     private final int[] optimizeSecondsBuf = new int[1];
     private final ImInt presetBuf = new ImInt();
     private final ImString presetNameInput = new ImString(64);
+    private final ImString customAngleBuf = new ImString(32);
+    private double lastSyncedCustomAngle = Double.NaN;
     private final String[] slipItems;
     private String[] presetNames;
     private String presetError;
@@ -119,6 +122,11 @@ public final class AngleSolverWindow implements RenderInterface {
     private boolean runTicksExpanded;
     private int doseToRemove;
     private RunTicksControls runTicks = RunTicksControls.NONE;
+    private java.util.function.DoubleSupplier playerYawSupplier = () -> 0.0;
+
+    public void setPlayerYawSupplier(java.util.function.DoubleSupplier supplier) {
+        this.playerYawSupplier = supplier != null ? supplier : () -> 0.0;
+    }
 
     public void setRunTicksControls(RunTicksControls controls) {
         this.runTicks = controls != null ? controls : RunTicksControls.NONE;
@@ -200,10 +208,69 @@ public final class AngleSolverWindow implements RenderInterface {
 
         solveForExpanded = sectionToggle("Solve for", "solvefor", solveForExpanded, scale);
         if (solveForExpanded) {
-            int ax = segmentedRow("Axis", "axis", AXES, state.getAxis().ordinal(), labelW);
-            if (ax >= 0) state.setAxis(AngleSolverState.Axis.values()[ax]);
-            int gl = segmentedRow("Goal", "goal", GOALS, state.getGoal().ordinal(), labelW);
-            if (gl >= 0) state.setGoal(AngleSolverState.Goal.values()[gl]);
+            if (!state.isCustomAngle()) {
+                int ax = segmentedRow("Axis", "axis", AXES, state.getAxis().ordinal(), labelW);
+                if (ax >= 0) state.setAxis(AngleSolverState.Axis.values()[ax]);
+                int gl = segmentedRow("Goal", "goal", GOALS, state.getGoal().ordinal(), labelW);
+                if (gl >= 0) state.setGoal(AngleSolverState.Goal.values()[gl]);
+            } else {
+                Controls.pushInputFrameHeight();
+                ImGui.beginGroup();
+                SolverWidgets.rowLabel("Target angle", labelW);
+
+                float btnW = ImGui.getFrameHeight();
+                float spacing = ImGui.getStyle().getItemInnerSpacing().x;
+                float segW = 96f * scale;
+                float inputW = Math.max(30f, ImGui.getContentRegionAvail().x - btnW - segW - 2f * spacing);
+
+                if (state.getCustomAngleDeg() != lastSyncedCustomAngle && !ImGui.isItemActive()) {
+                    customAngleBuf.set(String.format(Locale.ROOT, "%.4f", state.getCustomAngleDeg())
+                            .replaceAll("0+$", "").replaceAll("\\.$", ""));
+                    lastSyncedCustomAngle = state.getCustomAngleDeg();
+                }
+
+                ImGui.setNextItemWidth(inputW);
+                if (ImGui.inputText("##customAngleInput", customAngleBuf, imgui.flag.ImGuiInputTextFlags.CharsDecimal)) {
+                    try {
+                        String s = customAngleBuf.get().trim();
+                        if (!s.isEmpty() && !s.equals("-") && !s.equals(".")) {
+                            double val = Double.parseDouble(s);
+                            state.setCustomAngleDeg(val);
+                            lastSyncedCustomAngle = state.getCustomAngleDeg();
+                        }
+                    } catch (NumberFormatException ignored) {}
+                }
+                TooltipUtil.onHover("Target facing angle in degrees to optimize towards (e.g. 45.0° for diagonal).");
+
+                ImGui.sameLine(0, spacing);
+                if (ImGui.button("P##setPlayerFacing", btnW, btnW)) {
+                    double yaw = Angles.wrap(playerYawSupplier.getAsDouble());
+                    state.setCustomAngleDeg(yaw);
+                    customAngleBuf.set(String.format(Locale.ROOT, "%.4f", yaw)
+                            .replaceAll("0+$", "").replaceAll("\\.$", ""));
+                    lastSyncedCustomAngle = state.getCustomAngleDeg();
+                }
+                TooltipUtil.onHover("Set target angle to player's current facing yaw.");
+
+                ImGui.sameLine(0, spacing);
+                String[] typeItems = {"Pos", "Mot"};
+                String[] typeTooltips = {
+                        "Position: Maximize horizontal displacement/distance along the target angle.",
+                        "Motion: Maximize horizontal velocity/motion vector along the target angle at the goal tick."
+                };
+                int typePick = SolverWidgets.segmented("##customType", typeItems, typeTooltips, state.getCustomAngleType().ordinal(), segW);
+                if (typePick >= 0) state.setCustomAngleType(AngleSolverState.CustomAngleType.values()[typePick]);
+
+                ImGui.endGroup();
+                Controls.popInputFrameHeight();
+            }
+
+            ImGui.spacing();
+            if (Controls.checkbox("Custom angle##customAngleToggle", state.isCustomAngle())) {
+                state.setCustomAngle(!state.isCustomAngle());
+            }
+            TooltipUtil.onHover("Optimize trajectory distance or motion towards a custom facing angle instead of a fixed X/Z axis.\n"
+                    + "Using 'Optimize' effort is recommended for maximum reach.");
 
             ImGui.spacing();
             boolean fastTier = state.getEffort() == AngleSolverState.Effort.FAST;
@@ -949,9 +1016,16 @@ public final class AngleSolverWindow implements RenderInterface {
             rows.add(new SolveResult.Detail("Finished", r.getFinishedAt()));
         }
         if (r.hasObjective()) {
-            String goal = state.getGoal() == AngleSolverState.Goal.MAX ? "max" : "min";
-            rows.add(new SolveResult.Detail("Objective",
-                    goal + " " + state.getAxis().name() + " = " + ConstraintText.fixedStat(r.getObjectiveValue())));
+            if (state.isCustomAngle()) {
+                String mode = state.getCustomAngleType() == AngleSolverState.CustomAngleType.MOTION ? "mot" : "pos";
+                rows.add(new SolveResult.Detail("Objective",
+                        String.format(Locale.ROOT, "%s yaw %.1f° = ", mode, state.getCustomAngleDeg())
+                                + ConstraintText.fixedStat(r.getObjectiveValue())));
+            } else {
+                String goal = state.getGoal() == AngleSolverState.Goal.MAX ? "max" : "min";
+                rows.add(new SolveResult.Detail("Objective",
+                        goal + " " + state.getAxis().name() + " = " + ConstraintText.fixedStat(r.getObjectiveValue())));
+            }
         }
         return rows;
     }
@@ -1026,7 +1100,7 @@ public final class AngleSolverWindow implements RenderInterface {
         }
         double v = panel.getObjectiveValue();
         if (!Double.isNaN(improveTrackValue) && v != improveTrackValue) {
-            boolean max = state.getGoal() == AngleSolverState.Goal.MAX;
+            boolean max = state.isCustomAngle() || state.getGoal() == AngleSolverState.Goal.MAX;
             double delta = v - improveTrackValue;
             if (max ? delta > 0 : delta < 0) {
                 improveFlashStart = ImGui.getTime();

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverWindow.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverWindow.java
@@ -272,7 +272,6 @@ public final class AngleSolverWindow implements RenderInterface {
             TooltipUtil.onHover("Optimize trajectory distance or motion towards a custom facing angle instead of a fixed X/Z axis.\n"
                     + "Using 'Optimize' effort is recommended for maximum reach.");
 
-            ImGui.spacing();
             boolean fastTier = state.getEffort() == AngleSolverState.Effort.FAST;
             boolean optimizeTier = state.getEffort() == AngleSolverState.Effort.THOROUGH;
             boolean forced = fastTier || optimizeTier;


### PR DESCRIPTION
Closes #194

### Summary of Changes

- **Custom Angle Objective:** Allows optimizing jump trajectories directly towards any custom facing angle (e.g. 45.0° for diagonal jumps) instead of being restricted to fixed 1D X/Z axes.
- **Position & Motion (Velocity) Modes:** Added a mode selector (`[Pos | Mot]`) next to the target angle to choose between maximizing distance displacement along the angle or maximizing the velocity/motion vector at the goal tick.
- **Dynamic UI & Player Yaw Button:** 
  - Checkbox in the Angle Solver window toggles between standard Axis/Goal selectors and the target angle controls.
  - Added a `[ P ]` button to instantly capture the player's current facing yaw with full precision.