### PR TITLE
fix(solver): close free-start joint near misses with the wrap-window ILS

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/nodes/FreeStartImproveNode.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/nodes/FreeStartImproveNode.java
@@ -40,6 +40,7 @@ public final class FreeStartImproveNode implements NodeRuntime {
         cfg.slpPhase1Calls = params.getInt("fsSlpPhase1Calls");
         cfg.slpTotalCalls = params.getInt("fsSlpTotalCalls");
         cfg.jointMargins = ParamParse.doubles(params.getString("fsJointMargins"), cfg.jointMargins);
+        cfg.jointWrapClose = false;
     }
 
     @Override

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/FreeStartSolve.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/FreeStartSolve.java
@@ -24,9 +24,13 @@ public final class FreeStartSolve {
         public double jointPatternViolGate = 0.25;
         public double jointMarginMax = 0.25;
         public int jointBisectIters = 8;
+        public double jointWrapCloseGate = 0.05;
+        public boolean jointWrapClose = true;
     }
 
     private static final double[] JOINT_RECOVERY_FRACTIONS = {0.5, 0.25, 0.75, 0.0};
+    private static final long JOINT_WRAP_CLOSE_NANOS = 6_000_000_000L;
+    private static final double JOINT_WRAP_REPAIR_GATE = 1.0e-3;
 
     private static final class JointBest {
         double viol = Double.POSITIVE_INFINITY;
@@ -203,8 +207,49 @@ public final class FreeStartSolve {
                     }
                     return new Result(repaired, rs[0], rs[1], true);
                 }
+                if (cfg.jointWrapClose && overall.viol <= cfg.jointWrapCloseGate) {
+                    Result wr = jointWrapClose(exact, base, spec, box, overall.yaws, rs, feasTol, cancel);
+                    if (wr != null) return wr;
+                }
                 return new Result(Angles.wrapAll(overall.yaws.clone()), rs[0], rs[1], false);
             }
+        }
+        return null;
+    }
+
+    private static Result jointWrapClose(ExactJumpModel exact, JumpPhysicsInputs base, JumpSpec spec, StartBox box,
+                                         double[] yaws, double[] rs, double feasTol, AtomicBoolean cancel) {
+        JumpSpec atSpec = specAtStart(base, spec, rs[0], rs[1]);
+        JumpPhysicsInputs atSc = atSpec.asScenario();
+        double[] gf = atSc.toGameFacings(Angles.wrapAll(yaws.clone()));
+        double[] dom = {box.pxLo - rs[0], box.pxHi - rs[0], box.pzLo - rs[1], box.pzHi - rs[1]};
+        WrapWindowIls.Config wcfg = new WrapWindowIls.Config();
+        wcfg.roundCap = 1;
+        wcfg.evalCap = 4_000_000;
+        WrapWindowIls.Result w = WrapWindowIls.polish(exact, atSpec, gf, dom, wcfg,
+                System.nanoTime() + JOINT_WRAP_CLOSE_NANOS, cancel);
+        if (w == null || w.viol > JOINT_WRAP_REPAIR_GATE) {
+            if (SolverTrace.on()) {
+                SolverTrace.log("FREE", "joint wrap close miss viol=%s",
+                        w == null ? "-" : String.format(java.util.Locale.ROOT, "%.3e", w.viol));
+            }
+            return null;
+        }
+        double[] d = bestTranslate(atSpec, w.gf, exact.forward(atSc, w.gf), box);
+        double px = clamp(rs[0] + d[0], box.pxLo, box.pxHi);
+        double pz = clamp(rs[1] + d[1], box.pzLo, box.pzHi);
+        double v = violationAt(exact, spec, w.gf, px, pz);
+        if (SolverTrace.on()) {
+            SolverTrace.log("FREE", "joint wrap close ils=%.3e reaccum=%.3e start=(%.5f,%.5f)", w.viol, v, px, pz);
+        }
+        if (v <= feasTol) return new Result(Angles.wrapAll(w.gf.clone()), px, pz, true);
+        double[] repaired = LatticeRepair.repair(exact, specAtStart(base, spec, px, pz),
+                Angles.wrapAll(w.gf.clone()), feasTol, cancel);
+        if (repaired != null && violationAt(exact, spec, repaired, px, pz) <= feasTol) {
+            if (SolverTrace.on()) {
+                SolverTrace.log("FREE", "joint wrap close certified by lattice repair (%.5f,%.5f)", px, pz);
+            }
+            return new Result(repaired, px, pz, true);
         }
         return null;
     }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/LongRunSolver.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/LongRunSolver.java
@@ -3,7 +3,9 @@ package de.legoshi.parkourcalc.core.anglesolver.solver;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /** From-scratch solver for long multi-jump spans: the post-failure fallback for runs the closed-form dual
@@ -127,12 +129,13 @@ public final class LongRunSolver {
         if (jumps < 1) return null;
 
         double[] chosen = new double[2];
+        Map<Integer, Object> retryCache = new HashMap<>();
         for (int commit : cfg.commitLadder) {
             if (cancel != null && cancel.get()) return null;
             chosen[0] = Double.NaN;
             chosen[1] = Double.NaN;
             double[] gf = runHorizon(exact, sc, spec, bounds, jumps, commit, cfg.windowLadder, cancel,
-                    freeBox, chosen);
+                    freeBox, chosen, retryCache);
             if (gf == null || Double.isNaN(chosen[0])) continue;
             JumpPhysicsInputs at = FreeStartSolve.copyWithStart(sc, chosen[0], chosen[1]);
             double[] replay = at.toGameFacings(Angles.wrapAll(gf));
@@ -153,7 +156,7 @@ public final class LongRunSolver {
 
         for (int commit : cfg.commitLadder) {
             if (cancel != null && cancel.get()) return null;
-            double[] gf = runHorizon(exact, sc, spec, bounds, jumps, commit, cfg.windowLadder, cancel, null, null);
+            double[] gf = runHorizon(exact, sc, spec, bounds, jumps, commit, cfg.windowLadder, cancel, null, null, null);
             if (gf == null) continue;
             // Certify the chain Apply will actually realize, not the window-chained facings themselves:
             // the plan stores the wrapped facings and the game re-accumulates float deltas from them,
@@ -171,9 +174,11 @@ public final class LongRunSolver {
 
     /** One full receding-horizon sweep committing {@code commitJumps} jumps per window. Returns the chained
      *  game facings, or {@code null} if it gets stuck (no window solvable from some seam). */
+    private static final Object FREE_RETRY_MISS = new Object();
+
     private static double[] runHorizon(ExactJumpModel exact, JumpPhysicsInputs sc, JumpSpec spec, int[] bounds,
                                        int jumps, int commitJumps, int[] windowLadder, AtomicBoolean cancel,
-                                       StartBox freeBox, double[] chosenStart) {
+                                       StartBox freeBox, double[] chosenStart, Map<Integer, Object> retryCache) {
         int n = sc.numTicks;
         double[] gf = new double[n];
         Vec3dCore seedPos = sc.startPos, seedVel = sc.initialVelocity;
@@ -198,21 +203,27 @@ public final class LongRunSolver {
                         : new Objective(JumpPhysicsInputs.Axis.Z, Objective.Sense.MAX, c - a); // lead-in: any feasible
                 double[] yaws = solveWindow(exact, win, cons, obj, last, cancel);
                 if (yaws == null && i == 0 && freeBox != null) {
-                    JumpPhysicsInputs freeSc = FreeStartSolve.copyWithStart(sc, seedPos.x, seedPos.z);
-                    freeSc.startBox = new StartBox(seedPos.x, seedPos.z, seedVel.x, seedVel.z,
-                            freeBox.pxLo, freeBox.pxHi, freeBox.pzLo, freeBox.pzHi,
-                            seedVel.x, seedVel.x, seedVel.z, seedVel.z);
-                    List<JumpConstraint> upTo = new ArrayList<>();
-                    for (JumpConstraint jc : spec.constraints) {
-                        if (jc.t1 <= c && (jc.t2 == null || jc.t2 <= c)) upTo.add(jc);
-                    }
-                    Objective freeObj = last ? spec.objective
-                            : new Objective(JumpPhysicsInputs.Axis.Z, Objective.Sense.MAX, c);
-                    FreeStartSolve.Result fr = FreeStartSolve.solveJoint(
-                            exact, new JumpSpec(freeSc, upTo, freeObj), 0.0, cancel);
-                    if (SolverTrace.on()) {
-                        SolverTrace.log("FREE", "window free retry we=%d cons=%d -> %s",
-                                we, upTo.size(), fr != null && fr.feasible ? "solved" : "miss");
+                    Object cached = retryCache.get(we);
+                    FreeStartSolve.Result fr;
+                    if (cached != null) {
+                        fr = cached == FREE_RETRY_MISS ? null : (FreeStartSolve.Result) cached;
+                    } else {
+                        JumpPhysicsInputs freeSc = FreeStartSolve.copyWithStart(sc, seedPos.x, seedPos.z);
+                        freeSc.startBox = new StartBox(seedPos.x, seedPos.z, seedVel.x, seedVel.z,
+                                freeBox.pxLo, freeBox.pxHi, freeBox.pzLo, freeBox.pzHi,
+                                seedVel.x, seedVel.x, seedVel.z, seedVel.z);
+                        List<JumpConstraint> upTo = new ArrayList<>();
+                        for (JumpConstraint jc : spec.constraints) {
+                            if (jc.t1 <= c && (jc.t2 == null || jc.t2 <= c)) upTo.add(jc);
+                        }
+                        Objective freeObj = last ? spec.objective
+                                : new Objective(JumpPhysicsInputs.Axis.Z, Objective.Sense.MAX, c);
+                        fr = FreeStartSolve.solveJoint(exact, new JumpSpec(freeSc, upTo, freeObj), 0.0, cancel);
+                        retryCache.put(we, fr == null ? FREE_RETRY_MISS : fr);
+                        if (SolverTrace.on()) {
+                            SolverTrace.log("FREE", "window free retry we=%d cons=%d -> %s",
+                                    we, upTo.size(), fr != null && fr.feasible ? "solved" : "miss");
+                        }
                     }
                     if (fr != null && fr.feasible) {
                         chosenStart[0] = fr.startX;


### PR DESCRIPTION
Fixes #369. First of the three CMA-retirement PRs: makes gh283-j925-farseed, a reported jump, solve without CMA-ES.

## Root cause

The joint arc ladder gets remarkably close on the farseed class: its recovered start lands within 7e-4 blocks of the certified solution with a 1.585e-4 span-conflict floor (translation-conflicting X windows, the same class as j718's floor in #366). But the near miss died inside the rescue with no deterministic closer: `WrapWindowIls`, which demonstrably closes this class, was wired only as the THOROUGH `wrapIls` node polishing the engine incumbent, which the discarded near miss never becomes. Only the CMA near-miss race ever saw it.

## Changes

- `solveJointBest` tail: when the joint near miss is small (viol <= 0.05), run a bounded `WrapWindowIls.polish` at the recovered start with the box translation domain (one round, 4M evals, 6 s cap). The ILS result is raw-facing-exact but float32 re-accumulation shifts it by ~7.5e-5, so the residual is closed with `LatticeRepair` and the result certifies under the standard evaluation; no yaw-lock plumbing needed.
- Placement: the close is enabled only through the default config, i.e. the receding-horizon window free retry, where it wins earliest. `FreeStartImproveNode` disables it for both of its variants: the rescue's attempt duplicated the retry's, and the improve pass runs on an already-feasible incumbent where a feasibility closer is waste.
- `LongRunSolver.solveFree` memoizes the window-0 free retry per window extent across commit-ladder rounds (the result depends only on the extent), eliminating duplicate full arc-ladder runs for every free-start solve. j716 was the canary: without the memo and placement discipline, failed close attempts dragged it from 16 s to 35 s; with them it sits at 20.6 s.

## Results

- gh283-j925-farseed: solves with `SolveCore.optimize` disabled entirely (15.9 s FAST). With CMA present: 13.0 s, faster than the old race-carried 15.3 s.
- CMA-kill audit: ProblemsTest failures 4 -> 3 (gh313-j121-dfneo, loopmm-tight-t39, nix-full-t1); both hpk sweeps 52/52 CMA-free.
- Shifted sweep 52/52 with zero losses on the normal build; `:core:check` and full `:core:test -PslowTests` green; budgets hold (farseed 13.0 s of 20 s, nix-full-t1 81.9 s of 240 s).

Follow-ups in this train: the dF scope cut (dF = 0 only, per ruling) and the CMA-ES removal itself.
