### PR TITLE
fix(playback): keep replay in sync when restarting near a fall-damage ruling

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
@@ -703,6 +703,10 @@ public final class Application {
         return boxController;
     }
 
+    public de.legoshi.parkourcalc.core.sim.Checkpoint getCheckpoint(int index) {
+        return runner.getCheckpoint(index);
+    }
+
     public Settings getSettings() {
         return settings;
     }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/PlaybackController.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/PlaybackController.java
@@ -169,6 +169,7 @@ public final class PlaybackController {
             }
         }
         firstTickOnGround = runner.firstTickOnGround();
+        bridge.beginReplayLockstep();
         bridge.teleport(pos, vel, yaw, carry);
         // Drop any user-held key so the warmup runs with an empty InputRow like the simulator does.
         bridge.releaseAllKeys();
@@ -193,11 +194,11 @@ public final class PlaybackController {
         bridge.applyEffects(firstSpeedAmp, firstJumpAmp);
         lastSpeedAmplifier = firstSpeedAmp;
         lastJumpBoostAmplifier = firstJumpAmp;
+        if (DebugFlags.PAIRED_DIAGNOSTICS) {
+            lastCapturedTick = -1;
+            bridge.beginPlaybackCapture();
+        }
         if (settings.pairedSimulation) {
-            if (DebugFlags.PAIRED_DIAGNOSTICS) {
-                lastCapturedTick = -1;
-                bridge.beginPlaybackCapture();
-            }
             runner.onReplayStart(from);
         }
         running = true;
@@ -219,10 +220,10 @@ public final class PlaybackController {
         if (bridge != null) {
             bridge.releaseAllKeys();
             bridge.applyEffects(0, 0);
+            if (DebugFlags.PAIRED_DIAGNOSTICS) {
+                bridge.finishPlaybackCapture();
+            }
             if (settings.pairedSimulation) {
-                if (DebugFlags.PAIRED_DIAGNOSTICS) {
-                    bridge.finishPlaybackCapture();
-                }
                 runner.onReplayEnd();
             }
         }
@@ -281,6 +282,7 @@ public final class PlaybackController {
         if (warmupRemaining > 0) {
             bridge.releaseAllKeys();
             warmupRemaining--;
+            bridge.releaseReplayLockstep();
             return;
         }
 
@@ -318,6 +320,7 @@ public final class PlaybackController {
         bridge.setPitch(currentTickPitch);
         tickEndNanos = System.nanoTime();
         nextTick++;
+        bridge.releaseReplayLockstep();
     }
 
     private static float clampPitch(float pitch) {
@@ -362,7 +365,7 @@ public final class PlaybackController {
             }
             bridge.dumpPlayerState(t);
         }
-        if (settings.pairedSimulation && DebugFlags.PAIRED_DIAGNOSTICS) {
+        if (DebugFlags.PAIRED_DIAGNOSTICS) {
             int t = nextTick - 1 - warmupRemaining;
             if (t >= 0 && t != lastCapturedTick) {
                 lastCapturedTick = t;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ports/PlaybackBridge.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ports/PlaybackBridge.java
@@ -49,6 +49,12 @@ public interface PlaybackBridge {
 
     default void dumpPlayerState(int tickIndex) {}
 
+    /** Park the server before the restart state is applied, so no ungated tick can advance it. */
+    default void beginReplayLockstep() {}
+
+    /** Let the parked server run again, once the first replayed row has been sent. */
+    default void releaseReplayLockstep() {}
+
     default void beginPlaybackCapture() {}
 
     default void capturePlaybackSample(int tickIndex) {}

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricParkourCalculator.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricParkourCalculator.java
@@ -193,6 +193,7 @@ public class FabricParkourCalculator implements ClientModInitializer {
                 playbackBridge.resetInputOverride();
                 playbackBridge.endGhostPlayback();
                 ReplayLockstep.disengage();
+                de.legoshi.parkourcalc.fabric.sim.paired.RestartSettle.clear();
                 wasPlaybackRunning = false;
             }
             return;
@@ -205,6 +206,7 @@ public class FabricParkourCalculator implements ClientModInitializer {
             playbackBridge.restorePlaybackInput(p);
             playbackBridge.endGhostPlayback();
             ReplayLockstep.disengage();
+            de.legoshi.parkourcalc.fabric.sim.paired.RestartSettle.clear();
         }
         wasPlaybackRunning = isRunning;
     }
@@ -276,6 +278,10 @@ public class FabricParkourCalculator implements ClientModInitializer {
 
     public static java.util.List<de.legoshi.parkourcalc.core.sim.TickState> simStates() {
         return application.getBoxController().getStates();
+    }
+
+    public static de.legoshi.parkourcalc.core.sim.Checkpoint simCheckpoint(int index) {
+        return application.getCheckpoint(index);
     }
 
     private static void handleInput(Minecraft client) {

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricPlaybackBridge.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricPlaybackBridge.java
@@ -44,7 +44,8 @@ public final class FabricPlaybackBridge implements PlaybackBridge {
     private GhostPlayerEntity ghost;
     private final java.util.List<ReplaySample> replaySamples = new java.util.ArrayList<>();
 
-    private record ReplaySample(int tick, Vec3 pos, Vec3 vel, boolean onGround) {
+    private record ReplaySample(int tick, Vec3 pos, Vec3 vel, boolean onGround, double fallDistance, float health,
+                                Vec3 serverVel, String serverDesc) {
     }
 
     InputRow getCurrentRow() {
@@ -123,6 +124,29 @@ public final class FabricPlaybackBridge implements PlaybackBridge {
         mc.setCameraEntity(g);
     }
 
+    private ServerPlayer serverSideSelf() {
+        if (ghostMode) return null;
+        Minecraft mc = Minecraft.getInstance();
+        LocalPlayer client = mc.player;
+        IntegratedServer server = mc.getSingleplayerServer();
+        if (client == null || server == null) return null;
+        return server.getPlayerList().getPlayer(client.getUUID());
+    }
+
+    @Override
+    public void beginReplayLockstep() {
+        if (!FabricParkourCalculator.getSettings().lockstepReplay) return;
+        if (!isSingleplayer()) return;
+        IntegratedServer server = Minecraft.getInstance().getSingleplayerServer();
+        if (server == null) return;
+        ReplayLockstep.engageForStart(server);
+    }
+
+    @Override
+    public void releaseReplayLockstep() {
+        ReplayLockstep.releaseStartArm();
+    }
+
     @Override
     public void beginPlaybackCapture() {
         replaySamples.clear();
@@ -130,12 +154,73 @@ public final class FabricPlaybackBridge implements PlaybackBridge {
 
     @Override
     public void capturePlaybackSample(int tickIndex) {
-        Entity subject = ghostMode ? ghost : Minecraft.getInstance().player;
+        net.minecraft.world.entity.player.Player subject = ghostMode ? ghost : Minecraft.getInstance().player;
         if (subject == null) return;
-        replaySamples.add(new ReplaySample(tickIndex, subject.position(), subject.getDeltaMovement(), subject.onGround()));
+        ServerPlayer sp = serverSideSelf();
+        replaySamples.add(new ReplaySample(tickIndex, subject.position(), subject.getDeltaMovement(),
+                subject.onGround(), subject.fallDistance, subject.getHealth(),
+                sp == null ? Vec3.ZERO : sp.getDeltaMovement(),
+                sp == null ? "realSrv=unavailable" : describeRealServer(sp)));
         if (de.legoshi.parkourcalc.core.DebugFlags.PAIRED_DIAGNOSTICS && tickIndex <= 4) {
             System.out.println("[PC-NET] tick T" + (tickIndex + 1)
-                    + " pos=" + subject.position() + " vel=" + subject.getDeltaMovement());
+                    + " pos=" + subject.position() + " vel=" + subject.getDeltaMovement()
+                    + " fall=" + subject.fallDistance + " hp=" + subject.getHealth());
+        }
+    }
+
+    private static String describeRealServer(ServerPlayer sp) {
+        Vec3 v = sp.getDeltaMovement();
+        net.minecraft.server.network.ServerGamePacketListenerImpl conn = sp.connection;
+        return "realSrv=" + v.x + "," + v.y + "," + v.z
+                + " fall=" + sp.fallDistance
+                + " g=" + sp.onGround()
+                + " vCollB=" + sp.verticalCollisionBelow
+                + " spr=" + sp.isSprinting()
+                + " sneak=" + sp.isShiftKeyDown()
+                + " hurtMarked=" + sp.hurtMarked
+                + " invuln=" + sp.invulnerableTime
+                + " hurtTime=" + sp.hurtTime
+                + " fire=" + sp.getRemainingFireTicks()
+                + " in=" + de.legoshi.parkourcalc.fabric.sim.paired.PairedServerSim.describeInput(sp.getLastClientInput())
+                + " tp=" + (conn.awaitingPositionFromClient != null)
+                + " tpId=" + conn.awaitingTeleport
+                + " recv=" + conn.receivedMovePacketCount + "/" + conn.knownMovePacketCount
+                + " aboveG=" + conn.aboveGroundTickCount
+                + " lastGood=" + conn.lastGoodX + "," + conn.lastGoodY + "," + conn.lastGoodZ;
+    }
+
+    private static void printAccumulatorLine(ReplaySample sample) {
+        System.out.println("[PC-ACC] T" + (sample.tick() + 1)
+                + " " + sample.serverDesc()
+                + " | " + de.legoshi.parkourcalc.fabric.sim.paired.PairedCheckpoint.describeServer(
+                        FabricParkourCalculator.simCheckpoint(sample.tick() + 1)));
+    }
+
+    private static boolean matchesPair(Vec3 real, int checkpointIndex) {
+        Vec3 pair = de.legoshi.parkourcalc.fabric.sim.paired.PairedCheckpoint.serverVelocity(
+                FabricParkourCalculator.simCheckpoint(checkpointIndex));
+        return pair == null || real.distanceToSqr(pair) <= 1.0e-18;
+    }
+
+    private void reportAccumulator() {
+        int first = -1;
+        for (ReplaySample sample : replaySamples) {
+            if (matchesPair(sample.serverVel(), sample.tick() + 1)
+                    || matchesPair(sample.serverVel(), sample.tick())) {
+                continue;
+            }
+            first = sample.tick();
+            break;
+        }
+        if (first < 0) {
+            System.out.println("[PC-ACC] server accumulator matches the pair across " + replaySamples.size()
+                    + " ticks (phase-tolerant)");
+            return;
+        }
+        System.out.println("[PC-ACC] server accumulator first differs at T" + (first + 1));
+        for (ReplaySample sample : replaySamples) {
+            if (sample.tick() < first - 2 || sample.tick() > first + 6) continue;
+            printAccumulatorLine(sample);
         }
     }
 
@@ -155,6 +240,7 @@ public final class FabricPlaybackBridge implements PlaybackBridge {
                 break;
             }
         }
+        reportAccumulator();
         if (firstDiverged < 0) {
             System.out.println("[PC-REPLAY] no divergence across " + replaySamples.size() + " replayed ticks (eps 1e-6)");
             replaySamples.clear();
@@ -177,7 +263,10 @@ public final class FabricPlaybackBridge implements PlaybackBridge {
                     + " real=" + sample.pos().x + "," + sample.pos().y + "," + sample.pos().z
                     + " v=" + sample.vel().x + "," + sample.vel().y + "," + sample.vel().z
                     + " g=" + sample.onGround()
+                    + " fall=" + sample.fallDistance()
+                    + " hp=" + sample.health()
                     + " | " + simPart);
+            printAccumulatorLine(sample);
         }
         replaySamples.clear();
     }
@@ -236,25 +325,37 @@ public final class FabricPlaybackBridge implements PlaybackBridge {
         IntegratedServer server = mc.getSingleplayerServer();
         if (server == null) return;
         UUID uuid = client.getUUID();
+        Vec3 pendingStomp = de.legoshi.parkourcalc.fabric.sim.paired.PairedCheckpoint.pendingVelocity(carry);
+        Vec3 startVel = pendingStomp != null ? pendingStomp : new Vec3(vel.x, vel.y, vel.z);
+        if (pendingStomp != null && de.legoshi.parkourcalc.core.DebugFlags.PAIRED_DIAGNOSTICS) {
+            System.out.println("[PC-NET] restart applied pending velocity flush " + pendingStomp);
+        }
         server.execute(() -> {
-            ServerPlayer sp = server.getPlayerList().getPlayer(uuid);
-            if (sp == null) return;
-            // EntityPosition overload carries velocity in the teleport packet itself.
-            // The 5-arg overload zeroes velocity and the followup setVelocity+velocityModified
-            // path fires a SetEntityMotion packet that arrives ~1 tick late and stomps the
-            // player mid-playback.
-            sp.connection.teleport(
-                new PositionMoveRotation(new Vec3(pos.x, pos.y, pos.z), new Vec3(vel.x, vel.y, vel.z), yaw, sp.getXRot()),
-                Collections.emptySet()
-            );
-            de.legoshi.parkourcalc.fabric.sim.paired.PairedCheckpoint.applyRestartState(sp, carry);
+            try {
+                ServerPlayer sp = server.getPlayerList().getPlayer(uuid);
+                if (sp == null) return;
+                // EntityPosition overload carries velocity in the teleport packet itself.
+                // The 5-arg overload zeroes velocity and the followup setVelocity+velocityModified
+                // path fires a SetEntityMotion packet that arrives ~1 tick late and stomps the
+                // player mid-playback.
+                sp.connection.teleport(
+                    new PositionMoveRotation(new Vec3(pos.x, pos.y, pos.z), startVel, yaw, sp.getXRot()),
+                    Collections.emptySet()
+                );
+                de.legoshi.parkourcalc.fabric.sim.paired.PairedCheckpoint.applyRestartState(sp, carry);
+                if (carry instanceof de.legoshi.parkourcalc.fabric.sim.paired.PairedCheckpoint) {
+                    de.legoshi.parkourcalc.fabric.sim.paired.RestartSettle.arm(uuid, carry);
+                }
+            } finally {
+                ReplayLockstep.onRestartHopComplete();
+            }
         });
         client.absSnapTo(pos.x, pos.y, pos.z, yaw, client.getXRot());
         client.setYBodyRot(yaw);
         client.yBodyRotO = yaw;
         client.setYHeadRot(yaw);
         client.yHeadRotO = yaw;
-        client.setDeltaMovement(vel.x, vel.y, vel.z);
+        client.setDeltaMovement(startVel);
         if (carry != null) {
             de.legoshi.parkourcalc.fabric.sim.SimulatorEntity.applyCheckpoint(client, carry);
         } else {
@@ -280,6 +381,8 @@ public final class FabricPlaybackBridge implements PlaybackBridge {
         if (de.legoshi.parkourcalc.core.DebugFlags.PAIRED_DIAGNOSTICS) {
             System.out.println("[PC-NET] teleport snap pos=" + pos.x + "," + pos.y + "," + pos.z
                     + " vel=" + vel.x + "," + vel.y + "," + vel.z
+                    + " carry=" + (carry == null ? "none" : carry.getClass().getSimpleName())
+                    + " clientFall=" + client.fallDistance + " clientOnGround=" + client.onGround()
                     + " clientFire=" + client.getRemainingFireTicks() + " sharedFlagFire=" + client.isOnFire());
         }
     }

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/ReplayLockstep.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/ReplayLockstep.java
@@ -19,23 +19,42 @@ public final class ReplayLockstep {
     private static final long GATE_HORIZON_NANOS = 50_000_000L;
 
     private static volatile MinecraftServer engagedServer;
+    private static volatile boolean startArmed;
+    private static volatile long startHopTarget;
     private static long pendingTarget = -1L;
     private static final AtomicInteger permits = new AtomicInteger();
     private static final AtomicLong completedTicks = new AtomicLong();
     private static final AtomicLong lastPongId = new AtomicLong(Long.MIN_VALUE);
     private static final AtomicLong pingIds = new AtomicLong(PING_ID_BASE);
+    private static final AtomicLong restartHopSerial = new AtomicLong();
 
     private ReplayLockstep() {
     }
 
     public static void engage(MinecraftServer server) {
+        if (engagedServer == server) return;
         permits.set(0);
         pendingTarget = -1L;
         engagedServer = server;
     }
 
+    public static void engageForStart(MinecraftServer server) {
+        startHopTarget = restartHopSerial.get() + 1;
+        startArmed = true;
+        engage(server);
+    }
+
+    public static void releaseStartArm() {
+        startArmed = false;
+    }
+
+    public static void onRestartHopComplete() {
+        restartHopSerial.incrementAndGet();
+    }
+
     public static void disengage() {
         engagedServer = null;
+        startArmed = false;
         permits.set(0);
         pendingTarget = -1L;
     }
@@ -85,6 +104,7 @@ public final class ReplayLockstep {
     public static void clientBarrierPostTick() {
         MinecraftServer server = engagedServer;
         if (server == null) return;
+        if (startArmed) return;
         Minecraft mc = Minecraft.getInstance();
         if (mc.isPaused()) {
             permits.set(0);
@@ -105,8 +125,12 @@ public final class ReplayLockstep {
     public static void clientBarrierPreTick() {
         MinecraftServer server = engagedServer;
         if (server == null) return;
-        if (pendingTarget < 0L) return;
         Minecraft mc = Minecraft.getInstance();
+        if (startArmed) {
+            startWindowBarrier(mc);
+            return;
+        }
+        if (pendingTarget < 0L) return;
         if (mc.isPaused()) return;
         ClientPacketListener connection = mc.getConnection();
         if (connection == null) {
@@ -118,6 +142,31 @@ public final class ReplayLockstep {
         mc.packetProcessor().processQueuedPackets();
         mc.runAllTasks();
         pendingTarget = -1L;
+    }
+
+    private static void startWindowBarrier(Minecraft mc) {
+        if (mc.isPaused()) return;
+        ClientPacketListener connection = mc.getConnection();
+        if (connection == null) {
+            disengage();
+            return;
+        }
+        if (!awaitRestartHop()) return;
+        if (!awaitPong(connection)) return;
+        mc.packetProcessor().processQueuedPackets();
+        mc.runAllTasks();
+    }
+
+    private static boolean awaitRestartHop() {
+        long start = System.nanoTime();
+        while (restartHopSerial.get() < startHopTarget) {
+            if (engagedServer == null) return false;
+            if (!spinPause(start)) {
+                abort("restart teleport wait timed out");
+                return false;
+            }
+        }
+        return true;
     }
 
     private static boolean consumePermit() {

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/mixin/RestartSettleMixin.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/mixin/RestartSettleMixin.java
@@ -1,0 +1,18 @@
+package de.legoshi.parkourcalc.fabric.mixin;
+
+import de.legoshi.parkourcalc.fabric.sim.paired.RestartSettle;
+import net.minecraft.network.protocol.game.ServerboundMovePlayerPacket;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ServerGamePacketListenerImpl.class)
+public abstract class RestartSettleMixin {
+
+    @Inject(method = "handleMovePlayer", at = @At("RETURN"))
+    private void pkc$settleAfterMove(ServerboundMovePlayerPacket packet, CallbackInfo ci) {
+        RestartSettle.afterMovePlayer((ServerGamePacketListenerImpl) (Object) this);
+    }
+}

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/sim/paired/PairedCheckpoint.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/sim/paired/PairedCheckpoint.java
@@ -20,8 +20,47 @@ public final class PairedCheckpoint implements Checkpoint {
         return null;
     }
 
+    public static net.minecraft.world.phys.Vec3 pendingVelocity(Checkpoint checkpoint) {
+        if (!(checkpoint instanceof PairedCheckpoint paired)) return null;
+        java.util.List<net.minecraft.network.protocol.Packet<?>> pending = paired.server.pendingClientbound;
+        if (pending == null) return null;
+        for (net.minecraft.network.protocol.Packet<?> p : pending) {
+            if (p instanceof net.minecraft.network.protocol.game.ClientboundSetEntityMotionPacket motion) {
+                return PairedServerSim.quantizeVelocity(motion.movement());
+            }
+        }
+        return null;
+    }
+
+    public static net.minecraft.world.phys.Vec3 serverVelocity(Checkpoint checkpoint) {
+        if (!(checkpoint instanceof PairedCheckpoint paired)) return null;
+        return new net.minecraft.world.phys.Vec3(paired.server.velX, paired.server.velY, paired.server.velZ);
+    }
+
+    public static String describeServer(Checkpoint checkpoint) {
+        if (!(checkpoint instanceof PairedCheckpoint paired)) return "pairSrv=unavailable";
+        PairedServerSim.ServerCheckpoint s = paired.server;
+        return "pairSrv=" + s.velX + "," + s.velY + "," + s.velZ
+                + " fall=" + s.fallDistance
+                + " g=" + s.onGround
+                + " vCollB=" + s.verticalCollisionBelow
+                + " spr=" + s.sprinting
+                + " sneak=" + s.shiftKeyDown
+                + " hurtMarked=" + s.hurtMarked
+                + " invuln=" + s.invulnerableTime
+                + " hurtTime=" + s.hurtTime
+                + " fire=" + s.remainingFireTicks
+                + " in=" + PairedServerSim.describeInput(s.serverLastClientInput)
+                + " tp=" + (s.awaitingPositionFromClient != null)
+                + " tpId=" + s.awaitingTeleport
+                + " recv=" + s.receivedMovePacketCount + "/" + s.knownMovePacketCount
+                + " aboveG=" + s.aboveGroundTickCount
+                + " lastGood=" + s.lastGoodX + "," + s.lastGoodY + "," + s.lastGoodZ;
+    }
+
     public static void applyRestartState(ServerPlayer sp, Checkpoint checkpoint) {
         sp.hurtMarked = false;
+        net.minecraft.world.phys.Vec3 beforeMotion = sp.getDeltaMovement();
         if (checkpoint instanceof PairedCheckpoint paired) {
             sp.setRemainingFireTicks(paired.server.remainingFireTicks);
             sp.invulnerableTime = paired.server.invulnerableTime;
@@ -29,6 +68,12 @@ public final class PairedCheckpoint implements Checkpoint {
             sp.fallDistance = paired.server.fallDistance;
             sp.setOnGround(paired.server.onGround);
             sp.verticalCollisionBelow = paired.server.verticalCollisionBelow;
+            sp.setDeltaMovement(paired.server.velX, paired.server.velY, paired.server.velZ);
+            sp.setSprinting(paired.server.sprinting);
+            sp.setShiftKeyDown(paired.server.shiftKeyDown);
+            if (paired.server.serverLastClientInput != null) {
+                sp.setLastClientInput(paired.server.serverLastClientInput);
+            }
         } else {
             sp.clearFire();
             sp.invulnerableTime = 0;
@@ -40,6 +85,7 @@ public final class PairedCheckpoint implements Checkpoint {
                     + " invuln=" + sp.invulnerableTime
                     + " fallDistance=" + sp.fallDistance
                     + " serverMotion=" + sp.getDeltaMovement()
+                    + " wasServerMotion=" + beforeMotion
                     + " paired=" + (checkpoint instanceof PairedCheckpoint));
         }
     }

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/sim/paired/PairedServerSim.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/sim/paired/PairedServerSim.java
@@ -348,6 +348,14 @@ public final class PairedServerSim {
         }
     }
 
+    public static String describeInput(Input in) {
+        if (in == null) return "null";
+        return (in.forward() ? "W" : "-") + (in.backward() ? "S" : "-")
+                + (in.left() ? "A" : "-") + (in.right() ? "D" : "-")
+                + (in.jump() ? "J" : "-") + (in.shift() ? "N" : "-")
+                + (in.sprint() ? "R" : "-");
+    }
+
     private void reportReplayMismatch(SimulatorEntity e) {
         if (!DebugFlags.PAIRED_DIAGNOSTICS) return;
         double dx = sp.getX() - e.getX();
@@ -368,12 +376,15 @@ public final class PairedServerSim {
             sp.hurtMarked = false;
             pendingClientbound.add(new ClientboundSetEntityMotionPacket(sp));
             if (DebugFlags.PAIRED_DIAGNOSTICS) {
-                System.out.println("[PC-PAIR] T" + (tickIndex + 1) + " velocity queued " + formatVec(sp.getDeltaMovement()));
+                Vec3 raw = sp.getDeltaMovement();
+                System.out.println("[PC-PAIR] T" + (tickIndex + 1) + " velocity queued " + formatVec(raw)
+                        + " raw=" + raw.x + "," + raw.y + "," + raw.z
+                        + " quantized=" + quantizeVelocity(raw));
             }
         }
     }
 
-    private static Vec3 quantizeVelocity(Vec3 velocity) {
+    static Vec3 quantizeVelocity(Vec3 velocity) {
         ByteBuf buf = Unpooled.buffer();
         try {
             LpVec3.write(buf, velocity);
@@ -495,6 +506,7 @@ public final class PairedServerSim {
         c.lastOnGround = lastOnGround;
         c.lastHorizontalCollision = lastHorizontalCollision;
         c.lastSentInput = lastSentInput;
+        c.serverLastClientInput = sp.getLastClientInput();
         c.lastSprinting = lastSprinting;
         c.prevRightClick = prevRightClick;
         c.rightClickDelay = rightClickDelay;
@@ -551,6 +563,7 @@ public final class PairedServerSim {
         lastOnGround = c.lastOnGround;
         lastHorizontalCollision = c.lastHorizontalCollision;
         lastSentInput = c.lastSentInput;
+        sp.setLastClientInput(c.serverLastClientInput);
         lastSprinting = c.lastSprinting;
         prevRightClick = c.prevRightClick;
         rightClickDelay = c.rightClickDelay;
@@ -605,6 +618,7 @@ public final class PairedServerSim {
         boolean lastOnGround;
         boolean lastHorizontalCollision;
         Input lastSentInput;
+        Input serverLastClientInput;
         boolean lastSprinting;
         boolean prevRightClick;
         int rightClickDelay;

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/sim/paired/RestartSettle.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/sim/paired/RestartSettle.java
@@ -1,0 +1,46 @@
+package de.legoshi.parkourcalc.fabric.sim.paired;
+
+import de.legoshi.parkourcalc.core.DebugFlags;
+import de.legoshi.parkourcalc.core.sim.Checkpoint;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+
+import java.util.UUID;
+
+public final class RestartSettle {
+
+    private static volatile UUID pendingPlayer;
+    private static volatile Checkpoint pendingCarry;
+
+    private RestartSettle() {
+    }
+
+    public static void arm(UUID playerId, Checkpoint carry) {
+        pendingCarry = carry;
+        pendingPlayer = playerId;
+    }
+
+    public static void clear() {
+        pendingPlayer = null;
+        pendingCarry = null;
+    }
+
+    public static void afterMovePlayer(ServerGamePacketListenerImpl handler) {
+        UUID pending = pendingPlayer;
+        if (pending == null) return;
+        ServerPlayer sp = handler.player;
+        if (sp == null || !pending.equals(sp.getUUID())) return;
+        if (handler.awaitingPositionFromClient != null) return;
+        Checkpoint carry = pendingCarry;
+        clear();
+        if (carry == null) return;
+        boolean groundBefore = sp.onGround();
+        PairedCheckpoint.applyRestartState(sp, carry);
+        if (DebugFlags.PAIRED_DIAGNOSTICS) {
+            System.out.println("[PC-NET] restart settle post-confirm onGround " + groundBefore
+                    + " -> " + sp.onGround()
+                    + " vel=" + sp.getDeltaMovement()
+                    + " fall=" + sp.fallDistance);
+        }
+    }
+}

--- a/loader-fabric/src/client/resources/parkourcalculator.client.mixins.json
+++ b/loader-fabric/src/client/resources/parkourcalculator.client.mixins.json
@@ -21,6 +21,7 @@
     "PairedChunkTrackingMixin",
     "PairedSimSuppressMixin",
     "PlayerAccessor",
+    "RestartSettleMixin",
     "WorldJournalMixin"
   ],
   "injectors": {

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8ParkourCalculator.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8ParkourCalculator.java
@@ -58,6 +58,10 @@ public class Forge8ParkourCalculator {
                 ? APP.getBoxController().getStates()
                 : java.util.Collections.<de.legoshi.parkourcalc.core.sim.TickState>emptyList();
     }
+
+    static de.legoshi.parkourcalc.core.sim.Checkpoint simCheckpoint(int index) {
+        return APP != null ? APP.getCheckpoint(index) : null;
+    }
     private final Lwjgl2ImGuiHost imguiHost = new Lwjgl2ImGuiHost(
             application.getOverlayManager(),
             application.getSettings(),

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8PlaybackBridge.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8PlaybackBridge.java
@@ -78,6 +78,19 @@ public final class Forge8PlaybackBridge implements PlaybackBridge {
     }
 
     @Override
+    public void beginReplayLockstep() {
+        de.legoshi.parkourcalc.core.ui.Settings s = Forge8ParkourCalculator.settings();
+        if (s == null || !s.lockstepReplay) return;
+        if (!isSingleplayer()) return;
+        ReplayLockstep.engageForStart();
+    }
+
+    @Override
+    public void releaseReplayLockstep() {
+        ReplayLockstep.releaseStartArm();
+    }
+
+    @Override
     public void teleport(Vec3dCore pos, Vec3dCore vel, float yaw, de.legoshi.parkourcalc.core.sim.Checkpoint carry) {
         if (!isSingleplayer()) {
             beginGhostPlayback(pos, vel, yaw, carry);
@@ -113,6 +126,16 @@ public final class Forge8PlaybackBridge implements PlaybackBridge {
         client.motionX = vel.x;
         client.motionY = vel.y;
         client.motionZ = vel.z;
+        double[] pendingStomp = de.legoshi.parkourcalc.forge8.sim.paired.PairedCheckpoint.pendingVelocity(carry);
+        if (pendingStomp != null) {
+            client.motionX = pendingStomp[0];
+            client.motionY = pendingStomp[1];
+            client.motionZ = pendingStomp[2];
+            if (de.legoshi.parkourcalc.core.DebugFlags.PAIRED_DIAGNOSTICS) {
+                System.out.println("[PC-NET] restart applied pending velocity flush "
+                        + pendingStomp[0] + "," + pendingStomp[1] + "," + pendingStomp[2]);
+            }
+        }
         if (carry != null) {
             de.legoshi.parkourcalc.forge8.sim.SimulatorEntity.applyCheckpoint(client, carry);
         } else {
@@ -134,6 +157,12 @@ public final class Forge8PlaybackBridge implements PlaybackBridge {
         client.prevRenderArmYaw = yaw;
         client.renderArmPitch = client.rotationPitch;
         client.prevRenderArmPitch = client.rotationPitch;
+        if (de.legoshi.parkourcalc.core.DebugFlags.PAIRED_DIAGNOSTICS) {
+            System.out.println("[PC-NET] teleport snap pos=" + pos.x + "," + pos.y + "," + pos.z
+                    + " vel=" + vel.x + "," + vel.y + "," + vel.z
+                    + " carry=" + (carry == null ? "none" : carry.getClass().getSimpleName())
+                    + " clientFall=" + client.fallDistance + " clientOnGround=" + client.onGround);
+        }
     }
 
     private void beginGhostPlayback(Vec3dCore pos, Vec3dCore vel, float yaw, de.legoshi.parkourcalc.core.sim.Checkpoint carry) {
@@ -381,8 +410,13 @@ public final class Forge8PlaybackBridge implements PlaybackBridge {
         final double vy;
         final double vz;
         final boolean onGround;
+        final float fallDistance;
+        final float health;
+        final double[] serverVel;
+        final String serverDesc;
 
-        ReplaySample(int tick, double x, double y, double z, double vx, double vy, double vz, boolean onGround) {
+        ReplaySample(int tick, double x, double y, double z, double vx, double vy, double vz, boolean onGround,
+                     float fallDistance, float health, double[] serverVel, String serverDesc) {
             this.tick = tick;
             this.x = x;
             this.y = y;
@@ -391,10 +425,45 @@ public final class Forge8PlaybackBridge implements PlaybackBridge {
             this.vy = vy;
             this.vz = vz;
             this.onGround = onGround;
+            this.fallDistance = fallDistance;
+            this.health = health;
+            this.serverVel = serverVel;
+            this.serverDesc = serverDesc;
         }
     }
 
     private final java.util.List<ReplaySample> replaySamples = new java.util.ArrayList<ReplaySample>();
+
+    private EntityPlayerMP serverSideSelf() {
+        if (ghostMode) return null;
+        Minecraft mc = Minecraft.getMinecraft();
+        EntityPlayerSP client = mc.thePlayer;
+        IntegratedServer server = mc.getIntegratedServer();
+        if (client == null || server == null) return null;
+        return server.getConfigurationManager().getPlayerByUUID(client.getUniqueID());
+    }
+
+    private static String describeRealServer(EntityPlayerMP sp) {
+        String handlerPart = " handler=unavailable";
+        if (sp.playerNetServerHandler != null) {
+            handlerPart = " hasMoved=" + sp.playerNetServerHandler.hasMoved
+                    + " floating=" + sp.playerNetServerHandler.floatingTickCount
+                    + " lastPos=" + sp.playerNetServerHandler.lastPosX
+                    + "," + sp.playerNetServerHandler.lastPosY
+                    + "," + sp.playerNetServerHandler.lastPosZ;
+        }
+        return "realSrv=" + sp.motionX + "," + sp.motionY + "," + sp.motionZ
+                + " fall=" + sp.fallDistance
+                + " g=" + sp.onGround
+                + " spr=" + sp.isSprinting()
+                + " sneak=" + sp.isSneaking()
+                + " velChanged=" + sp.velocityChanged
+                + " hurtResist=" + sp.hurtResistantTime
+                + " hurtTime=" + sp.hurtTime
+                + " lastDmg=" + sp.lastDamage
+                + " fire=" + sp.fire
+                + handlerPart;
+    }
 
     @Override
     public void beginPlaybackCapture() {
@@ -405,8 +474,51 @@ public final class Forge8PlaybackBridge implements PlaybackBridge {
     public void capturePlaybackSample(int tickIndex) {
         net.minecraft.entity.player.EntityPlayer subject = ghostMode ? ghost : Minecraft.getMinecraft().thePlayer;
         if (subject == null) return;
+        EntityPlayerMP sp = serverSideSelf();
         replaySamples.add(new ReplaySample(tickIndex, subject.posX, subject.posY, subject.posZ,
-                subject.motionX, subject.motionY, subject.motionZ, subject.onGround));
+                subject.motionX, subject.motionY, subject.motionZ, subject.onGround,
+                subject.fallDistance, subject.getHealth(),
+                sp == null ? null : new double[]{sp.motionX, sp.motionY, sp.motionZ},
+                sp == null ? "realSrv=unavailable" : describeRealServer(sp)));
+    }
+
+    private static void printAccumulatorLine(ReplaySample sample) {
+        System.out.println("[PC-ACC] T" + (sample.tick + 1)
+                + " " + sample.serverDesc
+                + " | " + de.legoshi.parkourcalc.forge8.sim.paired.PairedCheckpoint.describeServer(
+                        Forge8ParkourCalculator.simCheckpoint(sample.tick + 1)));
+    }
+
+    private static boolean velMatches(double[] real, de.legoshi.parkourcalc.core.sim.Checkpoint pair) {
+        double[] p = de.legoshi.parkourcalc.forge8.sim.paired.PairedCheckpoint.serverVelocity(pair);
+        if (p == null) return true;
+        double dx = real[0] - p[0];
+        double dy = real[1] - p[1];
+        double dz = real[2] - p[2];
+        return dx * dx + dy * dy + dz * dz <= 1.0e-18;
+    }
+
+    private void reportAccumulator() {
+        int first = -1;
+        for (ReplaySample sample : replaySamples) {
+            if (sample.serverVel == null) continue;
+            if (velMatches(sample.serverVel, Forge8ParkourCalculator.simCheckpoint(sample.tick + 1))
+                    || velMatches(sample.serverVel, Forge8ParkourCalculator.simCheckpoint(sample.tick))) {
+                continue;
+            }
+            first = sample.tick;
+            break;
+        }
+        if (first < 0) {
+            System.out.println("[PC-ACC] server accumulator matches the pair across " + replaySamples.size()
+                    + " ticks (phase-tolerant)");
+            return;
+        }
+        System.out.println("[PC-ACC] server accumulator first differs at T" + (first + 1));
+        for (ReplaySample sample : replaySamples) {
+            if (sample.tick < first - 2 || sample.tick > first + 6) continue;
+            printAccumulatorLine(sample);
+        }
     }
 
     @Override
@@ -425,6 +537,7 @@ public final class Forge8PlaybackBridge implements PlaybackBridge {
                 break;
             }
         }
+        reportAccumulator();
         if (firstDiverged < 0) {
             System.out.println("[PC-REPLAY] no divergence across " + replaySamples.size() + " replayed ticks (eps 1e-6)");
             replaySamples.clear();
@@ -447,7 +560,10 @@ public final class Forge8PlaybackBridge implements PlaybackBridge {
                     + " real=" + sample.x + "," + sample.y + "," + sample.z
                     + " v=" + sample.vx + "," + sample.vy + "," + sample.vz
                     + " g=" + sample.onGround
+                    + " fall=" + sample.fallDistance
+                    + " hp=" + sample.health
                     + " | " + simPart);
+            printAccumulatorLine(sample);
         }
         replaySamples.clear();
     }

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/ReplayLockstep.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/ReplayLockstep.java
@@ -31,6 +31,7 @@ public final class ReplayLockstep {
     private static final String PIPELINE_NAME = "pkc_lockstep";
 
     private static volatile boolean engaged;
+    private static volatile boolean startArmed;
     private static volatile boolean serverSideReady;
     private static volatile boolean serverboundMarkerSeen;
     private static volatile boolean clientboundMarkerSeen;
@@ -69,9 +70,19 @@ public final class ReplayLockstep {
         engaged = true;
     }
 
+    public static void engageForStart() {
+        engage();
+        startArmed = true;
+    }
+
+    public static void releaseStartArm() {
+        startArmed = false;
+    }
+
     public static void disengage() {
         if (!engaged && clientChannel == null && serverChannel == null) return;
         engaged = false;
+        startArmed = false;
         serverSideReady = false;
         permits.set(0);
         pendingTarget = -1L;
@@ -116,6 +127,7 @@ public final class ReplayLockstep {
             pendingTarget = -1L;
             return;
         }
+        if (startArmed) return;
         if (!serverSideReady) return;
         if (pendingTarget >= 0L) return;
         NetHandlerPlayClient nh = mc.getNetHandler();
@@ -142,7 +154,7 @@ public final class ReplayLockstep {
         if (server == null) return;
         if (!serverSideReady) {
             injectServerSide(server);
-            return;
+            if (!serverSideReady) return;
         }
         while (engaged && server.isServerRunning()) {
             if (permits.get() > 0) {

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/sim/paired/PairedCheckpoint.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/sim/paired/PairedCheckpoint.java
@@ -1,5 +1,6 @@
 package de.legoshi.parkourcalc.forge8.sim.paired;
 
+import de.legoshi.parkourcalc.core.DebugFlags;
 import de.legoshi.parkourcalc.core.sim.Checkpoint;
 import de.legoshi.parkourcalc.forge8.sim.SimulatorEntity;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -20,6 +21,44 @@ public final class PairedCheckpoint implements Checkpoint {
         return null;
     }
 
+    public static double[] serverVelocity(Checkpoint checkpoint) {
+        if (!(checkpoint instanceof PairedCheckpoint)) return null;
+        PairedServerSim.ServerCheckpoint s = ((PairedCheckpoint) checkpoint).server;
+        return new double[]{s.velX, s.velY, s.velZ};
+    }
+
+    public static String describeServer(Checkpoint checkpoint) {
+        if (!(checkpoint instanceof PairedCheckpoint)) return "pairSrv=unavailable";
+        PairedServerSim.ServerCheckpoint s = ((PairedCheckpoint) checkpoint).server;
+        return "pairSrv=" + s.velX + "," + s.velY + "," + s.velZ
+                + " fall=" + s.fallDistance
+                + " g=" + s.onGround
+                + " spr=" + s.sprinting
+                + " sneak=" + s.sneaking
+                + " velChanged=" + s.velocityChanged
+                + " hurtResist=" + s.hurtResistantTime
+                + " hurtTime=" + s.hurtTime
+                + " lastDmg=" + s.lastDamage
+                + " fire=" + s.fire
+                + " hasMoved=" + s.hasMoved
+                + " floating=" + s.floatingTickCount
+                + " lastPos=" + s.lastPosX + "," + s.lastPosY + "," + s.lastPosZ;
+    }
+
+    public static double[] pendingVelocity(Checkpoint checkpoint) {
+        if (!(checkpoint instanceof PairedCheckpoint)) return null;
+        java.util.List<net.minecraft.network.Packet> pending = ((PairedCheckpoint) checkpoint).server.pendingClientbound;
+        if (pending == null) return null;
+        for (net.minecraft.network.Packet p : pending) {
+            if (p instanceof net.minecraft.network.play.server.S12PacketEntityVelocity) {
+                net.minecraft.network.play.server.S12PacketEntityVelocity v =
+                        (net.minecraft.network.play.server.S12PacketEntityVelocity) p;
+                return new double[]{v.getMotionX() / 8000.0, v.getMotionY() / 8000.0, v.getMotionZ() / 8000.0};
+            }
+        }
+        return null;
+    }
+
     public static void applyRestartState(EntityPlayerMP sp, Checkpoint checkpoint) {
         sp.velocityChanged = false;
         sp.respawnInvulnerabilityTicks = 0;
@@ -28,11 +67,30 @@ public final class PairedCheckpoint implements Checkpoint {
             sp.fire = c.fire;
             sp.hurtResistantTime = c.hurtResistantTime;
             sp.hurtTime = c.hurtTime;
+            sp.lastDamage = c.lastDamage;
+            sp.motionX = c.velX;
+            sp.motionY = c.velY;
+            sp.motionZ = c.velZ;
+            sp.fallDistance = c.fallDistance;
+            sp.onGround = c.onGround;
+            sp.setSprinting(c.sprinting);
+            sp.setSneaking(c.sneaking);
+            if (sp.playerNetServerHandler != null) {
+                sp.playerNetServerHandler.floatingTickCount = c.floatingTickCount;
+            }
         } else {
             sp.extinguish();
             sp.hurtResistantTime = 0;
             sp.hurtTime = 0;
             sp.fallDistance = 0.0F;
+        }
+        if (DebugFlags.PAIRED_DIAGNOSTICS) {
+            System.out.println("[PC-NET] restart state fire=" + sp.fire
+                    + " hurtResist=" + sp.hurtResistantTime
+                    + " fallDistance=" + sp.fallDistance
+                    + " onGround=" + sp.onGround
+                    + " serverMotion=" + sp.motionX + "," + sp.motionY + "," + sp.motionZ
+                    + " paired=" + (checkpoint instanceof PairedCheckpoint));
         }
     }
 }

--- a/loader-forge-1.8.9/src/main/resources/META-INF/parkourcalculator_at.cfg
+++ b/loader-forge-1.8.9/src/main/resources/META-INF/parkourcalculator_at.cfg
@@ -1,6 +1,7 @@
 public net.minecraft.entity.Entity fire
 public net.minecraft.entity.EntityLivingBase jumpTicks
 public net.minecraft.entity.EntityLivingBase isJumping
+public net.minecraft.entity.EntityLivingBase lastDamage
 public net.minecraft.entity.player.EntityPlayer flyToggleTimer
 public net.minecraft.client.entity.EntityPlayerSP lastReportedPosX
 public net.minecraft.client.entity.EntityPlayerSP lastReportedPosY


### PR DESCRIPTION
Closes #345

Replaying a TAS from a tick shortly before a fall-damage ruling desynced from the simulation. The only channel is the `hurtMarked` flush: a velocity packet built from the server player's own motion, which the client applies over its predicted velocity. Two restart-specific holes let the real replay miss it.

## The jump gate (Fabric 26.2)

`jumpFromGround()` runs inside `handleMovePlayer`, gated on the server still believing the player is grounded. At a restart the client's teleport-confirm `PosRot` hardcodes `onGround=false` and clears that gate, so the first replayed row lost the jump impulse and every grounded start failed deterministically.

`RestartSettle` re-applies the restart state on the first move packet processed once the handshake has settled, which by FIFO is exactly that confirm. The next packet is the first replayed row, and it now sees the checkpoint's grounded state. Stale pre-restart packets all precede the ack, so vanilla's own handshake filter still discards them: no bypass, nothing injected per tick.

The start-window lockstep barrier orders the teleport against the first replayed tick, so this is deterministic instead of frame-timing dependent.

## The ruling tick (both loaders)

A restart whose checkpoint sits exactly on a ruling tick resumes with the damage already consumed and its velocity packet still queued. The real server has nothing left to flush, while the simulation replays that queued packet from the checkpoint, so the two part company on the first replayed tick.

The start velocity now carries the pending flush, decoded exactly as the paired sim decodes it, so both agree bit for bit. This is start-state seeding, not per-tick injection: everything after the first tick is still computed independently by the real client and server.

On 26.2 the value also goes into the teleport packet, because vanilla's `setValuesFromPositionPacket` applies `deltaMovement` from it and would otherwise overwrite the client a moment later.

## Forge 1.8.9

No settle is needed here: the restart is a direct server snap with no handshake, so the jump gate survives on its own (verified against the module's decompiled sources rather than assumed). What it actually lacked was server-side restart parity, since `onGround`, `fallDistance`, `lastDamage` and `floatingTickCount` were being taken from the client carry while the server tracks its own fall accumulation, plus a start-window barrier that also closes the free window before the lockstep pipeline handlers are installed.

## Verification

In-game, paired simulation + paired damage + lockstep replay all on:

| loader | runs | ruling-tick start |
| --- | --- | --- |
| Fabric 26.2 | 7/7 clean | 0/3 to 3/3 |
| Forge 1.8.9 | 20/20 clean | 0/4 to 4/4 |

Zero lockstep aborts and zero movement corrections in both. Cross-check on both loaders: the injected velocity is byte-identical to the packet the real server sends in the runs where it does rule the damage itself, and the runs that start on a ruling tick correctly produce no packet at all. The 26.2 set includes a full from-the-top replay crossing two separate damage events.

`PAIRED_DIAGNOSTICS` is off and the throwaway tracing is stripped; the remaining diagnostics are reachable only through that flag.

## Not in this PR

Forge 1.12.2 and Fabric 1.21.3 have the same holes and are untouched, tracked separately.