### PR TITLE
feat(ui): move angle solver action buttons above results and persist section expansion

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverWindow.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverWindow.java
@@ -237,14 +237,14 @@ public final class AngleSolverWindow implements RenderInterface {
 
         ThemeManager.paddedSeparator();
 
+        renderActions();
+
         SolveResult panel = engine.isSolving() ? engine.liveBestResult() : state.getResult();
         trackObjectiveImprovement(panel);
         if (panel != null) {
-            renderResultPanel(io, panel, scale);
             ThemeManager.sectionSpacing();
+            renderResultPanel(io, panel, scale);
         }
-
-        renderActions();
     }
 
     private void longSpanWarning(int span, float scale) {
@@ -693,10 +693,6 @@ public final class AngleSolverWindow implements RenderInterface {
         }
         ImGui.sameLine();
         if (Controls.secondaryButton("Solve")) {
-            yawsExpanded = false;
-            detailsExpanded = false;
-            solverExpanded = false;
-            outcomesExpanded = true;
             engine.solve();
         }
     }


### PR DESCRIPTION
- render action buttons (Apply state, Solve, Cancel) above the result panel
- prevent action buttons from jumping position when results expand or collapse
- preserve expanded/collapsed states of result sections (Solved values, Details, Yaws) across solves