### PR TITLE
chore: drop the bundled commons-math3 and explain the unsupported-dF failure

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -32,8 +32,8 @@ dependencies {
 	compileOnly 'com.google.code.gson:gson:2.8.0'
 
 	// commons-math3 is test-only since the bespoke TrustRegionLp replaced the SimplexSolver in
-	// SlpSolve: TrustRegionLpTest keeps it as the randomized equivalence oracle. The loaders still
-	// bundle their own copies (Fabric `include`, Forge `shade`); dropping those is follow-up work.
+	// SlpSolve: TrustRegionLpTest keeps it as the randomized equivalence oracle. No loader bundles
+	// it any more, so it must never be promoted out of the test source set.
 	testImplementation 'org.apache.commons:commons-math3:3.6.1'
 
 	// Test-only. Gson is compileOnly for main (the loaders provide it), so the test source set needs

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/AngleSolverEngine.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/AngleSolverEngine.java
@@ -964,6 +964,7 @@ public final class AngleSolverEngine {
             SolveResult fail = new SolveResult(false, 0, job.uiConstraints.size(),
                     job.startTick + 1, job.landingTick + 1);
             if (ctx.chain() != null) fail.setSolver(ctx.chain());
+            if (hasUnsupportedDf(job)) fail.setNotice(DF_UNSUPPORTED_NOTICE);
             return new Outcome(fail, null);
         }
         double[] yaws = cand.yaws;
@@ -1004,6 +1005,18 @@ public final class AngleSolverEngine {
         Plan plan = new Plan(job.startTick, yaws, job.strafeMask, job.force45Mask, 1, path, sc.startPos, stageLocked);
         return new Outcome(result, plan);
     }
+
+    private static boolean hasUnsupportedDf(Job job) {
+        for (ConstraintAt ca : job.uiConstraints) if (ca.c.isUnsupportedDf()) return true;
+        return false;
+    }
+
+    public static final String DF_UNSUPPORTED_NOTICE =
+            "This jump carries a delta-facing (dF) constraint that is not dF = 0. Only dF = 0 is"
+            + " supported: the inequality and band shapes were retired, so every solver stage"
+            + " declines the problem before searching and the solve cannot succeed while one is"
+            + " present. Re-select the dF field on that constraint to reset it to dF = 0, or delete"
+            + " the constraint.";
 
     public static final String DF_DIRECTION_NOTICE =
             "This jump has a delta-facing (dF) constraint. Landing does not depend on the Solve For"

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/Constraint.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/Constraint.java
@@ -159,6 +159,10 @@ public final class Constraint {
         return op == Op.IN;
     }
 
+    public boolean isUnsupportedDf() {
+        return field == Field.DF && (isRange() || op != Op.EQ || value != 0.0);
+    }
+
     public boolean isEnabled() {
         return enabled;
     }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverTable.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverTable.java
@@ -121,10 +121,6 @@ public final class AngleSolverTable {
         return 0;
     }
 
-    private static boolean dfConforming(Constraint c) {
-        return !c.isRange() && c.getOp() == Constraint.Op.EQ && c.getValue() == 0.0;
-    }
-
     private static String dfOpGlyph(Constraint c) {
         return c.isRange() ? Constraint.Op.IN.glyph : c.getOp().glyph;
     }
@@ -137,10 +133,10 @@ public final class AngleSolverTable {
     }
 
     private static String dfTooltip(Constraint c) {
-        return dfConforming(c)
-                ? "dF is supported as dF = 0 only (hold the facing of the previous tick)"
-                : "Unsupported dF shape from an older save; solves containing it will fail."
-                        + " Re-select the dF field to reset it to dF = 0, or delete it.";
+        return c.isUnsupportedDf()
+                ? "Unsupported dF shape from an older save; solves containing it will fail."
+                        + " Re-select the dF field to reset it to dF = 0, or delete it."
+                : "dF is supported as dF = 0 only (hold the facing of the previous tick)";
     }
 
     public AngleSolverTable(AngleSolverState state, Settings settings, SelectionManager selection,
@@ -987,7 +983,7 @@ public final class AngleSolverTable {
                 }
                 ImGui.tableNextColumn();
                 if (c.getField() == Constraint.Field.DF) {
-                    ImGui.textDisabled(dfConforming(c) ? "=" : dfOpGlyph(c));
+                    ImGui.textDisabled(c.isUnsupportedDf() ? dfOpGlyph(c) : "=");
                     if (ImGui.isItemHovered()) ImGui.setTooltip(dfTooltip(c));
                 } else {
                     opCombo.set(opItemIndex(c));
@@ -1004,7 +1000,7 @@ public final class AngleSolverTable {
                 }
                 ImGui.tableNextColumn();
                 if (c.getField() == Constraint.Field.DF) {
-                    ImGui.textDisabled(dfConforming(c) ? "0" : dfValueLabel(c));
+                    ImGui.textDisabled(c.isUnsupportedDf() ? dfValueLabel(c) : "0");
                     if (ImGui.isItemHovered()) ImGui.setTooltip(dfTooltip(c));
                 } else {
                     renderConstraintValues(c);

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverWindow.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverWindow.java
@@ -771,7 +771,7 @@ public final class AngleSolverWindow implements RenderInterface {
             ThemeManager.pushTextColor(ThemeManager.warningColor());
             ImGui.textWrapped(notice);
             ThemeManager.popTextColor();
-            TooltipUtil.onHover(DIRECTION_TIP);
+            if (AngleSolverEngine.DF_DIRECTION_NOTICE.equals(notice)) TooltipUtil.onHover(DIRECTION_TIP);
         }
         renderOutcomes(r, scale);
         renderDetails(details, steps, scale);

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/DeltaFacingConstraintTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/DeltaFacingConstraintTest.java
@@ -18,6 +18,8 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -189,6 +191,49 @@ public class DeltaFacingConstraintTest {
         }
         assertTrue("seam dF outcome row missing from the result panel", reported);
         assertEquals(0.0, Angles.wrap(r.getYaws().get(0).yaw - seed - target), 2.0e-4);
+    }
+
+    @Test
+    public void onlyZeroEqualityCountsAsSupportedDf() {
+        assertFalse(Constraint.scalar(Constraint.Field.DF, Constraint.Op.EQ, 0.0).isUnsupportedDf());
+        assertTrue(Constraint.scalar(Constraint.Field.DF, Constraint.Op.LE, 0.0).isUnsupportedDf());
+        assertTrue(Constraint.scalar(Constraint.Field.DF, Constraint.Op.EQ, 1.0).isUnsupportedDf());
+        assertTrue(Constraint.range(Constraint.Field.DF, -1.0, 1.0, true, true).isUnsupportedDf());
+        assertFalse(Constraint.scalar(Constraint.Field.X, Constraint.Op.LE, 3.0).isUnsupportedDf());
+        assertFalse(Constraint.range(Constraint.Field.F, -1.0, 1.0, true, true).isUnsupportedDf());
+    }
+
+    @Test
+    public void unsupportedDfWallFailsWithTheExplanatoryNotice() {
+        Ctx ctx = build(state ->
+                addScalar(state, state.getStartTick() + 2, Constraint.Op.LE, 0.0));
+        SolveResult r = solve(ctx);
+        assertNotNull("engine returned no result", r);
+        assertFalse("a dF inequality is retired and must not solve", r.isSuccess());
+        assertEquals("failed solve must name the unsupported dF as the cause",
+                AngleSolverEngine.DF_UNSUPPORTED_NOTICE, r.getNotice());
+    }
+
+    @Test
+    public void unsupportedDfBandFailsWithTheExplanatoryNotice() {
+        Ctx ctx = build(state -> state.tickConstraints(state.getStartTick() + 2).getConstraints()
+                .add(Constraint.range(Constraint.Field.DF, -1.0, 1.0, true, true)));
+        SolveResult r = solve(ctx);
+        assertNotNull("engine returned no result", r);
+        assertFalse("a dF band is retired and must not solve", r.isSuccess());
+        assertEquals("failed solve must name the unsupported dF as the cause",
+                AngleSolverEngine.DF_UNSUPPORTED_NOTICE, r.getNotice());
+    }
+
+    @Test
+    public void supportedDfSolveCarriesNoUnsupportedNotice() {
+        Ctx ctx = build(state ->
+                addScalar(state, state.getStartTick() + 2, Constraint.Op.EQ, 0.0));
+        SolveResult r = solve(ctx);
+        assertNotNull("engine returned no result", r);
+        assertTrue("j004 must solve with a zero-turn tick", r.isSuccess());
+        assertNotEquals("a supported dF = 0 must not be reported as unsupported",
+                AngleSolverEngine.DF_UNSUPPORTED_NOTICE, r.getNotice());
     }
 
     @Test

--- a/loader-fabric-1.21.3/build.gradle
+++ b/loader-fabric-1.21.3/build.gradle
@@ -39,10 +39,6 @@ dependencies {
 	// Shared core module (Java 8, no MC). Bundle into the final mod JAR.
 	include implementation(project(':core'))
 
-	// commons-math3 backs the Angle Solver's CMA-ES; core needs it at runtime. Loom's `include`
-	// does not pull a project's transitive maven deps into jar-in-jar, so list it explicitly.
-	include implementation("org.apache.commons:commons-math3:3.6.1")
-
 	include implementation("io.github.spair:imgui-java-binding:${project.imgui_version}")
 	include implementation("io.github.spair:imgui-java-lwjgl3:${project.imgui_version}")
 	include implementation("io.github.spair:imgui-java-natives-windows:${project.imgui_version}")

--- a/loader-fabric/build.gradle
+++ b/loader-fabric/build.gradle
@@ -43,10 +43,6 @@ dependencies {
 	// Shared core module (Java 8, no MC). Bundle into the final mod JAR.
 	include implementation(project(':core'))
 
-	// commons-math3 backs the Angle Solver's CMA-ES; core needs it at runtime. Loom's `include`
-	// does not pull a project's transitive maven deps into jar-in-jar, so list it explicitly.
-	include implementation("org.apache.commons:commons-math3:3.6.1")
-
 	include implementation("io.github.spair:imgui-java-binding:${project.imgui_version}")
 	include implementation("io.github.spair:imgui-java-lwjgl3:${project.imgui_version}")
 	include implementation("io.github.spair:imgui-java-natives-windows:${project.imgui_version}")

--- a/loader-forge-1.12.2/build.gradle
+++ b/loader-forge-1.12.2/build.gradle
@@ -1,12 +1,3 @@
-buildscript {
-    repositories { mavenCentral() }
-    dependencies {
-        // jar->jar package relocator (ASM-based). Used to lift commons-math3 out of the
-        // FML-excluded `org.apache.commons.*` namespace; see the relocateMath3 task below.
-        classpath 'me.lucko:jar-relocator:1.7'
-    }
-}
-
 plugins {
     id 'xyz.wagyourtail.unimined' version '1.4.1'
     id 'java'
@@ -97,33 +88,7 @@ jar {
     }
 }
 
-// FML's LaunchClassLoader delegates the `org.apache.commons.` prefix to the parent app
-// classloader (FMLLaunchHandler line 70), which at runtime does not carry our bundled
-// commons-math3, so the classes ClassNotFound under launchwrapper even though they are
-// in the jar. Relocate them out of `org.apache.*` before remap. remapJar then consumes
-// the relocated fat jar instead of `jar` directly.
-def relocatedJar = layout.buildDirectory.file('relocated/relocated.jar')
-
-tasks.register('relocateMath3') {
-    dependsOn 'jar'
-    def input = tasks.named('jar').flatMap { it.archiveFile }
-    inputs.file(input)
-    outputs.file(relocatedJar)
-    doLast {
-        new me.lucko.jarrelocator.JarRelocator(
-            input.get().asFile,
-            relocatedJar.get().asFile,
-            [new me.lucko.jarrelocator.Relocation('org.apache.commons.math3', 'de.legoshi.parkourcalc.shaded.commons.math3')]
-        ).run()
-    }
-}
-
-tasks.named('remapJar') {
-    dependsOn 'relocateMath3'
-    inputFile.set(relocatedJar)
-}
-
-// No Forge test covers runtime AT application, so fail the build if the shade/relocate/remap
+// No Forge test covers runtime AT application, so fail the build if the shade/remap
 // pipeline drops the AT file or its FMLAT manifest entry from the final jar.
 def atFileName = 'parkourcalculator_at.cfg'
 tasks.register('verifyAccessTransformer') {

--- a/loader-forge-1.8.9/build.gradle
+++ b/loader-forge-1.8.9/build.gradle
@@ -1,12 +1,3 @@
-buildscript {
-    repositories { mavenCentral() }
-    dependencies {
-        // jar->jar package relocator (ASM-based). Used to lift commons-math3 out of the
-        // FML-excluded `org.apache.*` namespace; see the relocateMath3 task below.
-        classpath 'me.lucko:jar-relocator:1.7'
-    }
-}
-
 plugins {
     id 'xyz.wagyourtail.unimined' version '1.4.1'
     id 'java'
@@ -97,33 +88,7 @@ jar {
     }
 }
 
-// FML's LaunchClassLoader delegates the whole `org.apache.` prefix to the parent app
-// classloader (FMLLaunchHandler line 41), which at runtime does not carry our bundled
-// commons-math3, so the classes ClassNotFound under launchwrapper even though they are
-// in the jar. Relocate them out of `org.apache.*` before remap. remapJar then consumes
-// the relocated fat jar instead of `jar` directly.
-def relocatedJar = layout.buildDirectory.file('relocated/relocated.jar')
-
-tasks.register('relocateMath3') {
-    dependsOn 'jar'
-    def input = tasks.named('jar').flatMap { it.archiveFile }
-    inputs.file(input)
-    outputs.file(relocatedJar)
-    doLast {
-        new me.lucko.jarrelocator.JarRelocator(
-            input.get().asFile,
-            relocatedJar.get().asFile,
-            [new me.lucko.jarrelocator.Relocation('org.apache.commons.math3', 'de.legoshi.parkourcalc.shaded.commons.math3')]
-        ).run()
-    }
-}
-
-tasks.named('remapJar') {
-    dependsOn 'relocateMath3'
-    inputFile.set(relocatedJar)
-}
-
-// No Forge test covers runtime AT application, so fail the build if the shade/relocate/remap
+// No Forge test covers runtime AT application, so fail the build if the shade/remap
 // pipeline drops the AT file or its FMLAT manifest entry from the final jar.
 def atFileName = 'parkourcalculator_at.cfg'
 tasks.register('verifyAccessTransformer') {


### PR DESCRIPTION
Two independent cleanups surfaced by an audit of what the CMA-ES removal left behind. Separate commits; either can be dropped without touching the other.

## 1. Drop the bundled commons-math3 and the dead Forge relocation (#394)

`TrustRegionLp` replaced the commons-math3 `SimplexSolver` in `SlpSolve`, and the CMA removal took the last other consumer. `git grep -i "commons.math3" -- "*/src/main/*"` returns nothing in any module; the only user left is `TrustRegionLpTest`, the randomized equivalence oracle, so `core` keeps it as `testImplementation`.

The four loaders were in two different states:

- **Fabric 26.2 and 1.21.3 were still shipping it.** Both declared `include implementation("org.apache.commons:commons-math3:3.6.1")` explicitly, jar-in-jar'ing 2.2 MB into every published jar, under a comment claiming the Angle Solver's CMA-ES needed it at runtime.
- **Both Forge loaders had already dropped it without noticing.** `testImplementation` does not propagate to `:core`'s consumable runtime variant, so nothing pulled math3 into `shade` any more, but `relocateMath3` still ran jar-relocator over the entire fat jar on every build and relocated nothing. Removing it also retires the `me.lucko:jar-relocator` buildscript dependency and the `remapJar` input rewiring, so `remapJar` consumes `jar` directly again.

## 2. Explain the unsupported-dF failure on the solve result (#395)

Restricting dF to `dF = 0` (#372, PR #373) retired the inequality and band shapes. Saves written before that still load, deliberately: the ruling chose read-only display over silent data rewriting. But a solve containing one failed with no explanation.

The constraint still compiles into the spec, then every stage declines it before any search happens: `FacingPrefold.analyze` returns null, `ClosedFormSolve` bails, `SlpSolve` returns null from `YawTies.of`, and `BoundPrunedRecovery` / `RelaxationRecovery` / `LevelSetAscent` short-circuit on `hasFacingWall`. The graph ends with no candidate and the panel shows only:

```
No solution · 0/N constraints met
```

The real cause was stated only in a hover tooltip on the dimmed constraint row, so an unsupported constraint looked exactly like a genuinely hard jump. This is the surface a gh-313-style report comes back through.

The engine now sets an explanatory notice on the failure result, reusing the existing `SolveResult.notice` channel and its panel rendering rather than adding a message path. The "is this dF shape supported" rule moves out of `AngleSolverTable` onto `Constraint.isUnsupportedDf`, so the table and the engine share one definition instead of duplicating it. The notice hover tip in the result panel is now gated on `DF_DIRECTION_NOTICE`, which was its only intended target; previously any notice got the direction-optimizer explanation on hover.

No dF shape gains or loses support, nothing is rewritten on load, and successful solves are untouched.

## Tests

- `:core:check -PslowTests` green: 655 tests, 0 failures, 0 errors, `tableStyleCheck` clean.
- Four new cases in `DeltaFacingConstraintTest` (not slow-tagged): `dF <= 0` and a `dF` band each fail carrying `DF_UNSUPPORTED_NOTICE`, `dF = 0` still solves without it, and a predicate unit test pins that non-dF fields are never flagged.
- `./gradlew build` green across all modules.
- All four output jars inspected: zero `math3` entries under either the original or the relocated package name, no nested commons jar, and both Forge jars keep `META-INF/parkourcalculator_at.cfg` plus the `FMLAT` manifest attribute. `verifyAccessTransformer` passes on the shortened pipeline, which was the main risk in rewiring `remapJar`.
- Fabric jars drop 2.2 MB each.

## QA

In-game QA still pending. Worth covering on one Fabric and one Forge loader: open a save carrying a legacy dF wall, run a solve, confirm the results panel shows the notice instead of a bare "No solution", and confirm a normal solve still runs (nothing on a path that used to touch math3 throws `NoClassDefFoundError`).

Fixes #394
Fixes #395
