### PR TITLE
feat(solver): branch the pattern B&B on keeping the inertia gate open

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/BoundPrunedRecovery.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/BoundPrunedRecovery.java
@@ -18,6 +18,7 @@ public final class BoundPrunedRecovery {
     private static final double RESTORE_STEP_CAP_DEG = 20.0;
     private static final double BOUND_QUANTUM = 2.0e-6;
     private static final double TARGET_CONVERT_MAX_CORRIDOR = 2.0e-3;
+    private static final int MAX_KEEP_ALIVE = 4;
 
     public static final class Config {
         public double searchShare = 0.8;
@@ -103,6 +104,15 @@ public final class BoundPrunedRecovery {
                 if (!Double.isNaN(targetNorm) && !searchCancel.get()) {
                     rankYaws = ClosedFormSolve.optimize(exact, searchSpec, feasTol, searchCancel);
                 }
+            }
+            if (!searchCancel.get()) {
+                JumpLinearModel free = new JumpLinearModel(sc);
+                double[] gateRef = rankYaws != null ? rankYaws : freeDualSeed(searchSpec, free);
+                List<Pattern> keepAlive = keepAlivePatterns(exact, searchSpec, sc, free, gateRef);
+                if (SolverTrace.on()) {
+                    for (Pattern p : keepAlive) SolverTrace.log("BNB", "pattern %s bound=%.9f", p.label, p.normBound);
+                }
+                patterns.addAll(keepAlive);
             }
             for (Pattern p : patterns) {
                 if (!p.patterned || p.zeroX == null || searchCancel.get()) continue;
@@ -369,6 +379,64 @@ public final class BoundPrunedRecovery {
         Double bound = rootBound(spec, lin, vel);
         if (bound == null) return;
         cands.add(new Pattern(label, lin, vel, true, bound, k, zx && zz ? 0 : (zx ? 0 : 1), zeroX, zeroZ));
+    }
+
+    /** Patterns that hold the objective axis out of the inertia band at a momentum reversal, the branch
+     *  complementary to the zeroing patterns: the gate destroys the whole carry when the axis coasts through
+     *  the band, and the free relaxation cannot see that because it never models the gate at all. Nominated
+     *  where {@code reference} either trips the gate or reverses sign, in the sign the objective improves. */
+    private static List<Pattern> keepAlivePatterns(ExactJumpModel exact, JumpSpec spec, JumpPhysicsInputs sc,
+                                                   JumpLinearModel free, double[] reference) {
+        List<Pattern> out = new ArrayList<>();
+        if (reference == null) return out;
+        int axis = spec.objective.axis == JumpPhysicsInputs.Axis.X ? 0 : 1;
+        boolean positive = spec.objective.sense == Objective.Sense.MAX;
+        ForwardPath path = exact.forward(sc, sc.toGameFacings(Angles.wrapAll(reference)));
+        double[] vel = axis == 0 ? path.velX : path.velZ;
+        if (vel == null) return out;
+        double thr = exact.inertiaThreshold();
+        for (int k = 1; k < free.n && out.size() < MAX_KEEP_ALIVE; k++) {
+            if (Math.abs(vel[k]) >= thr && vel[k - 1] * vel[k] >= 0.0) continue;
+            JumpLinearModel.Wall w = free.keepAliveWall(axis, k, thr, positive);
+            if (w == null) continue;
+            List<JumpLinearModel.Wall> velWalls = new ArrayList<>(1);
+            velWalls.add(w);
+            Double bound = rootBound(spec, free, velWalls);
+            if (bound == null) continue;
+            out.add(new Pattern(w.name, free, velWalls, true, bound, -1, -1, null, null));
+        }
+        return out;
+    }
+
+    /** The margin-0 dual recovery of the unpatterned model: the always-available reference trajectory when
+     *  the closed form found nothing to rank by. */
+    private static double[] freeDualSeed(JumpSpec spec, JumpLinearModel lin) {
+        boolean[] trivial = {false};
+        List<JumpLinearModel.Wall> walls = lin.compileWalls(spec.constraints, 0.0, trivial);
+        if (trivial[0]) return null;
+        int n = lin.n;
+        double[] cx = new double[n];
+        double[] cz = new double[n];
+        lin.objectiveVectors(spec.objective, cx, cz);
+        CostateDualSolver.Result r = new CostateDualSolver(n, cx, cz, lin.mMagAll(), walls).solve(0.0, null);
+        if (r == null) return null;
+        boolean max = spec.objective.sense == Objective.Sense.MAX;
+        double[] yaws = new double[n];
+        for (int t = 0; t < n; t++) {
+            double gx = r.gx[t];
+            double gz = r.gz[t];
+            if (gx * gx + gz * gz < 1.0e-18) {
+                if (spec.objective.axis == JumpPhysicsInputs.Axis.X) {
+                    gx = max ? 1.0 : -1.0;
+                    gz = 0.0;
+                } else {
+                    gx = 0.0;
+                    gz = max ? 1.0 : -1.0;
+                }
+            }
+            yaws[t] = lin.recoverYawDeg(t, gx, gz);
+        }
+        return yaws;
     }
 
     private static Double rootBound(JumpSpec spec, JumpLinearModel lin, List<JumpLinearModel.Wall> vel) {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/JumpLinearModel.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/JumpLinearModel.java
@@ -301,6 +301,26 @@ public final class JumpLinearModel {
         return walls;
     }
 
+    /** The complement of a {@link #velocityWalls} pair: one half-space keeping {@code v_axis(tick)} outside
+     *  the inertia band, on the {@code positive} side ({@code v >= bound}) or the negative one
+     *  ({@code v <= -bound}). Null when no input reaches the tick. */
+    public Wall keepAliveWall(int axis, int tick, double bound, boolean positive) {
+        if (tick <= 0 || tick >= n) return null;
+        double[] coef = new double[n];
+        boolean any = false;
+        for (int s = 0; s < tick; s++) {
+            if (zNext[axis][s] < tick) continue;
+            coef[s] = positive ? -(fPre[tick] / fPre[s]) : (fPre[tick] / fPre[s]);
+            any = true;
+        }
+        if (!any) return null;
+        double v0 = axis == 0 ? sc.initialVelocity.x : sc.initialVelocity.z;
+        double constVal = zFirst[axis] < tick ? 0.0 : v0 * fPre[tick];
+        double bPrime = positive ? constVal - bound : -bound - constVal;
+        String ax = axis == 0 ? "X" : "Z";
+        return new Wall(axis, coef, bPrime, false, "keep" + ax + "@" + tick + (positive ? "+" : "-"), 0.0);
+    }
+
     public void zeroingPattern(double[] yawsAbsWrapped, double threshold, boolean perAxis,
                                boolean[] outZeroX, boolean[] outZeroZ) {
         double vx = sc.initialVelocity.x;

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/InertiaFoldingTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/InertiaFoldingTest.java
@@ -50,6 +50,61 @@ public class InertiaFoldingTest {
                 foldedDiff < 2.0e-3);
     }
 
+    @Test
+    public void keepAliveWallIsTheComplementOfTheZeroingWall() {
+        ProblemFixture pf = ProblemFixture.load("solve", "loopmm-3jump-lands");
+        JumpSpec spec = pf.specFor(AngleSolverState.Axis.Z, AngleSolverState.Goal.MAX);
+        JumpPhysicsInputs sc = spec.asScenario();
+        ExactJumpModel exact = pf.model;
+        int n = sc.numTicks;
+        double thr = exact.inertiaThreshold();
+
+        JumpLinearModel lin = new JumpLinearModel(sc);
+        double[] yaws = recoverMarginZero(lin, spec);
+        double[] gf = sc.toGameFacings(Angles.wrapAll(yaws));
+        ForwardPath path = exact.forward(sc, gf);
+        double[] ux = new double[n];
+        double[] uz = new double[n];
+        for (int t = 0; t < n; t++) {
+            double phi = lin.baseArg(t) + Angles.wrap(yaws[t]) * RAD;
+            ux[t] = lin.mMag(t) * Math.cos(phi);
+            uz[t] = lin.mMag(t) * Math.sin(phi);
+        }
+
+        for (int axis = 0; axis < 2; axis++) {
+            double[] vel = axis == 0 ? path.velX : path.velZ;
+            int firstGate = n;
+            for (int k = 0; k < n; k++) {
+                if (Math.abs(vel[k]) < thr) { firstGate = k; break; }
+            }
+            boolean[] mask = new boolean[n];
+            for (int k = 1; k < n; k++) {
+                mask[k] = true;
+                List<JumpLinearModel.Wall> zeroing = new JumpLinearModel(sc, axis == 0 ? mask : null,
+                        axis == 1 ? mask : null).velocityWalls(thr);
+                mask[k] = false;
+                JumpLinearModel.Wall keep = lin.keepAliveWall(axis, k, thr, true);
+                if (keep == null) continue;
+
+                JumpLinearModel.Wall mirror = null;
+                for (JumpLinearModel.Wall w : zeroing) if (w.name.endsWith("-")) mirror = w;
+                assertTrue("the zeroing pattern must emit the mirrored wall at " + axis + "@" + k, mirror != null);
+                for (int s = 0; s < n; s++) {
+                    assertTrue("keep-alive must reuse the zeroing coefficients at " + axis + "@" + k,
+                            keep.coef[s] == mirror.coef[s]);
+                }
+                assertTrue("keep-alive must sit a band width below the zeroing bound at " + axis + "@" + k,
+                        Math.abs(keep.bPrime - (mirror.bPrime - 2.0 * thr)) < 1.0e-15);
+
+                if (k > firstGate) continue;
+                double slack = -keep.bPrime;
+                for (int s = 0; s < n; s++) slack += keep.coef[s] * (axis == 0 ? ux[s] : uz[s]);
+                assertTrue("keep-alive slack must read the byte-exact velocity at " + axis + "@" + k
+                        + " (slack=" + slack + " vel=" + vel[k] + ")", Math.abs(slack - (thr - vel[k])) < 2.0e-3);
+            }
+        }
+    }
+
     private static double[] recoverMarginZero(JumpLinearModel lin, JumpSpec spec) {
         int n = lin.n;
         double[] cx = new double[n];

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/TESTS.md
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/TESTS.md
@@ -76,13 +76,12 @@ anglesolver/
                            PKC_RAZORT1_TAG to run; PASS = success + fresh-reparse viol <= 0;
                            report at build/reports/razort1-<tag>.txt
                            (solve/loopmm-tight-t39: the loopmm misses capture with its shipped-
-                           disabled pad wall ENABLED; the tight Z@71 >= -279.3 pad sat on an
-                           incidental hug trajectory of the commons-math LP and stopped landing
-                           with the bespoke TrustRegionLp swap, so shouldSolve is false until the
-                           redirect class is won back, THOROUGH 45 s)
+                           disabled pad wall ENABLED; the tight Z@71 >= -279.3 pad is reachable
+                           only while the Z inertia gate is held open across the momentum
+                           reversal, so this pins the pattern B&B's keep-alive branch,
+                           THOROUGH 45 s)
                            (solve/loopmm-tight-t39-fast: the SAME capture under FAST effort,
-                           accepted-fail for the same reason, budget 90 s; the redirect-class
-                           frontier)
+                           same keep-alive pin on the shorter chain, budget 90 s)
                            (solve/gh313-j121-dfneo: gh-313; hpk j121 neo with dF <= 0 walls. The
                            dF inequality class is retired by ruling (issue 372, dF = 0 only) and
                            CMA-ES is removed (issue 374), so shouldSolve is false by design)

--- a/core/src/test/resources/problems/dualrecovery/loopmm-3jump-lands.expect.json
+++ b/core/src/test/resources/problems/dualrecovery/loopmm-3jump-lands.expect.json
@@ -3,5 +3,5 @@
   "shouldSolve": true,
   "bnbSeconds": 60,
   "refObjective": -279.3,
-  "maxObjectiveGap": 5.0e-4
+  "maxObjectiveGap": 0.0
 }

--- a/core/src/test/resources/problems/solve/loopmm-tight-t39-fast.expect.json
+++ b/core/src/test/resources/problems/solve/loopmm-tight-t39-fast.expect.json
@@ -1,1 +1,1 @@
-{ "capture": "loopmm-tight-t39", "shouldSolve": false, "maxSolveMs": 90000 }
+{ "capture": "loopmm-tight-t39", "shouldSolve": true, "maxSolveMs": 90000 }

--- a/core/src/test/resources/problems/solve/loopmm-tight-t39.expect.json
+++ b/core/src/test/resources/problems/solve/loopmm-tight-t39.expect.json
@@ -1,1 +1,1 @@
-{ "capture": "loopmm-tight-t39", "shouldSolve": false, "effort": "THOROUGH", "optimizeSeconds": 45, "maxSolveMs": 120000 }
+{ "capture": "loopmm-tight-t39", "shouldSolve": true, "effort": "THOROUGH", "optimizeSeconds": 45, "maxSolveMs": 120000 }

--- a/docs/research/angle-solver.md
+++ b/docs/research/angle-solver.md
@@ -434,6 +434,7 @@ This document's narrative ends at the 2026-07-10 port. The later solver work has
 - The dual Newton iteration audit (issue 384): both truncation lanes measured dead, capped iterations are load-bearing. Record: `dual-newton-iteration-audit.md`.
 - The CMA-ES removal train (PRs 371 to 382): wrap-window ILS near-miss close, dF=0-only chains, full CMA-ES removal, the performance cleanup, and the issue 380 simplification (TrustRegionLp shipped; AlmSnapStage and its satellites removed).
 - Free-start seed independence (PRs 387 to 390, commit e171cc52): seed-independent free-start solves for dF=0 chains.
+- The loopmm redirect win-back (issue 383): the pattern enumeration of 10.3 branched only one way on the inertia disjunction; the complementary keep-alive branch (`JumpLinearModel.keepAliveWall`) holds the objective axis outside the band at a momentum reversal and is what lands the tight pad after the TrustRegionLp swap. Record: `dual-newton-hessian-handoff.md` section 6.
 
 ## 16. ILS global-solve findings (carried 2026-08-21 from ils-global-solve.md, since deleted)
 

--- a/docs/research/dual-newton-hessian-handoff.md
+++ b/docs/research/dual-newton-hessian-handoff.md
@@ -10,6 +10,7 @@ Written at dev 64dada4 (the #382 squash merge). Read this before touching `Costa
 - Update (2026-08-21): the sweep baseline moved from 25.1 s to ~30 s after the #387-390 sharpening ladder shipped; accepted cost, see `dual-newton-iteration-audit.md` section 5.
 - `SlpSolve` now runs on the bespoke `TrustRegionLp` (bounded simplex, split step variables). commons-math3 is a test-only dependency of core (`TrustRegionLpTest` is the 300-instance randomized value-equivalence oracle against the old formulation). The loaders still bundle commons-math (Fabric `include`, Forge shade relocations); dropping that is packaging work with in-game QA.
 - Accepted frontier per ruling: `solve/loopmm-tight-t39` and `-fast` are `shouldSolve: false`; `dualrecovery/loopmm-3jump-lands` and `solve/j022-1bmhbfly-noland` carry `maxObjectiveGap: 5.0e-4`. Win-back criteria live in #383.
+- **Update (#383 executed): the three loopmm pins are back.** The pattern B&B grew a keep-alive branch (`JumpLinearModel.keepAliveWall`), so `solve/loopmm-tight-t39` and `-fast` are `shouldSolve: true` again and `dualrecovery/loopmm-3jump-lands` is back at `maxObjectiveGap: 0.0`. `solve/j022-1bmhbfly-noland` stays at 5.0e-4: its shortfall is a different mechanism, see section 6.
 
 ## 1. What the deep dive found
 
@@ -53,7 +54,7 @@ Measure first, kill-audit style: temporary counters (the RungAudit pattern from 
 
 ## 3. Traps learned this session (do not relearn these)
 
-- **LP value-equality does not imply trajectory-equality.** TrustRegionLp matches the old commons-math optimal VALUES on 300 randomized instances, yet the loopmm redirect class stopped landing: its pad (~1e-5 headroom under the dual bound) rode one lucky hug trajectory (1 hit in ~320 SLP calls; 0 in ~6,700 on the new LP, hugs top out 2-5e-4 short class-wide). Two rescue attempts failed and were reverted: a minimal-norm lexicographic face pass in the LP, and lifting the B&B's best search-spec-feasible near-miss with `LevelSetAscent` (the bisection cannot close the last ~2e-4 either). Do not re-attempt those two; #383 needs a genuinely different mechanism.
+- **LP value-equality does not imply trajectory-equality.** TrustRegionLp matches the old commons-math optimal VALUES on 300 randomized instances, yet the loopmm redirect class stopped landing: its pad (~1e-5 headroom under the dual bound) rode one lucky hug trajectory (1 hit in ~320 SLP calls; 0 in ~6,700 on the new LP, hugs top out 2-5e-4 short class-wide). Two rescue attempts failed and were reverted: a minimal-norm lexicographic face pass in the LP, and lifting the B&B's best search-spec-feasible near-miss with `LevelSetAscent` (the bisection cannot close the last ~2e-4 either). Do not re-attempt those two; the mechanism that actually won the class back is the inertia keep-alive branch in section 6.
 - **Split variables, not shifted ones.** The first reformulation (e = d + tr on commons-math) broke dualrecovery/j346 because phase-1 degeneracy parked uninvolved ticks at d = -tr. The split (d = p - q, both in [0, tr]) keeps uninvolved ticks at zero; that alone fixed j346. Phase-1 of this LP is massively degenerate; vertex selection is a real degree of freedom.
 - **The B&B floor conversion**: `BoundPrunedRecovery` converts a target wall into `searchSpec` (wall removed) + `floorNorm`; `offer()` checks the FULL spec, so near-misses are invisible today. If #383 wants them, that is where they surface.
 - Sidecar re-pin precedent: accepted-fail = `shouldSolve: false` (nix-full-t1 pattern); feasible-but-short = widen `maxObjectiveGap`.
@@ -64,7 +65,7 @@ Measure first, kill-audit style: temporary counters (the RungAudit pattern from 
 
 1. **Dual Newton iteration waste (#384)**: lanes A+B above. ~62% of solver CPU; the largest single win available, moderate risk (trajectory shifts in the capped population). DONE, negative: see `dual-newton-iteration-audit.md`; capped iterations are load-bearing.
 2. **Free-start scan-volume restructure**: the 140-theta x ~6-round x ~12-solve multiplication is the machine that FEEDS lever 1; coarse-to-fine plus cross-round reuse attacks it structurally. Overlaps lane B; worth designing together. Farseed spends ~3.6 s here even before the Newton waste inside it. Declined by the audit's section 4: the theta machine never runs on the sweep and the j990 pin protects its exact enumeration.
-3. **loopmm redirect win-back (#383)**: capability, not speed. The pad needs a deliberate crossing mechanism (the corridor between dual bound and pad is ~1e-5 deep; float-lattice realization inside it is the hard part). Acceptance criteria are in the issue.
+3. **loopmm redirect win-back (#383)**: capability, not speed. DONE, positive: the pad was never an LP-vertex problem, it was the inertia gate eating the reversal carry. See section 6.
 4. **FAST-path last-window polish cost**: pre-LP measurements showed `LevelSetAscent` + hug on last windows at ~6.2 s of the then-57 s sweep (20 calls, all wins) and window CF/SLP alternates at ~10 s combined; all contribute results, so this is a budget/semantics question (how much objective polish does first-feasible FAST owe?), needs a ruling plus re-measurement post-LP before touching.
 5. **Packaging simplification**: drop the commons-math bundles from the loaders (Fabric `include`, both Forge relocations plus the jar-relocator machinery that exists only for it) now that core no longer needs it at runtime. Mechanical, but it is loader packaging: needs the usual in-game QA pass on all three loaders.
 
@@ -78,3 +79,32 @@ java -XX:StartFlightRecording=filename=out.jfr,settings=profile -cp ... (aggrega
 ```
 
 Gates for any change here: sweep 104/104 with no capture meaningfully slower, `:core:check -PslowTests`, farseed/j990 FAST 20 s budgets, and the #383 pins staying at their re-pinned expectations.
+
+## 6. The loopmm redirect win-back (#383, executed 2026-08-22)
+
+The pad was never an LP-vertex problem. `dualrecovery/loopmm-3jump-lands` has exactly one binding wall
+(`Z@61 <= -282.825`); the whole objective reduces to "arrive at that wall with the most +Z velocity", and the
+final ten ticks all sit at `phi = 90` in every candidate. The 5e-4 that separated the landing trajectory from
+the missing one was a single inertia-gate firing at tick 4, where the Z velocity crosses zero during the
+momentum reversal: the missing trajectory coasts through the band at `vz = -0.0010..+0.0050` and the gate
+zeroes it, destroying the whole carry from ticks 0-3; the old commons-math trajectory happened to land at
+`vz = +0.00505825`, 5.8e-5 clear of the 0.005 threshold, and kept it. That is the "1 lucky hug in 320 calls".
+
+The pattern enumeration only ever branched one way on that disjunction. `zx@k`/`zz@k`/`zx1@k`/`zz1@k` are the
+"velocity IS inside the band" branch (`velocityWalls` pins `|v| <= thr` so the folded dynamics are
+self-consistent); nothing generated the complementary "velocity is OUTSIDE the band, on this side" branch, and
+the `free` pattern relaxes the gate away entirely instead of enforcing it. `JumpLinearModel.keepAliveWall`
+emits that complement (same coefficients as the `velocityWalls` pair, bound flipped a band width), and
+`BoundPrunedRecovery.keepAlivePatterns` nominates it on the objective axis, in the objective-improving sign,
+at ticks where a reference realization either trips the gate or reverses sign. Two candidates on loopmm
+(`keepZ@3+`, `keepZ@4+`); `keepZ@4+` lands at -279.29986, past the -279.3 pad. The reference is `rankYaws` when
+the closed form produced one, otherwise the margin-0 dual recovery of the free model.
+
+Measured cost: sweep 104/104, 32.7 s -> 33.6 s wall, zero solver-chain changes across all 104 rows;
+`:core:check -PslowTests` 2m45s. Nomination is capped at `MAX_KEEP_ALIVE = 4` patterns.
+
+What this does NOT fix: `solve/j022-1bmhbfly-noland`, still 2.7e-4 short (bar was 1.446e-4 pre-#382). Its
+dual-chain seed trips no gate at all in either the old or the new build; the seed itself regressed
+(-531.70000 old, -531.69975 new) because `LevelSetAscent` rungs that were feasible on commons-math are not on
+`TrustRegionLp`, and the ILS closes only ~1e-4 of that in its 2 s budget. That is LP hug quality in the
+level-set ladder, a separate lever; the pin stays at `maxObjectiveGap: 5.0e-4`.


### PR DESCRIPTION
Closes #383

## What was actually wrong

Not the LP. `dualrecovery/loopmm-3jump-lands` has exactly one binding wall (`Z@61 <= -282.825`) and the last ten ticks sit at `phi = 90` in every candidate, so the whole objective reduces to "arrive at that wall with the most +Z velocity". The 5e-4 separating the landing trajectory from the missing one is a single **inertia-gate firing at tick 4**, where the Z velocity crosses zero during the momentum reversal:

| trajectory | `vz` carried into tick 4 | gate | `Z@71` |
| --- | --- | --- | --- |
| commons-math (landed) | +0.00505825 | survives, 5.8e-5 clear of 0.005 | -279.299912 |
| TrustRegionLp (missed) | -0.00101368 | zeroed, ticks 0-3 carry destroyed | -279.300466 |
| this PR | outside the band by construction | survives | **-279.299859** |

That is the "1 lucky hug in 320 calls". The old LP was not picking a better vertex; it was landing on the lucky side of a threshold nothing in the model was aiming at.

## The mechanism

The pattern enumeration only ever branched one way on that disjunction. `zx@k` / `zz@k` / `zx1@k` / `zz1@k` are the "velocity IS inside the band" branch, with `velocityWalls` pinning `|v| <= thr` so the folded dynamics stay self-consistent. Nothing generated the complementary "velocity is OUTSIDE the band, on this side" branch, and the `free` pattern relaxes the gate away entirely rather than enforcing it, so its relaxation cannot see the cliff at all.

- `JumpLinearModel.keepAliveWall` emits that complement: same coefficients as the `velocityWalls` pair, bound flipped a band width. Pinned algebraically by a new `InertiaFoldingTest` case (coefficients identical to the mirrored zeroing wall, bound exactly `2*thr` below it, slack reads the byte-exact velocity).
- `BoundPrunedRecovery.keepAlivePatterns` nominates it on the objective axis, in the objective-improving sign, at up to `MAX_KEEP_ALIVE = 4` ticks where a reference realization either trips the gate or reverses sign. On loopmm that is `keepZ@3+` and `keepZ@4+`; `keepZ@4+` is the one that lands.
- The reference is `rankYaws` when the closed form produced one, otherwise the margin-0 dual recovery of the free model (`freeDualSeed`).

Everything downstream is existing machinery: the pattern carries a normal root dual bound, `restore` already evaluates velocity walls in u-space, and `offer` still gates on the full byte-exact spec.

## Pins restored

- `solve/loopmm-tight-t39`: `shouldSolve` back to true. Lands in 35.5 s of its 120 s budget, deterministic over 3 runs.
- `solve/loopmm-tight-t39-fast`: `shouldSolve` back to true. 22.5 s of 90 s, deterministic over 3 runs.
- `dualrecovery/loopmm-3jump-lands`: `maxObjectiveGap` back to 0.0. Lands -279.2998588 blind, past the -279.3 pad.

## Not fixed, and why

`solve/j022-1bmhbfly-noland` stays at `maxObjectiveGap: 5.0e-4` (its pre-#382 bar was 1.446e-4). It is a different mechanism: its dual-chain seed trips no inertia gate at all in either build. The seed itself regressed with the LP swap (-531.70000 old, -531.69975 new) because `LevelSetAscent` rungs that were feasible on commons-math are not on `TrustRegionLp`, and the 2 s ILS closes only ~1e-4 of that. Measured, not assumed; the numbers are in `docs/research/dual-newton-hessian-handoff.md` section 6. Chasing it means touching SLP hug quality globally, which is a separate lever with a much wider blast radius.

## Gates

- `FreeStartSweepBench` 104/104 both before and after; 32.7 s -> 33.6 s wall; **zero solver-chain changes across all 104 rows** (the keep-alive branch only fires where the B&B runs and the gate actually bites).
- `:core:check -PslowTests` green, 3m01s (baseline ~2m45s).
- `ProblemsTest -PslowTests` run 3x, stable.

## Test plan

- [x] `./gradlew :core:check -PslowTests`
- [x] `FreeStartSweepBench` before/after diff
- [x] loopmm pins repeated 3x each for timing stability
- [x] in-game QA on one loader (core-only change)
