### PR TITLE
feat(solver): restrict dF constraints to dF = 0

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/Constraint.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/Constraint.java
@@ -76,6 +76,10 @@ public final class Constraint {
         this.field = next;
         if (next != Field.X && next != Field.Z) refTick = null;
         if (next != Field.DX) vsDz = false;
+        if (next == Field.DF) {
+            op = Op.EQ;
+            value = 0.0;
+        }
     }
 
     public Integer getRefTick() {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/nodes/FreeStartImproveNode.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/nodes/FreeStartImproveNode.java
@@ -40,6 +40,7 @@ public final class FreeStartImproveNode implements NodeRuntime {
         cfg.slpPhase1Calls = params.getInt("fsSlpPhase1Calls");
         cfg.slpTotalCalls = params.getInt("fsSlpTotalCalls");
         cfg.jointMargins = ParamParse.doubles(params.getString("fsJointMargins"), cfg.jointMargins);
+        cfg.jointWrapClose = false;
     }
 
     @Override

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/FreeStartSolve.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/FreeStartSolve.java
@@ -24,9 +24,13 @@ public final class FreeStartSolve {
         public double jointPatternViolGate = 0.25;
         public double jointMarginMax = 0.25;
         public int jointBisectIters = 8;
+        public double jointWrapCloseGate = 0.05;
+        public boolean jointWrapClose = true;
     }
 
     private static final double[] JOINT_RECOVERY_FRACTIONS = {0.5, 0.25, 0.75, 0.0};
+    private static final long JOINT_WRAP_CLOSE_NANOS = 6_000_000_000L;
+    private static final double JOINT_WRAP_REPAIR_GATE = 1.0e-3;
 
     private static final class JointBest {
         double viol = Double.POSITIVE_INFINITY;
@@ -203,8 +207,49 @@ public final class FreeStartSolve {
                     }
                     return new Result(repaired, rs[0], rs[1], true);
                 }
+                if (cfg.jointWrapClose && overall.viol <= cfg.jointWrapCloseGate) {
+                    Result wr = jointWrapClose(exact, base, spec, box, overall.yaws, rs, feasTol, cancel);
+                    if (wr != null) return wr;
+                }
                 return new Result(Angles.wrapAll(overall.yaws.clone()), rs[0], rs[1], false);
             }
+        }
+        return null;
+    }
+
+    private static Result jointWrapClose(ExactJumpModel exact, JumpPhysicsInputs base, JumpSpec spec, StartBox box,
+                                         double[] yaws, double[] rs, double feasTol, AtomicBoolean cancel) {
+        JumpSpec atSpec = specAtStart(base, spec, rs[0], rs[1]);
+        JumpPhysicsInputs atSc = atSpec.asScenario();
+        double[] gf = atSc.toGameFacings(Angles.wrapAll(yaws.clone()));
+        double[] dom = {box.pxLo - rs[0], box.pxHi - rs[0], box.pzLo - rs[1], box.pzHi - rs[1]};
+        WrapWindowIls.Config wcfg = new WrapWindowIls.Config();
+        wcfg.roundCap = 1;
+        wcfg.evalCap = 4_000_000;
+        WrapWindowIls.Result w = WrapWindowIls.polish(exact, atSpec, gf, dom, wcfg,
+                System.nanoTime() + JOINT_WRAP_CLOSE_NANOS, cancel);
+        if (w == null || w.viol > JOINT_WRAP_REPAIR_GATE) {
+            if (SolverTrace.on()) {
+                SolverTrace.log("FREE", "joint wrap close miss viol=%s",
+                        w == null ? "-" : String.format(java.util.Locale.ROOT, "%.3e", w.viol));
+            }
+            return null;
+        }
+        double[] d = bestTranslate(atSpec, w.gf, exact.forward(atSc, w.gf), box);
+        double px = clamp(rs[0] + d[0], box.pxLo, box.pxHi);
+        double pz = clamp(rs[1] + d[1], box.pzLo, box.pzHi);
+        double v = violationAt(exact, spec, w.gf, px, pz);
+        if (SolverTrace.on()) {
+            SolverTrace.log("FREE", "joint wrap close ils=%.3e reaccum=%.3e start=(%.5f,%.5f)", w.viol, v, px, pz);
+        }
+        if (v <= feasTol) return new Result(Angles.wrapAll(w.gf.clone()), px, pz, true);
+        double[] repaired = LatticeRepair.repair(exact, specAtStart(base, spec, px, pz),
+                Angles.wrapAll(w.gf.clone()), feasTol, cancel);
+        if (repaired != null && violationAt(exact, spec, repaired, px, pz) <= feasTol) {
+            if (SolverTrace.on()) {
+                SolverTrace.log("FREE", "joint wrap close certified by lattice repair (%.5f,%.5f)", px, pz);
+            }
+            return new Result(repaired, px, pz, true);
         }
         return null;
     }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/LongRunSolver.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/LongRunSolver.java
@@ -3,7 +3,9 @@ package de.legoshi.parkourcalc.core.anglesolver.solver;
 import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /** From-scratch solver for long multi-jump spans: the post-failure fallback for runs the closed-form dual
@@ -127,12 +129,13 @@ public final class LongRunSolver {
         if (jumps < 1) return null;
 
         double[] chosen = new double[2];
+        Map<Integer, Object> retryCache = new HashMap<>();
         for (int commit : cfg.commitLadder) {
             if (cancel != null && cancel.get()) return null;
             chosen[0] = Double.NaN;
             chosen[1] = Double.NaN;
             double[] gf = runHorizon(exact, sc, spec, bounds, jumps, commit, cfg.windowLadder, cancel,
-                    freeBox, chosen);
+                    freeBox, chosen, retryCache);
             if (gf == null || Double.isNaN(chosen[0])) continue;
             JumpPhysicsInputs at = FreeStartSolve.copyWithStart(sc, chosen[0], chosen[1]);
             double[] replay = at.toGameFacings(Angles.wrapAll(gf));
@@ -153,7 +156,7 @@ public final class LongRunSolver {
 
         for (int commit : cfg.commitLadder) {
             if (cancel != null && cancel.get()) return null;
-            double[] gf = runHorizon(exact, sc, spec, bounds, jumps, commit, cfg.windowLadder, cancel, null, null);
+            double[] gf = runHorizon(exact, sc, spec, bounds, jumps, commit, cfg.windowLadder, cancel, null, null, null);
             if (gf == null) continue;
             // Certify the chain Apply will actually realize, not the window-chained facings themselves:
             // the plan stores the wrapped facings and the game re-accumulates float deltas from them,
@@ -171,9 +174,11 @@ public final class LongRunSolver {
 
     /** One full receding-horizon sweep committing {@code commitJumps} jumps per window. Returns the chained
      *  game facings, or {@code null} if it gets stuck (no window solvable from some seam). */
+    private static final Object FREE_RETRY_MISS = new Object();
+
     private static double[] runHorizon(ExactJumpModel exact, JumpPhysicsInputs sc, JumpSpec spec, int[] bounds,
                                        int jumps, int commitJumps, int[] windowLadder, AtomicBoolean cancel,
-                                       StartBox freeBox, double[] chosenStart) {
+                                       StartBox freeBox, double[] chosenStart, Map<Integer, Object> retryCache) {
         int n = sc.numTicks;
         double[] gf = new double[n];
         Vec3dCore seedPos = sc.startPos, seedVel = sc.initialVelocity;
@@ -198,21 +203,27 @@ public final class LongRunSolver {
                         : new Objective(JumpPhysicsInputs.Axis.Z, Objective.Sense.MAX, c - a); // lead-in: any feasible
                 double[] yaws = solveWindow(exact, win, cons, obj, last, cancel);
                 if (yaws == null && i == 0 && freeBox != null) {
-                    JumpPhysicsInputs freeSc = FreeStartSolve.copyWithStart(sc, seedPos.x, seedPos.z);
-                    freeSc.startBox = new StartBox(seedPos.x, seedPos.z, seedVel.x, seedVel.z,
-                            freeBox.pxLo, freeBox.pxHi, freeBox.pzLo, freeBox.pzHi,
-                            seedVel.x, seedVel.x, seedVel.z, seedVel.z);
-                    List<JumpConstraint> upTo = new ArrayList<>();
-                    for (JumpConstraint jc : spec.constraints) {
-                        if (jc.t1 <= c && (jc.t2 == null || jc.t2 <= c)) upTo.add(jc);
-                    }
-                    Objective freeObj = last ? spec.objective
-                            : new Objective(JumpPhysicsInputs.Axis.Z, Objective.Sense.MAX, c);
-                    FreeStartSolve.Result fr = FreeStartSolve.solveJoint(
-                            exact, new JumpSpec(freeSc, upTo, freeObj), 0.0, cancel);
-                    if (SolverTrace.on()) {
-                        SolverTrace.log("FREE", "window free retry we=%d cons=%d -> %s",
-                                we, upTo.size(), fr != null && fr.feasible ? "solved" : "miss");
+                    Object cached = retryCache.get(we);
+                    FreeStartSolve.Result fr;
+                    if (cached != null) {
+                        fr = cached == FREE_RETRY_MISS ? null : (FreeStartSolve.Result) cached;
+                    } else {
+                        JumpPhysicsInputs freeSc = FreeStartSolve.copyWithStart(sc, seedPos.x, seedPos.z);
+                        freeSc.startBox = new StartBox(seedPos.x, seedPos.z, seedVel.x, seedVel.z,
+                                freeBox.pxLo, freeBox.pxHi, freeBox.pzLo, freeBox.pzHi,
+                                seedVel.x, seedVel.x, seedVel.z, seedVel.z);
+                        List<JumpConstraint> upTo = new ArrayList<>();
+                        for (JumpConstraint jc : spec.constraints) {
+                            if (jc.t1 <= c && (jc.t2 == null || jc.t2 <= c)) upTo.add(jc);
+                        }
+                        Objective freeObj = last ? spec.objective
+                                : new Objective(JumpPhysicsInputs.Axis.Z, Objective.Sense.MAX, c);
+                        fr = FreeStartSolve.solveJoint(exact, new JumpSpec(freeSc, upTo, freeObj), 0.0, cancel);
+                        retryCache.put(we, fr == null ? FREE_RETRY_MISS : fr);
+                        if (SolverTrace.on()) {
+                            SolverTrace.log("FREE", "window free retry we=%d cons=%d -> %s",
+                                    we, upTo.size(), fr != null && fr.feasible ? "solved" : "miss");
+                        }
                     }
                     if (fr != null && fr.feasible) {
                         chosenStart[0] = fr.startX;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/SlpSolve.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/SlpSolve.java
@@ -108,19 +108,18 @@ public final class SlpSolve {
         List<JumpConstraint> constraints = spec.constraints;
         JumpPhysicsInputs sc = spec.asScenario();
         YawTies ties = null;
-        List<JumpConstraint> yawIneq = new ArrayList<>();
         if (JumpLinearModel.hasFacingWall(constraints)) {
             ties = YawTies.of(constraints, sc.numTicks);
+            if (ties == null) return null; // not position-linear
             for (JumpConstraint c : constraints) {
                 if (c.mode != JumpConstraint.Mode.F) continue;
                 if (c.t1 < 0 || c.t1 >= sc.numTicks) continue;
                 boolean delta = c.t2 != null;
-                if (delta && !(c.op == JumpConstraint.Op.MINUS && c.t2 == c.t1 - 1 && c.t1 >= 1)) return null;
-                boolean absorbed = ties != null
-                        && (delta ? ties.groupOf(c.t1) == ties.groupOf(c.t1 - 1) : ties.varOf(c.t1) < 0);
-                if (absorbed) continue;
-                if (c.cmp == JumpConstraint.Cmp.EQ) return null;
-                yawIneq.add(c);
+                boolean absorbed = delta
+                        ? c.op == JumpConstraint.Op.MINUS && c.t2 == c.t1 - 1 && c.t1 >= 1
+                                && ties.groupOf(c.t1) == ties.groupOf(c.t1 - 1)
+                        : ties.varOf(c.t1) < 0;
+                if (!absorbed) return null; // not position-linear
             }
         }
         for (JumpConstraint c : constraints) {
@@ -141,9 +140,7 @@ public final class SlpSolve {
             if (trivialInfeasible[0]) return null; // a violated constant is unfixable
             if (w != null) { ineq.add(c); walls.add(w); }
         }
-        int mPos = walls.size();
-        ineq.addAll(yawIneq);
-        int m = ineq.size();
+        int m = walls.size();
         if (m == 0) return null; // nothing to restore; the closed form already handles the unconstrained case
 
         double[] cx = new double[n];
@@ -213,8 +210,8 @@ public final class SlpSolve {
                     List<JumpLinearModel.Wall> rebuilt = null;
                     if (anySet(zeroX) || anySet(zeroZ)) {
                         JumpLinearModel patterned = new JumpLinearModel(sc, zeroX.clone(), zeroZ.clone());
-                        rebuilt = new ArrayList<>(mPos);
-                        for (JumpConstraint c : ineq.subList(0, mPos)) {
+                        rebuilt = new ArrayList<>(m);
+                        for (JumpConstraint c : ineq) {
                             JumpLinearModel.Wall w = patterned.compileWall(c, 0.0, null);
                             if (w == null) { rebuilt = null; break; }
                             rebuilt.add(w);
@@ -243,24 +240,13 @@ public final class SlpSolve {
                 int nv = dims + 1; // facing deltas (deg) + worst-slack variable s
                 List<LinearConstraint> cons = new ArrayList<>(m + 2 * dims + 1);
                 for (int j = 0; j < m; j++) {
+                    JumpLinearModel.Wall wall = lpWalls.get(j);
                     double[] row = new double[nv];
-                    if (j < mPos) {
-                        JumpLinearModel.Wall wall = lpWalls.get(j);
-                        for (int t = 0; t < n; t++) {
-                            int v = col[t];
-                            if (v < 0) continue;
-                            double du = wall.axis == 0 ? -uz[t] : ux[t]; // d(u.axis)/dyaw, deg-scaled below
-                            row[v] += wall.coef[t] * du * RAD;
-                        }
-                    } else {
-                        JumpConstraint c = ineq.get(j);
-                        double sgn = c.cmp == JumpConstraint.Cmp.GE ? -1.0 : 1.0;
-                        int v1 = col[c.t1];
-                        if (v1 >= 0) row[v1] += sgn;
-                        if (c.t2 != null) {
-                            int v2 = col[c.t2];
-                            if (v2 >= 0) row[v2] -= sgn;
-                        }
+                    for (int t = 0; t < n; t++) {
+                        int v = col[t];
+                        if (v < 0) continue;
+                        double du = wall.axis == 0 ? -uz[t] : ux[t]; // d(u.axis)/dyaw, deg-scaled below
+                        row[v] += wall.coef[t] * du * RAD;
                     }
                     row[dims] = -1.0;
                     cons.add(new LinearConstraint(row, Relationship.LEQ, -viol[j]));

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverTable.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverTable.java
@@ -121,6 +121,28 @@ public final class AngleSolverTable {
         return 0;
     }
 
+    private static boolean dfConforming(Constraint c) {
+        return !c.isRange() && c.getOp() == Constraint.Op.EQ && c.getValue() == 0.0;
+    }
+
+    private static String dfOpGlyph(Constraint c) {
+        return c.isRange() ? Constraint.Op.IN.glyph : c.getOp().glyph;
+    }
+
+    private static String dfValueLabel(Constraint c) {
+        if (c.isRange()) {
+            return String.format(java.util.Locale.ROOT, "%.4g..%.4g !", c.getLo(), c.getHi());
+        }
+        return String.format(java.util.Locale.ROOT, "%.4g !", c.getValue());
+    }
+
+    private static String dfTooltip(Constraint c) {
+        return dfConforming(c)
+                ? "dF is supported as dF = 0 only (hold the facing of the previous tick)"
+                : "Unsupported dF shape from an older save; solves containing it will fail."
+                        + " Re-select the dF field to reset it to dF = 0, or delete it.";
+    }
+
     public AngleSolverTable(AngleSolverState state, Settings settings, SelectionManager selection,
                             ConstraintSelection constraintSelection, IntSupplier rowCount) {
         this.state = state;
@@ -964,19 +986,29 @@ public final class AngleSolverTable {
                     c.setField(Constraint.Field.values()[fieldCombo.get()]);
                 }
                 ImGui.tableNextColumn();
-                opCombo.set(opItemIndex(c));
-                if (Controls.combo("##op", opCombo, OP_ITEMS, ImGui.getContentRegionAvail().x)) {
-                    int v = opCombo.get();
-                    if (v < SCALAR_OPS.length) {
-                        c.setOp(SCALAR_OPS[v]);
-                    } else {
-                        c.setOp(Constraint.Op.IN);
-                        int b = v - SCALAR_OPS.length;
-                        c.setInclusive((b & 2) != 0, (b & 1) != 0);
+                if (c.getField() == Constraint.Field.DF) {
+                    ImGui.textDisabled(dfConforming(c) ? "=" : dfOpGlyph(c));
+                    if (ImGui.isItemHovered()) ImGui.setTooltip(dfTooltip(c));
+                } else {
+                    opCombo.set(opItemIndex(c));
+                    if (Controls.combo("##op", opCombo, OP_ITEMS, ImGui.getContentRegionAvail().x)) {
+                        int v = opCombo.get();
+                        if (v < SCALAR_OPS.length) {
+                            c.setOp(SCALAR_OPS[v]);
+                        } else {
+                            c.setOp(Constraint.Op.IN);
+                            int b = v - SCALAR_OPS.length;
+                            c.setInclusive((b & 2) != 0, (b & 1) != 0);
+                        }
                     }
                 }
                 ImGui.tableNextColumn();
-                renderConstraintValues(c);
+                if (c.getField() == Constraint.Field.DF) {
+                    ImGui.textDisabled(dfConforming(c) ? "0" : dfValueLabel(c));
+                    if (ImGui.isItemHovered()) ImGui.setTooltip(dfTooltip(c));
+                } else {
+                    renderConstraintValues(c);
+                }
                 ImGui.tableNextColumn();
                 if (deleteX("del")) delete = i;
                 if (dim) ImGui.popStyleVar();

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/TESTS.md
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/TESTS.md
@@ -69,9 +69,9 @@ anglesolver/
                            (solve/loopmm-tight-t39-fast: the SAME capture under FAST effort; pins
                            the staged late-race: primary fast starves, the explore arm spawns at
                            the 20 s checkpoint and lands it, budget 90 s; the redirect-class gate)
-                           (solve/gh313-j121-dfneo: gh-313; hpk j121 neo with dF <= 0 walls, a
-                           facing-wall spec every deterministic recovery bails on; pins the
-                           near-miss seeded feasibility rescue in SolveCore under FAST effort)
+                           (solve/gh313-j121-dfneo: gh-313; hpk j121 neo with dF <= 0 walls. The
+                           dF inequality class is retired by ruling (issue 372, dF = 0 only); still
+                           carried by the CMA rescue until the removal PR flips this to not-solving)
                            (solve/gh283-j925-farseed: gh-283; hpk j925 momentum+neo with the start
                            dragged ~2 blocks outside its tick-0 footprint box, cold rows; pins the
                            seed-position-independent free-start solve, FAST 20 s: bestTranslate's


### PR DESCRIPTION
Part of #372, second of the three CMA-retirement PRs. Stacked on #371.

## Ruling

dF constraints are supported as dF = 0 only. The inequality and band shapes (dF <= 0 and friends, the gh-313 class) are deliberately retired: they were carried exclusively by the CMA seeded rescue, forced special cases into every deterministic stage (#360's blanket refusals, #368's yaw rows), and blocked the CMA-ES removal. This un-fixes the gh-313 report's specific file; that trade-off is intentional and stated here rather than slipped in.

## Changes

- UI: selecting the dF field normalizes the constraint to = 0 (`Constraint.setField`, same pattern as the existing refTick/vsDz normalization). The editor renders the op and value as fixed "=" and "0" with a tooltip. Unsupported dF shapes from older saves still load and render read-only, marked with a tooltip explaining that solves containing them fail and how to reset or delete them; no silent data rewriting.
- SlpSolve: #368's yaw-space LP rows are reverted; the retired class was their only consumer. The tie fold and the inertia-aware retry stay; they carry gh283-j925-farseed and gh283-j990-cold.
- TESTS.md: gh313-j121-dfneo entry documents the retirement. Its expect stays shouldSolve true on this branch because the CMA rescue still solves it; the removal PR flips it to not-solving.
- #360 is effectively closed by this ruling: its remaining items existed to widen support for the class now retired. The surviving design, fold dF = 0 pins and chains and refuse everything else, is implemented.

## Tests

- :core:check and full :core:test -PslowTests green on the stacked state (369 + this).
- No sweep impact: the hpk corpora contain no dF constraints; the dF=0 capture suites (df-chain-free-start, f2f-dfchain-multijump, gh283-j990-cold) all pass through the fold path unchanged.

In-game QA note: the dF row in the constraint editor now shows fixed "= 0"; a save containing legacy dF walls shows them dimmed with the explanatory tooltip.
