### PR TITLE
fix: report which constraints a failed solve missed

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
@@ -563,6 +563,7 @@ public final class Application {
         if (!wasSolving) return;
         SolveResult done = angleSolverState.getResult();
         if (done == null) return;
+        saveController.markDirty();
         if (done.isSuccess() && !done.getYaws().isEmpty()) {
             solverEngine.apply();
             if (angleSolverState.getApplyDeviation() != null) {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/RunTicksController.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/RunTicksController.java
@@ -232,8 +232,11 @@ public final class RunTicksController implements RunTicksControls {
         originalDocument.restoreInto(inputs, state);
         runSimulation.run();
 
-        SolveResult failed = new SolveResult(false, 0, enabledConstraintCount(),
-                state.getStartTick() + 1, state.getLandingTick() + 1);
+        SolveResult failed = engine.diagnoseCurrentPath();
+        if (failed == null) {
+            failed = new SolveResult(false, 0, enabledConstraintCount(),
+                    state.getStartTick() + 1, state.getLandingTick() + 1);
+        }
         failed.setSolver(cancelRequested ? "Run ticks (cancelled)" : "Run ticks");
         failed.addDetail("Run ticks", cancelRequested
                 ? "Cancelled, path restored" : "No solution, path restored");

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/AngleSolverEngine.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/AngleSolverEngine.java
@@ -17,6 +17,7 @@ import de.legoshi.parkourcalc.core.anglesolver.graph.SolverGraph;
 import de.legoshi.parkourcalc.core.anglesolver.solver.Angles;
 import de.legoshi.parkourcalc.core.anglesolver.solver.BucketAscentPolish;
 import de.legoshi.parkourcalc.core.anglesolver.solver.ClosedFormSolve;
+import de.legoshi.parkourcalc.core.anglesolver.solver.ClosestMiss;
 import de.legoshi.parkourcalc.core.anglesolver.solver.ExactJumpModel;
 import de.legoshi.parkourcalc.core.anglesolver.solver.LongRunSolver;
 import de.legoshi.parkourcalc.core.anglesolver.solver.RelaxationRecovery;
@@ -986,8 +987,7 @@ public final class AngleSolverEngine {
         if (cancel.get()) return null;
         if (cand == null || cand.yaws == null) {
             finishRecord(rec, SolveRunRecord.STATUS_FAILED, null, null, null, ctx.chain(), null);
-            SolveResult fail = new SolveResult(false, 0, job.uiConstraints.size(),
-                    job.startTick + 1, job.landingTick + 1);
+            SolveResult fail = failureResult(job, sc, ctx, System.nanoTime() - solveStart);
             if (ctx.chain() != null) fail.setSolver(ctx.chain());
             if (hasUnsupportedDf(job)) fail.setNotice(DF_UNSUPPORTED_NOTICE);
             return new Outcome(fail, null);
@@ -1078,7 +1078,12 @@ public final class AngleSolverEngine {
     }
 
     private SolveResult buildResultWithObjective(Job job, double[] yaws, double[] gameFacings, ForwardPath path) {
-        SolveResult result = buildResult(job, yaws, gameFacings, path);
+        return buildResultWithObjective(job, yaws, gameFacings, path, true);
+    }
+
+    private SolveResult buildResultWithObjective(Job job, double[] yaws, double[] gameFacings, ForwardPath path,
+                                                 boolean feasible) {
+        SolveResult result = buildResult(job, yaws, gameFacings, path, feasible);
         result.setObjective(path.getPos(job.spec.objective.tick, job.spec.objective.axis));
         result.getOutcomes().add(0, objectiveOutcome(result, job.spec.objective, job.startTick));
         return result;
@@ -1123,6 +1128,61 @@ public final class AngleSolverEngine {
         String sense = o.sense == Objective.Sense.MAX ? "max" : "min";
         return new SolveResult.Outcome(field, "T" + (startTick + o.tick + 1), sense,
                 ConstraintText.fixedStat(r.getObjectiveValue()), "");
+    }
+
+    private SolveResult failureResult(Job job, JumpPhysicsInputs sc, GraphContext ctx, long solveNanos) {
+        double[] yaws = ctx.closestMiss().yaws();
+        double violation = ctx.closestMiss().violation();
+        String source = "closest attempt";
+        if (yaws != null && yaws.length != sc.numTicks) yaws = null;
+        if (yaws == null) {
+            yaws = currentRowYaws(job.startTick, job.numTicks);
+            source = "current path";
+            if (yaws != null) violation = ctx.violationOf(yaws);
+        }
+        if (yaws == null) {
+            return new SolveResult(false, 0, job.uiConstraints.size(), job.startTick + 1, job.landingTick + 1);
+        }
+        double[] gameFacings = sc.toGameFacings(yaws);
+        ForwardPath path = model.forward(sc, gameFacings);
+        SolveResult r = buildResultWithObjective(job, yaws, gameFacings, path, false);
+        r.setDurationNanos(solveNanos);
+        r.setDurationMs(solveNanos / 1_000_000L);
+        r.setFinishedAt(formatClock());
+        addBaseDetails(r, solveNanos);
+        r.addDetail("Values from", source);
+        if (!Double.isNaN(violation) && !Double.isInfinite(violation)) {
+            r.addDetail("Worst violation", ConstraintText.fixedStat(violation));
+        }
+        return r;
+    }
+
+    public SolveResult diagnoseCurrentPath() {
+        if (solving) return null;
+        Job job = buildJob(state.getEffort());
+        if (job == null) return null;
+        double[] yaws = currentRowYaws(job.startTick, job.numTicks);
+        if (yaws == null) return null;
+        JumpPhysicsInputs sc = job.spec.asScenario();
+        double[] gameFacings = sc.toGameFacings(yaws);
+        SolveResult r = buildResultWithObjective(job, yaws, gameFacings, model.forward(sc, gameFacings), false);
+        r.addDetail("Values from", "current path");
+        return r;
+    }
+
+    private double[] currentRowYaws(int startTick, int numTicks) {
+        List<InputRow> rows = inputs.getRows();
+        if (startTick < 0 || numTicks <= 0 || startTick + numTicks > rows.size()) return null;
+        if (startTick >= boxes.size()) return null;
+        double[] out = new double[numTicks];
+        double prevAbs = boxes.getYaw(startTick);
+        for (int k = 0; k < numTicks; k++) {
+            InputRow row = rows.get(startTick + k);
+            Float yaw = row.getYaw();
+            if (yaw != null) prevAbs = row.isYawLocked() ? yaw : prevAbs + yaw;
+            out[k] = prevAbs;
+        }
+        return Angles.wrapAll(out);
     }
 
     // The solver chain is not a detail row: the UI lists it in its own numbered section from getSolver().
@@ -1403,7 +1463,7 @@ public final class AngleSolverEngine {
 
     // ---- result panel (worker thread, from the Job snapshot) ------------------
 
-    private SolveResult buildResult(Job job, double[] yaws, double[] gameFacings, ForwardPath path) {
+    private SolveResult buildResult(Job job, double[] yaws, double[] gameFacings, ForwardPath path, boolean feasible) {
         int total = 0;
         int met = 0;
         List<SolveResult.Outcome> outs = new ArrayList<>();
@@ -1420,7 +1480,7 @@ public final class AngleSolverEngine {
             else unmet.add(ca.absTick);
             outs.add(outcome(ca.c, ca.absTick, found, ok));
         }
-        SolveResult r = new SolveResult(met == total, met, total, job.startTick + 1, job.landingTick + 1);
+        SolveResult r = new SolveResult(feasible && met == total, met, total, job.startTick + 1, job.landingTick + 1);
         r.getOutcomes().addAll(outs);
         for (int t : unmet) r.addUnmetTick(t);
         for (int k = 0; k < yaws.length; k++) {
@@ -1579,6 +1639,13 @@ public final class AngleSolverEngine {
                                      AtomicBoolean cancel, String[] nameOut, long deadlineNanos,
                                      SlpSolve.Config slpCfg, ClosedFormSolve.Config cfCfg,
                                      RelaxationRecovery.Config rrCfg) {
+        return dualChain(em, spec, sc, cancel, nameOut, deadlineNanos, slpCfg, cfCfg, rrCfg, null);
+    }
+
+    public static double[] dualChain(ExactJumpModel em, JumpSpec spec, JumpPhysicsInputs sc,
+                                     AtomicBoolean cancel, String[] nameOut, long deadlineNanos,
+                                     SlpSolve.Config slpCfg, ClosedFormSolve.Config cfCfg,
+                                     RelaxationRecovery.Config rrCfg, ClosestMiss miss) {
         if (SolverTrace.on()) SolverTrace.log("CHAIN", "closed form start");
         double[] yaws = ClosedFormSolve.optimize(em, spec, FEAS_TOL, cancel, cfCfg);
         if (yaws != null) {
@@ -1588,7 +1655,7 @@ public final class AngleSolverEngine {
         }
         if (cancel.get()) return null;
         if (SolverTrace.on()) SolverTrace.log("CHAIN", "slp start");
-        yaws = SlpSolve.optimize(em, spec, FEAS_TOL, cancel, null, slpCfg);
+        yaws = SlpSolve.optimize(em, spec, FEAS_TOL, cancel, null, slpCfg, miss);
         if (yaws != null) {
             if (SolverTrace.on()) SolverTrace.log("CHAIN", "slp solved");
             return levelSetTopUp(em, spec, yaws, cancel, "closed form -> SLP", nameOut);
@@ -1608,7 +1675,7 @@ public final class AngleSolverEngine {
             if (SolverTrace.on()) SolverTrace.log("CHAIN", "alt seed %s %s start", alt.axis, alt.sense);
             double[] seed = ClosedFormSolve.optimize(em, new JumpSpec(sc, spec.constraints, alt), FEAS_TOL, cancel, cfCfg);
             if (seed == null) continue;
-            yaws = SlpSolve.optimize(em, spec, FEAS_TOL, cancel, seed, slpCfg);
+            yaws = SlpSolve.optimize(em, spec, FEAS_TOL, cancel, seed, slpCfg, miss);
             if (yaws != null) {
                 if (SolverTrace.on()) SolverTrace.log("CHAIN", "reseeded slp solved");
                 return levelSetTopUp(em, spec, yaws, cancel, "closed form -> SLP (reseeded)", nameOut);

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/GraphContext.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/GraphContext.java
@@ -1,6 +1,7 @@
 package de.legoshi.parkourcalc.core.anglesolver.graph;
 
 import de.legoshi.parkourcalc.core.anglesolver.solver.ClosedFormSolve;
+import de.legoshi.parkourcalc.core.anglesolver.solver.ClosestMiss;
 import de.legoshi.parkourcalc.core.anglesolver.solver.ExactJumpModel;
 import de.legoshi.parkourcalc.core.anglesolver.solver.ForwardModel;
 import de.legoshi.parkourcalc.core.anglesolver.solver.JumpConstraint;
@@ -30,6 +31,7 @@ public final class GraphContext {
     public final boolean sequential;
     public final LongRunSolver.LongRunConfig longRun;
     public final AtomicLong smoothingEvals = new AtomicLong();
+    private final ClosestMiss closestMiss = new ClosestMiss();
 
     private final BudgetWatchdog watchdog;
     private String chain;
@@ -67,6 +69,10 @@ public final class GraphContext {
 
     public boolean exact() {
         return exactModel != null;
+    }
+
+    public ClosestMiss closestMiss() {
+        return closestMiss;
     }
 
     public void setOverallDeadline(long absoluteNanos) {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/nodes/BnbNode.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/nodes/BnbNode.java
@@ -50,7 +50,7 @@ public final class BnbNode implements NodeRuntime {
             if (ctx.progress != null) ctx.progress.setStage(ctx.chainWith("pattern B&B"));
             if (SolverTrace.on()) SolverTrace.log("ENGINE", "bnb rescue budgetMs=%d", remaining / 1_000_000L);
             double[] rescue = BoundPrunedRecovery.solve(ctx.exactModel, ctx.spec, ctx.feasTol, nodeToken,
-                    remaining, max ? -1.0e300 : 1.0e300, cfg);
+                    remaining, max ? -1.0e300 : 1.0e300, cfg, ctx.closestMiss());
             if (SolverTrace.on()) SolverTrace.log("ENGINE", "bnb rescue %s", rescue != null ? "solved" : "miss");
             if (rescue == null) return passthrough(in);
             double[] yaws = Angles.wrapAll(rescue);
@@ -66,7 +66,8 @@ public final class BnbNode implements NodeRuntime {
             SolverTrace.log("ENGINE", "bnb start budgetMs=%d stopAt=%s", remaining / 1_000_000L,
                     Double.isNaN(stopAt) ? "-" : String.valueOf(stopAt));
         }
-        double[] bnb = BoundPrunedRecovery.solve(ctx.exactModel, ctx.spec, ctx.feasTol, nodeToken, remaining, stopAt, cfg);
+        double[] bnb = BoundPrunedRecovery.solve(ctx.exactModel, ctx.spec, ctx.feasTol, nodeToken, remaining, stopAt, cfg,
+                ctx.closestMiss());
         if (bnb != null) {
             double cur = ctx.scoredObjective(in.yaws);
             double bnbObj = ctx.scoredObjective(bnb);

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/nodes/DualChainNode.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/nodes/DualChainNode.java
@@ -62,7 +62,7 @@ public final class DualChainNode implements NodeRuntime {
         if (!ctx.exact()) return NodeOutcome.of(Guarantee.NONE, in);
         String[] chainName = new String[1];
         double[] chain = AngleSolverEngine.dualChain(ctx.exactModel, ctx.spec, ctx.scenario, nodeToken,
-                chainName, deadlineNanos, slpConfig(), cfConfig(), rrConfig());
+                chainName, deadlineNanos, slpConfig(), cfConfig(), rrConfig(), ctx.closestMiss());
         if (chain == null) {
             if (!keepBetter) ctx.chainAppend("closed form");
             return NodeOutcome.of(Guarantee.NONE, in);

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/BoundPrunedRecovery.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/BoundPrunedRecovery.java
@@ -50,6 +50,12 @@ public final class BoundPrunedRecovery {
 
     public static double[] solve(ExactJumpModel exact, JumpSpec spec, double feasTol,
                                  AtomicBoolean cancel, long budgetNanos, double stopAtObjective, Config cfg) {
+        return solve(exact, spec, feasTol, cancel, budgetNanos, stopAtObjective, cfg, null);
+    }
+
+    public static double[] solve(ExactJumpModel exact, JumpSpec spec, double feasTol,
+                                 AtomicBoolean cancel, long budgetNanos, double stopAtObjective, Config cfg,
+                                 ClosestMiss miss) {
         if (spec == null) return null;
         if (JumpLinearModel.hasFacingWall(spec.constraints)
                 && FacingPrefold.analyze(spec.constraints, new JumpLinearModel(spec.asScenario())) == null) {
@@ -186,7 +192,7 @@ public final class BoundPrunedRecovery {
                                     ? Math.min(searchDeadline, System.nanoTime() + sliceNanos)
                                     : searchDeadline;
                             Search search = Search.build(exact, treeSpec, compiled, feasTol, searchCancel, deadline,
-                                    p.lin, p.velWalls, p.patterned, stopNorm, p.label, searchFloor, cfg);
+                                    p.lin, p.velWalls, p.patterned, stopNorm, p.label, searchFloor, cfg, miss);
                             if (search == null) return null;
                             if (seedYaws != null) search.offer(seedYaws);
                             search.run();
@@ -559,6 +565,7 @@ public final class BoundPrunedRecovery {
         final double stopNorm;
         final String label;
         final Config cfg;
+        final ClosestMiss miss;
         int lastRestoreIters;
 
         private Search(ExactJumpModel exact, JumpSpec spec, double feasTol, AtomicBoolean cancel, long deadline,
@@ -567,12 +574,13 @@ public final class BoundPrunedRecovery {
                        int[] consOfWall, int[] seamTick, int[] seamAxis, int[] seamGeWall, int[] seamLeWall,
                        int[] seamGeCons, int[] seamLeCons, double[] seamConst, double[] baseLo, double[] baseHi,
                        int consWallCount, boolean patterned, double stopNorm, String label, double floorNorm,
-                       Config cfg) {
+                       Config cfg, ClosestMiss miss) {
             this.consWallCount = consWallCount;
             this.patterned = patterned;
             this.stopNorm = stopNorm;
             this.label = label;
             this.cfg = cfg;
+            this.miss = miss;
             this.incumbentNorm = floorNorm;
             this.exact = exact;
             this.spec = spec;
@@ -613,7 +621,7 @@ public final class BoundPrunedRecovery {
         static Search build(ExactJumpModel exact, JumpSpec spec, JumpConstraintCompiler.Compiled acceptCompiled,
                             double feasTol, AtomicBoolean cancel, long deadline,
                             JumpLinearModel lin, List<JumpLinearModel.Wall> velWalls, boolean patterned,
-                            double stopNorm, String label, double floorNorm, Config cfg) {
+                            double stopNorm, String label, double floorNorm, Config cfg, ClosestMiss miss) {
             JumpPhysicsInputs sc = spec.asScenario();
             int objTick = spec.objective.tick;
 
@@ -726,7 +734,7 @@ public final class BoundPrunedRecovery {
             lin.objectiveVectors(spec.objective, cx, cz);
             return new Search(exact, spec, feasTol, cancel, deadline, sc, lin, acceptCompiled, cx, cz, canonical, walls,
                     consOfWall, seamTick, seamAxis, seamGeWall, seamLeWall, seamGeCons, seamLeCons, seamConst,
-                    baseLo, baseHi, consWallCount, patterned, stopNorm, label, floorNorm, cfg);
+                    baseLo, baseHi, consWallCount, patterned, stopNorm, label, floorNorm, cfg, miss);
         }
 
         private static double reach(JumpLinearModel lin, int tick) {
@@ -1190,7 +1198,11 @@ public final class BoundPrunedRecovery {
             double[] wrapped = Angles.wrapAll(yawsAbs);
             double[] gf = sc.toGameFacings(wrapped);
             ForwardPath path = exact.forward(sc, gf);
-            if (compiled.maxViolation(gf, path) > feasTol) return Double.NaN;
+            double violation = compiled.maxViolation(gf, path);
+            if (violation > feasTol) {
+                if (miss != null) miss.offer(wrapped, violation);
+                return Double.NaN;
+            }
             double normed = normObjective(path);
             if (normed > incumbentNorm) {
                 incumbentNorm = normed;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/ClosestMiss.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/ClosestMiss.java
@@ -1,0 +1,25 @@
+package de.legoshi.parkourcalc.core.anglesolver.solver;
+
+public final class ClosestMiss {
+
+    private double[] yaws;
+    private double violation = Double.POSITIVE_INFINITY;
+
+    public synchronized void offer(double[] absWrappedYaws, double violation) {
+        if (absWrappedYaws == null || Double.isNaN(violation) || violation >= this.violation) return;
+        this.yaws = absWrappedYaws.clone();
+        this.violation = violation;
+    }
+
+    public synchronized boolean isEmpty() {
+        return yaws == null;
+    }
+
+    public synchronized double[] yaws() {
+        return yaws == null ? null : yaws.clone();
+    }
+
+    public synchronized double violation() {
+        return violation;
+    }
+}

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/SlpSolve.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/SlpSolve.java
@@ -38,7 +38,7 @@ public final class SlpSolve {
 
     /** Returns absolute wrapped facings with byte-exact {@code maxViolation <= feasTol}, or {@code null}. */
     public static double[] optimize(ExactJumpModel exact, JumpSpec spec, double feasTol, AtomicBoolean cancel) {
-        return optimize(exact, spec, feasTol, cancel, CLEARANCE, true, null, false, false, new Config());
+        return optimize(exact, spec, feasTol, cancel, CLEARANCE, true, null, false, false, new Config(), null);
     }
 
     /** Like {@link #optimize}, but seeded from the given absolute wrapped facings instead of the dual
@@ -46,30 +46,35 @@ public final class SlpSolve {
      *  this spec's objective even where this direction's own dual recovery degenerates. */
     public static double[] optimize(ExactJumpModel exact, JumpSpec spec, double feasTol, AtomicBoolean cancel,
                                     double[] seedAbsWrapped) {
-        return optimize(exact, spec, feasTol, cancel, CLEARANCE, true, seedAbsWrapped, false, false, new Config());
+        return optimize(exact, spec, feasTol, cancel, CLEARANCE, true, seedAbsWrapped, false, false, new Config(), null);
     }
 
     public static double[] optimize(ExactJumpModel exact, JumpSpec spec, double feasTol, AtomicBoolean cancel,
                                     double[] seedAbsWrapped, Config cfg) {
-        return optimize(exact, spec, feasTol, cancel, CLEARANCE, true, seedAbsWrapped, false, false, cfg);
+        return optimize(exact, spec, feasTol, cancel, CLEARANCE, true, seedAbsWrapped, false, false, cfg, null);
+    }
+
+    public static double[] optimize(ExactJumpModel exact, JumpSpec spec, double feasTol, AtomicBoolean cancel,
+                                    double[] seedAbsWrapped, Config cfg, ClosestMiss miss) {
+        return optimize(exact, spec, feasTol, cancel, CLEARANCE, true, seedAbsWrapped, false, false, cfg, miss);
     }
 
     public static double[] optimize(ExactJumpModel exact, JumpSpec spec, double feasTol, AtomicBoolean cancel,
                                     double[] seedAbsWrapped, int phase1Calls, int totalCalls) {
         return optimize(exact, spec, feasTol, cancel, CLEARANCE, true, seedAbsWrapped, false, false,
-                withCalls(phase1Calls, totalCalls));
+                withCalls(phase1Calls, totalCalls), null);
     }
 
     public static double[] optimizeBestEffort(ExactJumpModel exact, JumpSpec spec, double feasTol, AtomicBoolean cancel,
                                               double[] seedAbsWrapped, int phase1Calls, int totalCalls) {
         return optimize(exact, spec, feasTol, cancel, CLEARANCE, true, seedAbsWrapped, true, true,
-                withCalls(phase1Calls, totalCalls));
+                withCalls(phase1Calls, totalCalls), null);
     }
 
     public static double[] optimizeBestEffort(ExactJumpModel exact, JumpSpec spec, double feasTol, AtomicBoolean cancel,
                                               double[] seedAbsWrapped, int phase1Calls, int totalCalls, boolean inertiaAware) {
         return optimize(exact, spec, feasTol, cancel, CLEARANCE, true, seedAbsWrapped, true, inertiaAware,
-                withCalls(phase1Calls, totalCalls));
+                withCalls(phase1Calls, totalCalls), null);
     }
 
     public static double[] optimizeBestEffort(ExactJumpModel exact, JumpSpec spec, double feasTol, AtomicBoolean cancel,
@@ -77,14 +82,14 @@ public final class SlpSolve {
                                               double trMinDeg) {
         Config cfg = withCalls(phase1Calls, totalCalls);
         cfg.trMinDeg = trMinDeg;
-        return optimize(exact, spec, feasTol, cancel, CLEARANCE, true, seedAbsWrapped, true, inertiaAware, cfg);
+        return optimize(exact, spec, feasTol, cancel, CLEARANCE, true, seedAbsWrapped, true, inertiaAware, cfg, null);
     }
 
     /** Feasibility-only centered solve: phase 1 deepens clearance toward {@link Config#centerClearance}, the
      *  hugging phase 2 is skipped. For surrogate-objective solves (lead-in windows). */
     public static double[] optimizeCentered(ExactJumpModel exact, JumpSpec spec, double feasTol, AtomicBoolean cancel) {
         Config cfg = new Config();
-        return optimize(exact, spec, feasTol, cancel, cfg.centerClearance, false, null, false, false, cfg);
+        return optimize(exact, spec, feasTol, cancel, cfg.centerClearance, false, null, false, false, cfg, null);
     }
 
     private static Config withCalls(int phase1Calls, int totalCalls) {
@@ -96,7 +101,7 @@ public final class SlpSolve {
 
     private static double[] optimize(ExactJumpModel exact, JumpSpec spec, double feasTol, AtomicBoolean cancel,
                                      double targetClearance, boolean hugObjective, double[] seedAbsWrapped,
-                                     boolean bestEffort, boolean inertiaAware, Config cfg) {
+                                     boolean bestEffort, boolean inertiaAware, Config cfg, ClosestMiss miss) {
         List<JumpConstraint> constraints = spec.constraints;
         JumpPhysicsInputs sc = spec.asScenario();
         YawTies ties = null;
@@ -190,7 +195,10 @@ public final class SlpSolve {
         for (int phase = 1; phase <= (hugObjective ? 2 : 1) && lpCalls < cfg.totalCalls; phase++) {
             int budget = phase == 1 ? cfg.phase1Calls : cfg.totalCalls;
             while (lpCalls < budget) {
-                if (cancel != null && cancel.get()) return null;
+                if (cancel != null && cancel.get()) {
+                    offerMiss(miss, exact, sc, compiled, theta);
+                    return null;
+                }
                 double[] gf = sc.toGameFacings(Angles.wrapAll(theta));
                 ForwardPath path = exact.forward(sc, gf);
                 double maxViol = exactSlacks(ineq, gf, path, viol);
@@ -302,8 +310,9 @@ public final class SlpSolve {
                     }
                     if (!inertiaAware && !bestEffort) {
                         return optimize(exact, spec, feasTol, cancel, targetClearance, hugObjective,
-                                Angles.wrapAll(theta), false, true, cfg);
+                                Angles.wrapAll(theta), false, true, cfg, miss);
                     }
+                    offerMiss(miss, exact, sc, compiled, theta);
                     return bestEffort ? Angles.wrapAll(theta) : null;
                 }
                 if (SolverTrace.on()) SolverTrace.log("SLP", "phase1 done viol=%.3e lps=%d", endViol, lpCalls);
@@ -323,7 +332,16 @@ public final class SlpSolve {
                     (System.nanoTime() - t0) / 1e6, finalViol <= feasTol ? "feasible" : (bestEffort ? "best effort" : "null"));
         }
         if (finalViol <= feasTol) return yaws;
+        if (miss != null) miss.offer(yaws, finalViol);
         return bestEffort ? yaws : null;
+    }
+
+    private static void offerMiss(ClosestMiss miss, ExactJumpModel exact, JumpPhysicsInputs sc,
+                                  JumpConstraintCompiler.Compiled compiled, double[] theta) {
+        if (miss == null) return;
+        double[] yaws = Angles.wrapAll(theta);
+        double[] gf = sc.toGameFacings(yaws);
+        miss.offer(yaws, compiled.maxViolation(gf, exact.forward(sc, gf)));
     }
 
     private static boolean patternEquals(boolean[] a, boolean[] b) {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveFile.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveFile.java
@@ -158,6 +158,7 @@ public final class SaveFile {
         public List<Outcome> outcomes = new ArrayList<Outcome>();
         public List<Yaw> yaws = new ArrayList<Yaw>();
         public List<Detail> details = new ArrayList<Detail>();
+        public List<Integer> unmetTicks = new ArrayList<Integer>();
     }
 
     public static final class Detail {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveIO.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveIO.java
@@ -812,6 +812,7 @@ public final class SaveIO {
             sd.value = d.value;
             out.details.add(sd);
         }
+        out.unmetTicks.addAll(r.getUnmetTicks());
         return out;
     }
 
@@ -836,6 +837,11 @@ public final class SaveIO {
         }
         if (rd.details != null) {
             for (SaveFile.Detail d : rd.details) r.addDetail(d.label, d.value);
+        }
+        if (rd.unmetTicks != null) {
+            for (Integer t : rd.unmetTicks) {
+                if (t != null) r.addUnmetTick(t);
+            }
         }
         return r;
     }

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/SolveFailureDiagnosticsTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/SolveFailureDiagnosticsTest.java
@@ -1,0 +1,136 @@
+package de.legoshi.parkourcalc.anglesolver;
+
+import de.legoshi.parkourcalc.anglesolver.harness.Fixtures;
+import de.legoshi.parkourcalc.anglesolver.harness.ProblemFixture;
+import de.legoshi.parkourcalc.core.anglesolver.AngleSolverEngine;
+import de.legoshi.parkourcalc.core.anglesolver.AngleSolverState;
+import de.legoshi.parkourcalc.core.anglesolver.Constraint;
+import de.legoshi.parkourcalc.core.anglesolver.SolveResult;
+import de.legoshi.parkourcalc.core.save.SaveIO;
+import de.legoshi.parkourcalc.core.ui.InputData;
+import org.junit.Test;
+
+import java.util.function.Consumer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class SolveFailureDiagnosticsTest {
+
+    private static final String PROBLEM = "j004";
+
+    private static final class Ctx {
+        final AngleSolverState state;
+        final AngleSolverEngine engine;
+
+        Ctx(AngleSolverState state, AngleSolverEngine engine) {
+            this.state = state;
+            this.engine = engine;
+        }
+    }
+
+    private static Ctx build(Consumer<AngleSolverState> mutate) {
+        ProblemFixture pf = ProblemFixture.load("closedform", PROBLEM);
+        InputData inputs = new InputData();
+        SaveIO.applyRowsTo(pf.file, inputs);
+        AngleSolverState state = new AngleSolverState();
+        SaveIO.applyAngleSolverTo(pf.file, state);
+        state.setEffort(AngleSolverState.Effort.FAST);
+        state.clearResult();
+        mutate.accept(state);
+        AngleSolverEngine engine = new AngleSolverEngine(state, Fixtures.buildBoxes(pf.file), inputs, t -> { }, pf.model);
+        return new Ctx(state, engine);
+    }
+
+    private static SolveResult solve(Ctx ctx) {
+        ctx.engine.solve();
+        long deadline = System.currentTimeMillis() + 120_000L;
+        while (ctx.engine.isSolving() && System.currentTimeMillis() < deadline) {
+            ctx.engine.poll();
+            try {
+                Thread.sleep(2);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        ctx.engine.poll();
+        return ctx.state.getResult();
+    }
+
+    private static SolveResult.Outcome unmetOutcomeAt(SolveResult r, String field, int displayTick) {
+        for (SolveResult.Outcome o : r.getOutcomes()) {
+            if (!o.met && field.equals(o.field) && ("T" + displayTick).equals(o.tick)) return o;
+        }
+        return null;
+    }
+
+    @Test
+    public void unreachableWallStillReportsEveryConstraintAndTheMissedTick() {
+        Ctx base = build(state -> { });
+        SolveResult baseline = solve(base);
+        assertTrue("baseline j004 must solve", baseline.isSuccess());
+        boolean max = base.state.getGoal() == AngleSolverState.Goal.MAX;
+        Constraint.Field axis = base.state.getAxis() == AngleSolverState.Axis.X
+                ? Constraint.Field.X : Constraint.Field.Z;
+        double target = baseline.getObjectiveValue() + (max ? 0.5 : -0.5);
+
+        int[] landing = new int[1];
+        Ctx ctx = build(state -> {
+            landing[0] = state.getLandingTick();
+            state.tickConstraints(landing[0]).getConstraints().add(Constraint.scalar(
+                    axis, max ? Constraint.Op.GE : Constraint.Op.LE, target));
+        });
+        SolveResult r = solve(ctx);
+
+        assertNotNull("engine returned no result", r);
+        assertFalse("a wall half a block past the optimum must not solve", r.isSuccess());
+        assertTrue("a failed solve must still report the constraints it was judged against",
+                r.getTotal() > 0);
+        assertFalse("a failed solve must still list per-constraint outcomes", r.getOutcomes().isEmpty());
+        assertTrue("a failed solve must report which constraints missed", r.getMet() < r.getTotal());
+
+        SolveResult.Outcome missed = unmetOutcomeAt(r, axis.label, landing[0] + 1);
+        assertNotNull("the unreachable wall is not reported as an unmet outcome row", missed);
+        assertFalse("an unmet row must carry a margin the panel can colour", missed.margin.isEmpty());
+        assertTrue("the missed tick must be flagged for the world overlay",
+                r.getUnmetTicks().contains(landing[0]));
+        assertEquals("the search reached a near-miss, so it must be reported instead of the current path",
+                "closest attempt", detail(r, "Values from"));
+        assertNotNull("a near-miss must report how far off it was", detail(r, "Worst violation"));
+    }
+
+    @Test
+    public void declinedSolveFallsBackToTheCurrentPath() {
+        int[] at = new int[1];
+        Ctx ctx = build(state -> {
+            at[0] = state.getStartTick() + 2;
+            state.tickConstraints(at[0]).getConstraints()
+                    .add(Constraint.scalar(Constraint.Field.DF, Constraint.Op.LE, 0.0));
+        });
+        SolveResult r = solve(ctx);
+
+        assertNotNull("engine returned no result", r);
+        assertFalse("a retired dF inequality must not solve", r.isSuccess());
+        assertEquals("failed solve must name the unsupported dF as the cause",
+                AngleSolverEngine.DF_UNSUPPORTED_NOTICE, r.getNotice());
+        assertFalse("a declined solve must still report the current path's values", r.getOutcomes().isEmpty());
+        assertEquals("current path", detail(r, "Values from"));
+    }
+
+    @Test
+    public void successfulSolveIsUnaffected() {
+        SolveResult r = solve(build(state -> { }));
+        assertNotNull("engine returned no result", r);
+        assertTrue("baseline j004 must still solve", r.isSuccess());
+        assertEquals(r.getTotal(), r.getMet());
+    }
+
+    private static String detail(SolveResult r, String label) {
+        for (SolveResult.Detail d : r.getDetails()) {
+            if (label.equals(d.label)) return d.value;
+        }
+        return null;
+    }
+}

--- a/core/src/test/java/de/legoshi/parkourcalc/core/UnmetTicksSaveTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/UnmetTicksSaveTest.java
@@ -1,0 +1,59 @@
+package de.legoshi.parkourcalc.core;
+
+import de.legoshi.parkourcalc.core.anglesolver.AngleSolverState;
+import de.legoshi.parkourcalc.core.anglesolver.SolveResult;
+import de.legoshi.parkourcalc.core.save.FileSystemSaveStore;
+import de.legoshi.parkourcalc.core.save.Result;
+import de.legoshi.parkourcalc.core.save.SaveFile;
+import de.legoshi.parkourcalc.core.save.SaveIO;
+import de.legoshi.parkourcalc.core.sim.Vec3dCore;
+import de.legoshi.parkourcalc.core.ui.InputData;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashSet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class UnmetTicksSaveTest {
+
+    @Test
+    public void unmetTicksSurviveSaveRoundTrip() throws Exception {
+        Path dir = Files.createTempDirectory("pkc-unmet");
+        FileSystemSaveStore store = new FileSystemSaveStore(dir, "test", "1.8.9", () -> null);
+        AngleSolverState in = new AngleSolverState();
+        SolveResult r = new SolveResult(false, 2, 4, 1, 10);
+        r.addUnmetTick(7);
+        r.addUnmetTick(3);
+        in.setResult(r);
+
+        Result<String> saved = SaveIO.save(store, "run", new InputData(), Vec3dCore.ZERO, Vec3dCore.ZERO,
+                0f, PlaybackController.DEFAULT_PITCH, in, null, false);
+        assertTrue("save should succeed: " + saved.error, saved.ok);
+        Result<SaveFile> loaded = SaveIO.load(store, "run");
+        assertTrue("load should succeed: " + loaded.error, loaded.ok);
+
+        AngleSolverState out = new AngleSolverState();
+        SaveIO.applyAngleSolverTo(loaded.value, out);
+        assertNotNull(out.getResult());
+        assertEquals("the world overlay's unmet ticks must survive a reload",
+                new HashSet<Integer>(Arrays.asList(3, 7)),
+                new HashSet<Integer>(out.getResult().getUnmetTicks()));
+    }
+
+    @Test
+    public void legacyResultLoadsWithoutUnmetTicks() {
+        SaveFile f = SaveIO.parseSafe("{\"version\":1,\"angleSolver\":{\"result\":{"
+                + "\"success\":false,\"met\":1,\"total\":2,\"startTick\":1,\"landingTick\":5}}}");
+        assertNotNull(f);
+        AngleSolverState state = new AngleSolverState();
+        SaveIO.applyAngleSolverTo(f, state);
+        assertNotNull(state.getResult());
+        assertTrue("a file written before the field existed must load with no plates",
+                state.getResult().getUnmetTicks().isEmpty());
+    }
+}


### PR DESCRIPTION
## Problem

A failed solve shows `No solution · 0/N constraints met` and nothing else: no "Solved values" table, no red margins, no red constraint plates in world. There is no way to see which constraint the solver could not reach.

Everything that reports *where* a solve failed is derived from a candidate **path**, not from the constraints. `AngleSolverEngine.buildResult` is the only place that evaluates each UI constraint (`findValue` then `satisfied`), fills the `SolveResult.Outcome` rows, and calls `addUnmetTick`. It needs yaws. The graph's failure branch published a bare `SolveResult(false, 0, N)` instead, so `AngleSolverWindow.renderOutcomes` returned on its first line and `AngleSolverConstraintSource.solverUnmetTicks()` came back empty.

It regressed in #382 (the CMA-ES removal). CMA was the only stage that returned its best-objective point even when infeasible; the old code said so explicitly. Every deterministic stage (`dualChain` = closed form, SLP, relaxation, alt-seed; B&B; ILS) is feasibility-gated and returns `null` on a miss, and `GraphRunner.reportIncumbent` skips null candidates, so `progress.haveBest()` was false too.

## Fix

New `ClosestMiss`: a synchronized lowest-violation holder owned by `GraphContext`. Producers hand it a point plus its byte-exact `maxViolation`.

- `SlpSolve` gains an `optimize(..., cfg, miss)` overload; the private `optimize` records at the phase-1 infeasible return, at the final infeasible return, and on cancel/deadline.
- `BoundPrunedRecovery` gains a `solve(..., cfg, miss)` overload threaded into `Search`; recorded in `Search.offer()`, the single choke point every tree candidate passes through, already measured against the full spec's `compiled`.
- Wired by `DualChainNode` and `BnbNode`.

`AngleSolverEngine.failureResult` then rebuilds the panel from that point through `buildResultWithObjective(..., feasible = false)`. The new `feasible` flag forces `success = false` even when every mapped UI constraint happens to read as met, so a near-miss can never be reported as solved.

Fallback when no stage reached anything (a declined dF solve, a structurally infeasible spec): `currentRowYaws`, the inverse of `writeYawRows`, evaluates the constraints against the facings the rows encode today. `RunTicksController`'s failure path gets the same treatment via the new `engine.diagnoseCurrentPath()`.

Two new detail rows say which of the two the values came from: `Values from` (`closest attempt` or `current path`) and `Worst violation`.

## Result

`No solution · 3/5 constraints met` instead of `0/5`, the "Solved values" table back with red margins on the rows that missed, and the red constraint plates back in world via `getUnmetTicks()`.

Zero extra compute when the miss sink is null, which is every call site outside the two nodes. The applied plan is unchanged: a failure result still carries a `null` plan, so `apply()` no-ops and `Application.pollSolver` only auto-applies on `isSuccess()`.

## Worth knowing

SLP usually contributes nothing here. On the common single-jump case its dual seed (`CostateDualSolver.solve(0.0, null)`) returns null, a continuous-infeasible certificate, before it ever computes an iterate. On j004 with a wall half a block past the optimum the trace shows `CHAIN slp start` then `CHAIN relaxation start` in 1.8 ms with no `SLP start` line at all. The near-miss that reaches the panel there comes from the B&B path, which is why both are wired.

## Second commit: unmet ticks survive a save reload

`SaveIO` persisted the per-outcome `met` flag but never the unmet tick set, so reloading a save kept the panel's red rows and lost the matching red constraint plates in world. That gap has been there since `unmetTicks` was introduced in #255/#263 and was never implemented for any earlier solver either, but it only *mattered* once failed solves started producing unmet ticks, which is exactly when you reopen a save to keep looking at the failure. So it belongs here rather than in a follow-up.

Three lines: a `List<Integer> unmetTicks` on `SaveFile.Result`, a copy in `toSaveResult`, a null-guarded restore in `toResult`. Additive and null tolerant in the same way `Outcome.met` already is, so files written before the field exists load with no plates, exactly as they do today.

## Third commit: a published result marks the document dirty

Auto-save only writes a dirty document (`FileMenu.tickAutoSave`), and nothing dirtied it when a solve finished. A *successful* solve got there indirectly: auto-apply writes the yaw rows, and `AngleSolverEngine`'s `onApplied` is wired to `Application::onUserChange`, which marks dirty. A *failed* solve never applies, so its result was never written, and `SaveController.load` overwrites the session without saving the outgoing document. Switching files silently dropped it.

The result is part of the save schema, so publishing one is a document change. One line in `pollSolver` marks it as such. Success is unaffected (it was already being dirtied, just via the rows); failure now survives a file switch. Without this the second commit is unreachable for failed solves through auto-save, though Ctrl+S always wrote them.

Trade-off: auto-save now fires after solves it previously ignored. Once per solve, not per frame, and the write is async.

## Testing

- `:core:test` green, `:core:test -PslowTests` green, `tableStyleCheck` green, both Forge loaders compile.
- `SolveFailureDiagnosticsTest` pins three cases: a B&B near-miss reported as `closest attempt` with the unmet row and unmet tick, a declined dF solve falling back to `current path`, and a successful solve unaffected. Runs in about half a second, so it stays in the default suite.
- `UnmetTicksSaveTest` pins the round trip and the legacy-file path.

The slow suite was run against the first commit, which is the one that touches solver code; the save and dirty-flag commits do not.

The dirty-flag one-liner is not unit tested: `Application` has no headless test harness (nothing in `core/src/test` constructs one), and building one for a single wiring line is not worth it. It needs the in-game pass below.

In-game QA still pending. Worth covering specifically: fail a solve, switch to another file and back, confirm the failure text and the red plates return.
