### PR TITLE
fix(solver): restore Optimize's objective with a coarse facing ascent

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/BuiltinGraphs.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/BuiltinGraphs.java
@@ -88,6 +88,7 @@ public final class BuiltinGraphs {
         g.add("repA", "report");
         g.add("repWarm", "report");
         g.add("repSkip", "report");
+        if (!sof) g.add("coarseWarm", "coarseAscent");
         router(g, "rSeedHave", "HAS_CANDIDATE");
         if (sof) router(g, "rImproveFeas", "CANDIDATE_FEASIBLE_SCORED");
         router(g, "rFree", "HAS_FREE_START");
@@ -197,9 +198,13 @@ public final class BuiltinGraphs {
         g.edge("rWarmTicks", Guarantee.FALSE, "settledMark");
         g.edge("smoothWarm", Guarantee.DONE, "repWarm");
         g.edge("settledMark", Guarantee.DONE, "repSkip");
-        g.edge("repSkip", Guarantee.DONE, coldEntry);
+        g.edge("repSkip", Guarantee.DONE, sof ? coldEntry : "coarseWarm");
         g.edge("repA", Guarantee.DONE, sof ? "rFeasFastCold" : "rEarlyFeas");
-        g.edge("repWarm", Guarantee.DONE, sof ? "rFeasFastWarm" : coldEntry);
+        g.edge("repWarm", Guarantee.DONE, sof ? "rFeasFastWarm" : "coarseWarm");
+        if (!sof) {
+            g.edge("coarseWarm", Guarantee.IMPROVED, coldEntry);
+            g.edge("coarseWarm", Guarantee.UNCHANGED, coldEntry);
+        }
         if (sof) {
             g.edge("rFeasFastCold", Guarantee.TRUE, "lblFF");
             g.edge("rFeasFastCold", Guarantee.FALSE, "rEarlyFree");

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/NodeCatalog.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/NodeCatalog.java
@@ -2,6 +2,7 @@ package de.legoshi.parkourcalc.core.anglesolver.graph;
 
 import de.legoshi.parkourcalc.core.anglesolver.graph.nodes.BnbNode;
 import de.legoshi.parkourcalc.core.anglesolver.graph.nodes.CapCertifyNode;
+import de.legoshi.parkourcalc.core.anglesolver.graph.nodes.CoarseAscentNode;
 import de.legoshi.parkourcalc.core.anglesolver.graph.nodes.DualChainNode;
 import de.legoshi.parkourcalc.core.anglesolver.graph.nodes.FreeStartImproveNode;
 import de.legoshi.parkourcalc.core.anglesolver.graph.nodes.IlsPolishNode;
@@ -226,6 +227,13 @@ public final class NodeCatalog {
                 .budgetParam("budgetSec")
                 .fallback(Guarantee.UNCHANGED)
                 .factory(IlsPolishNode::new)
+                .build());
+        register(NodeType.builder("coarseAscent", "Coarse ascent", NodeCategory.POLISH)
+                .requires(InputRequirement.ANY)
+                .branch(Branch.feasible(Guarantee.IMPROVED))
+                .branch(Branch.preserves(Guarantee.UNCHANGED))
+                .fallback(Guarantee.UNCHANGED)
+                .factory(CoarseAscentNode::new)
                 .build());
         register(NodeType.builder("wrapIls", "Wrap ILS", NodeCategory.POLISH)
                 .requires(InputRequirement.ANY)

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/nodes/CoarseAscentNode.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/nodes/CoarseAscentNode.java
@@ -1,0 +1,34 @@
+package de.legoshi.parkourcalc.core.anglesolver.graph.nodes;
+
+import de.legoshi.parkourcalc.core.anglesolver.graph.Candidate;
+import de.legoshi.parkourcalc.core.anglesolver.graph.GraphContext;
+import de.legoshi.parkourcalc.core.anglesolver.graph.Guarantee;
+import de.legoshi.parkourcalc.core.anglesolver.graph.NodeOutcome;
+import de.legoshi.parkourcalc.core.anglesolver.graph.NodeRuntime;
+import de.legoshi.parkourcalc.core.anglesolver.graph.ParamValues;
+import de.legoshi.parkourcalc.core.anglesolver.solver.BucketAscentPolish;
+import de.legoshi.parkourcalc.core.anglesolver.solver.SolverTrace;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public final class CoarseAscentNode implements NodeRuntime {
+
+    public CoarseAscentNode(ParamValues params) {
+    }
+
+    @Override
+    public NodeOutcome execute(GraphContext ctx, Candidate in, AtomicBoolean nodeToken, long deadlineNanos) {
+        if (in == null || in.yaws == null) return NodeOutcome.of(Guarantee.UNCHANGED, in);
+        double[] wide = BucketAscentPolish.coarse(ctx.model, ctx.spec, in.yaws, nodeToken);
+        if (wide == null) return NodeOutcome.of(Guarantee.UNCHANGED, in);
+        boolean max = ctx.maximize();
+        double cur = ctx.scoredExactObjective(in.yaws);
+        double got = ctx.scoredExactObjective(wide);
+        if (SolverTrace.on()) SolverTrace.log("ENGINE", "coarse %.7f -> %.7f", cur, got);
+        if (max ? got > cur : got < cur) {
+            ctx.chainAppend("coarse ascent");
+            return NodeOutcome.of(Guarantee.IMPROVED, Candidate.of(ctx, wide));
+        }
+        return NodeOutcome.of(Guarantee.UNCHANGED, in);
+    }
+}

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/BucketAscentPolish.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/BucketAscentPolish.java
@@ -53,6 +53,28 @@ public final class BucketAscentPolish {
             12, 8, 3
     );
 
+    private static final double[][] COARSE = {{180.0, 5.0}, {180.0, 1.0}};
+
+    public static double[] coarse(ForwardModel model, JumpSpec spec, double[] startAbsWrapped, AtomicBoolean cancel) {
+        JumpConstraintCompiler.Compiled c = JumpConstraintCompiler.compile(spec);
+        JumpPhysicsInputs scenario = spec.asScenario();
+        Objective obj = spec.objective;
+        double sign = obj.sense == Objective.Sense.MAX ? -1.0 : 1.0;
+        double[] y = startAbsWrapped.clone();
+        if (score(model, scenario, c, obj, sign, y) == Double.POSITIVE_INFINITY) return y;
+        try {
+            for (double[] r : COARSE) {
+                for (int it = 0; it < 60; it++) {
+                    if (!block1(y, r[0], r[1], model, scenario, c, obj, sign, cancel)) break;
+                }
+            }
+            b1refine(y, model, scenario, c, obj, sign, THOROUGH, cancel);
+        } catch (SolveCancelledException e) {
+            return y;
+        }
+        return y;
+    }
+
     public static double[] polish(ForwardModel model, JumpSpec spec, double[] startAbsWrapped, Config cfg, AtomicBoolean cancel) {
         JumpConstraintCompiler.Compiled c = JumpConstraintCompiler.compile(spec);
         JumpPhysicsInputs scenario = spec.asScenario();

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/OptimizeVsFastTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/OptimizeVsFastTest.java
@@ -76,6 +76,11 @@ public class OptimizeVsFastTest {
                         + " is worse than fast's " + fast.result.getObjectiveValue(),
                 optimize.result.getObjectiveValue() <= fast.result.getObjectiveValue());
 
+        assertTrue("optimize objective " + optimize.result.getObjectiveValue()
+                        + " is short of the 1.9.0 baseline (-51.6214); the coarse ascent is not reaching"
+                        + " the flat-facing basin",
+                optimize.result.getObjectiveValue() <= -51.0);
+
         assertNotNull("optimize: no run record", optimize.record);
         assertTrue("optimize published " + optimize.record.trajectory.size()
                         + " incumbents; Cancel would keep the first candidate",


### PR DESCRIPTION
Closes the third point of #398 ("final result is worse than the old version"). PR #399 fixed the progress publishing and the budget split; it did not fix the objective itself.

## The regression

Measured on the reporter's capture (`gh398-optimize-2jump`), identical 9-constraint problem:

| budget | `main` (1.9.0, CMA-ES) | `dev` before | this PR |
| --- | --- | --- | --- |
| 10s | -51.6214 | -50.2279 | **-51.5612** |
| 30s | -51.6215 | -50.2279 | -51.5612 |
| 60s | -51.6215 | -50.8872 | |
| 120s | | -51.6216 | |

`dev` needed 120 seconds to reach what 1.9.0 reached in 10.

## Cause

Removing CMA-ES left the Optimize path with no coarse global search at all.

`BucketAscentPolish` is a byte-exact bucket settler: its widest scan window is 1.5 degrees in `THOROUGH` and 0.2 degrees in `FAST`. It settles a basin but can never leave one. The only wide move left is `IlsPolish`'s kick, a random per-tick scatter over 3 to 15 ticks, which cannot produce a coherent rotation and mostly lands infeasible because it perturbs constrained ticks too.

The optimum on this capture needs exactly such a coherent move: the approach swings to -11 degrees so the `dX < dZ` gate at T30 is cleared cheaply, then the facing snaps 101 degrees to a flat 90 and holds it dead straight for the rest of the jump. CMA-ES found that with `sigmaDeg=90` and 16 restarts. Nothing on `dev` could.

## Fix

`BucketAscentPolish.coarse`: a deterministic coordinate descent over the whole yaw range, 5 degrees then 1 degree, followed by the existing fine settle. It reuses `block1`, so like every other pass here it only accepts strictly feasible improvements and can never clip a feasible start.

Wired as a `coarseAscent` graph node placed right after the warm start, on the graphs that are not stop-on-feasible. FAST is untouched (it is `sof=true`, so the node is not added).

Cost is 17ms. On this capture the chain becomes `receding horizon -> coarse ascent -> ILS`, and `bnbOpt`, which was burning 3.2s of the 7.5s window to gain 0.26, is skipped.

## Tests

`./gradlew :core:test -PslowTests` green, 660 tests, 3m08s.

`OptimizeVsFastTest` previously only asserted that Optimize beats FAST, which `dev` satisfied while sitting 1.39 blocks down. It now also pins the objective at -51.0 or better, so this regression cannot return unnoticed.

## Known gap

Still 0.06 short of the 1.9.0 CMA-ES result (-51.5612 vs -51.6214). The remaining difference is ILS settling into a slightly different local optimum; more budget does not close it.

The deeper cause is separate and filed on its own: `dX < dZ` is nonlinear, so `JumpLinearModel.compileWall` silently drops it, which blinds the dual bound, SLP and the closed form to it. With that constraint removed the closed form returns the exact optimum in 20ms at any goal level. This PR does not address that.


## Corpus cost

Measured on matched bases (`b3f25e64` with and without this commit), runs sequential so they do not contend.

`:core:test -PslowTests`, 687 tests on both sides:

| | before | after | delta |
| --- | --- | --- | --- |
| `ProblemsTest` (120 tests) | 153.74s | 152.13s | -1.61s |
| suite total | 179.80s | 178.24s | -1.56s |

`FreeStartSweepBench` (hpk free-start sweep, FAST, 104 runs):

| | before | after |
| --- | --- | --- |
| solved | 104/104 | 104/104 |
| total | 29.0s | 29.0s |
| captures moving more than 300ms | | 0 |
| success/fail changes | | none |

Both deltas are run-to-run noise, not a speedup. Neither bench exercises the new node at all: both run FAST, which is `sof=true`, so `coarseWarm` is never added to the graph. Only Optimize and Custom pay the 17ms.
