### PR TITLE
fix(solver): stop the feasibility repair from flicking the smoothed path

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/BuiltinGraphs.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/BuiltinGraphs.java
@@ -31,7 +31,7 @@ public final class BuiltinGraphs {
                 .set("bnbFF", "budgetSec", bnbSec).set("bnbFF", "minBudgetMs", 0);
         router(g, "rIls", "CANDIDATE_FEASIBLE_RAW");
         g.add("ils", "ilsPolish").set("ils", "budgetSec", ilsSec).set("ils", "roundCap", 400);
-        g.add("smooth", "smoothing").set("smooth", "countEvals", true);
+        g.add("smooth", "smoothing").set("smooth", "countEvals", true).set("smooth", "deWiggle", true);
         g.edge("entry", Guarantee.DONE, "seed");
         g.edge("seed", Guarantee.FOUND, "rFeas");
         g.edge("seed", Guarantee.NONE, "bnbFF");
@@ -157,7 +157,8 @@ public final class BuiltinGraphs {
         }
         router(g, "rTrans", "HAS_FREE_START");
         g.add("translate", "translatedStart");
-        g.add("smoothFinal", "smoothing").set("smoothFinal", "countEvals", true);
+        g.add("smoothFinal", "smoothing").set("smoothFinal", "countEvals", true)
+                .set("smoothFinal", "deWiggle", true);
         if (win) {
             g.add("horizon", "recedingHorizon")
                     .set("horizon", "window", window)

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/GraphRunner.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/GraphRunner.java
@@ -54,7 +54,7 @@ public final class GraphRunner {
                 runtimes.put(cur.id, rt);
             }
             boolean isWrap = "wrapIls".equals(cur.type.id);
-            if (isWrap) wrapPending = false;
+            if (isWrap || (wrapPending && !reachesWrap(graph, cur))) wrapPending = false;
             long budgetNanos = budgetNanos(cur);
             long deadline = budgetNanos > 0 ? System.nanoTime() + budgetNanos : 0L;
             if (overall > 0 && (deadline == 0L || overall < deadline)) deadline = overall;
@@ -99,6 +99,23 @@ public final class GraphRunner {
         if (p == null) return 0L;
         int secs = n.params.getInt(p);
         return secs > 0 ? secs * 1_000_000_000L : 0L;
+    }
+
+    private static boolean reachesWrap(SolverGraph g, GraphNode from) {
+        java.util.Set<String> seen = new java.util.HashSet<>();
+        java.util.ArrayDeque<GraphNode> queue = new java.util.ArrayDeque<>();
+        queue.add(from);
+        seen.add(from.id);
+        while (!queue.isEmpty()) {
+            GraphNode n = queue.poll();
+            if ("wrapIls".equals(n.type.id)) return true;
+            for (GraphEdge e : g.edges) {
+                if (!e.fromNode.equals(n.id)) continue;
+                GraphNode to = g.node(e.toNode);
+                if (to != null && seen.add(to.id)) queue.add(to);
+            }
+        }
+        return false;
     }
 
     private static GraphNode next(SolverGraph g, GraphNode n, Guarantee branch) {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/NodeCatalog.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/NodeCatalog.java
@@ -255,6 +255,7 @@ public final class NodeCatalog {
                 .requires(InputRequirement.ANY)
                 .branch(Branch.preserves(Guarantee.DONE))
                 .param(ParamSpec.bool("countEvals", "Count evals", false))
+                .param(ParamSpec.bool("deWiggle", "Remove short turn runs", false))
                 .param(ParamSpec.integer("maxRounds", "Max rounds", 1, 1000, 24))
                 .param(ParamSpec.integer("maxEvals", "Max evals", 100, 10000000, 24000))
                 .param(ParamSpec.integer("pairSpan", "Pair span", 1, 64, 3))

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/nodes/SmoothingNode.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/nodes/SmoothingNode.java
@@ -8,17 +8,21 @@ import de.legoshi.parkourcalc.core.anglesolver.graph.NodeOutcome;
 import de.legoshi.parkourcalc.core.anglesolver.graph.NodeRuntime;
 import de.legoshi.parkourcalc.core.anglesolver.graph.ParamParse;
 import de.legoshi.parkourcalc.core.anglesolver.graph.ParamValues;
+import de.legoshi.parkourcalc.core.anglesolver.solver.DeWiggle;
 import de.legoshi.parkourcalc.core.anglesolver.solver.SmoothingPolish;
+import de.legoshi.parkourcalc.core.anglesolver.solver.SolverTrace;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public final class SmoothingNode implements NodeRuntime {
 
     private final boolean countEvals;
+    private final boolean deWiggle;
     private final SmoothingPolish.Config cfg;
 
     public SmoothingNode(ParamValues params) {
         this.countEvals = params.getBool("countEvals");
+        this.deWiggle = params.getBool("deWiggle");
         this.cfg = new SmoothingPolish.Config();
         cfg.maxRounds = params.getInt("maxRounds");
         cfg.maxEvals = params.getInt("maxEvals");
@@ -29,14 +33,24 @@ public final class SmoothingNode implements NodeRuntime {
     @Override
     public NodeOutcome execute(GraphContext ctx, Candidate in, AtomicBoolean nodeToken, long deadlineNanos) {
         if (in == null || in.yaws == null || ctx.stageLocked()) return NodeOutcome.of(Guarantee.DONE, in);
+        double[] base = in.yaws;
+        if (deWiggle && ctx.spec.objective.smoothLambda > 0.0) {
+            base = DeWiggle.run(ctx.model, ctx.spec, in.yaws, nodeToken);
+            if (SolverTrace.on()) {
+                SolverTrace.log("DEWIGGLE", "runs %d -> %d",
+                        DeWiggle.runs(ctx.scenario.startYaw, in.yaws).size(),
+                        DeWiggle.runs(ctx.scenario.startYaw, base).size());
+            }
+        }
         double[] smoothed;
         if (countEvals) {
             CountingForwardModel counting = new CountingForwardModel(ctx.model);
-            smoothed = SmoothingPolish.smooth(counting, ctx.spec, in.yaws, nodeToken, cfg);
+            smoothed = SmoothingPolish.smooth(counting, ctx.spec, base, nodeToken, cfg);
             ctx.smoothingEvals.addAndGet(counting.evals());
         } else {
-            smoothed = SmoothingPolish.smooth(ctx.model, ctx.spec, in.yaws, nodeToken, cfg);
+            smoothed = SmoothingPolish.smooth(ctx.model, ctx.spec, base, nodeToken, cfg);
         }
+        if (smoothed == null) smoothed = base;
         if (smoothed == null) return NodeOutcome.of(Guarantee.DONE, in);
         return NodeOutcome.of(Guarantee.DONE, Candidate.of(ctx, smoothed));
     }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/DeWiggle.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/DeWiggle.java
@@ -1,0 +1,333 @@
+package de.legoshi.parkourcalc.core.anglesolver.solver;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/** Removes the short turn segments a feasibility repair leaves behind. The solved facing path splits into
+ *  maximal same-sign turn runs; a human's runs all carry tens of degrees, while a repaired path carries
+ *  runs of a fraction of a degree, which read as flicks. This pass takes each run below {@link #MIN_ARC_DEG},
+ *  replaces its span with a constant turn rate, and restores byte-exact feasibility with a Gauss-Newton step
+ *  that holds the flattened span fixed and measures correction size in second differences, so the restore
+ *  cannot re-introduce a flick. A candidate is kept only when it is strictly feasible and carries fewer
+ *  runs than before, so the pass can never make a path worse. */
+public final class DeWiggle {
+
+    public static final double MIN_ARC_DEG = 45.0;
+    private static final double FLOOR_DEG = 0.01;
+    private static final int MAX_GROW = 12;
+    private static final double METRIC_EPS = 5.0e-3;
+    private static final double MARGIN = 2.0e-4;
+    private static final int NEWTON_ITERS = 40;
+    private static final double FEAS_TOL = 0.0;
+
+    private DeWiggle() {
+    }
+
+    public static double[] run(ForwardModel model, JumpSpec spec, double[] yawsAbsWrapped, AtomicBoolean cancel) {
+        if (yawsAbsWrapped == null || yawsAbsWrapped.length < 3) return yawsAbsWrapped;
+        JumpPhysicsInputs sc = spec.asScenario();
+        JumpConstraintCompiler.Compiled compiled = JumpConstraintCompiler.compile(spec);
+        List<JumpConstraint> cs = usable(sc, spec);
+        if (cs.isEmpty()) return yawsAbsWrapped;
+        double anchor = sc.startYaw;
+        double[] y = Angles.wrapAll(yawsAbsWrapped.clone());
+        if (violation(model, sc, compiled, y) > FEAS_TOL) return yawsAbsWrapped;
+
+        Set<String> stuck = new HashSet<>();
+        while (true) {
+            if (cancel != null && cancel.get()) return y;
+            List<int[]> rs = runs(anchor, y);
+            int arcs = rs.size();
+            int[] pick = null;
+            double pickMass = 0.0;
+            for (int[] r : rs) {
+                double mass = Math.abs(mass(anchor, y, r[0], r[1]));
+                if (mass >= MIN_ARC_DEG) continue;
+                if (stuck.contains(r[0] + ":" + r[1])) continue;
+                if (pick == null || mass < pickMass) {
+                    pick = r;
+                    pickMass = mass;
+                }
+            }
+            if (pick == null) return y;
+            double[] taken = null;
+            for (int g = 0; g <= MAX_GROW && taken == null; g++) {
+                for (int side = 0; side < 3 && taken == null; side++) {
+                    int lo = pick[0];
+                    int hi = pick[1];
+                    if (side == 0 || side == 1) lo = Math.max(0, pick[0] - g);
+                    if (side == 0 || side == 2) hi = Math.min(y.length - 1, pick[1] + g);
+                    if (g > 0 && side > 0 && lo == pick[0] && hi == pick[1]) continue;
+                    double[] c = flatten(anchor, y, lo, hi);
+                    if (runs(anchor, c).size() >= arcs) continue;
+                    double viol = violation(model, sc, compiled, c);
+                    if (viol > FEAS_TOL) {
+                        c = repair(model, sc, compiled, spec, cs, c, lo, hi, cancel);
+                        if (c == null) continue;
+                        if (runs(anchor, c).size() >= arcs) continue;
+                    }
+                    taken = c;
+                }
+            }
+            if (taken == null) stuck.add(pick[0] + ":" + pick[1]);
+            else y = taken;
+        }
+    }
+
+    private static double[] flatten(double anchor, double[] y, int lo, int hi) {
+        int n = y.length;
+        double left = lo == 0 ? anchor : y[lo - 1];
+        double right = hi + 1 < n ? y[hi + 1] : y[hi];
+        int steps = hi + 1 < n ? hi - lo + 2 : hi - lo + 1;
+        double span = Angles.wrapDelta(right - left);
+        double[] c = y.clone();
+        for (int k = lo; k <= hi; k++) c[k] = Angles.wrap(left + span * (k - lo + 1.0) / steps);
+        return c;
+    }
+
+    private static double[] repair(ForwardModel model, JumpPhysicsInputs sc, JumpConstraintCompiler.Compiled compiled,
+                                   JumpSpec spec, List<JumpConstraint> cs, double[] start, int lo, int hi,
+                                   AtomicBoolean cancel) {
+        int n = start.length;
+        double[] y = start.clone();
+        double best = violation(model, sc, compiled, y);
+        int nf = 0;
+        for (int t = 0; t < n; t++) if (t < lo || t > hi) nf++;
+        if (nf == 0) return null;
+        int[] free = new int[nf];
+        int fi = 0;
+        for (int t = 0; t < n; t++) if (t < lo || t > hi) free[fi++] = t;
+        double[][] wmat = smoothMetric(free, n);
+
+        for (int it = 0; it < NEWTON_ITERS && best > FEAS_TOL; it++) {
+            if (cancel != null && cancel.get()) return null;
+            double[] r = residuals(model, sc, spec, cs, y);
+            boolean[] keep = new boolean[r.length];
+            int m = 0;
+            for (int i = 0; i < r.length; i++) {
+                keep[i] = r[i] < MARGIN * 4.0;
+                if (keep[i]) m++;
+            }
+            if (m == 0) break;
+            double[][] j = jacobian(sc, y, cs, keep);
+            double[] want = new double[m];
+            int q = 0;
+            for (int i = 0; i < r.length; i++) {
+                if (keep[i]) want[q++] = Math.max(0.0, MARGIN - r[i]);
+            }
+            double[][] jw = new double[m][nf];
+            for (int a = 0; a < m; a++) {
+                for (int x = 0; x < nf; x++) {
+                    double s = 0.0;
+                    for (int z = 0; z < nf; z++) s += j[a][free[z]] * wmat[z][x];
+                    jw[a][x] = s;
+                }
+            }
+            double[][] jjt = new double[m][m];
+            for (int a = 0; a < m; a++) {
+                for (int b = 0; b < m; b++) {
+                    double s = 0.0;
+                    for (int x = 0; x < nf; x++) s += jw[a][x] * j[b][free[x]];
+                    jjt[a][b] = s;
+                }
+            }
+            double scale = 0.0;
+            for (int a = 0; a < m; a++) scale = Math.max(scale, Math.abs(jjt[a][a]));
+            double[] lam = solveSym(jjt, want, scale * 1.0e-8 + 1.0e-18);
+            double[] dy = new double[n];
+            for (int a = 0; a < m; a++) {
+                if (lam[a] == 0.0) continue;
+                for (int x = 0; x < nf; x++) dy[free[x]] += lam[a] * jw[a][x];
+            }
+            boolean stepped = false;
+            for (double damp = 1.0; damp >= 1.0 / 64.0; damp *= 0.5) {
+                double[] c = new double[n];
+                for (int t = 0; t < n; t++) c[t] = Angles.wrap(y[t] + damp * dy[t]);
+                double v = violation(model, sc, compiled, c);
+                if (v < best - 1.0e-15 || v <= FEAS_TOL) {
+                    y = c;
+                    best = v;
+                    stepped = true;
+                    break;
+                }
+            }
+            if (!stepped) break;
+        }
+        return best <= FEAS_TOL ? y : null;
+    }
+
+    private static List<JumpConstraint> usable(JumpPhysicsInputs sc, JumpSpec spec) {
+        JumpLinearModel lin = new JumpLinearModel(sc);
+        List<JumpConstraint> out = new ArrayList<>();
+        for (JumpConstraint c : spec.constraints) {
+            if (c.t2 != null) continue;
+            if (c.mode != JumpConstraint.Mode.X && c.mode != JumpConstraint.Mode.Z) continue;
+            if (lin.compileWall(c, 0.0, null) == null) continue;
+            out.add(c);
+        }
+        return out;
+    }
+
+    private static double[] residuals(ForwardModel model, JumpPhysicsInputs sc, JumpSpec spec,
+                                      List<JumpConstraint> cs, double[] y) {
+        double[] gf = sc.toGameFacings(Angles.wrapAll(y));
+        ForwardPath p = model.forward(sc, gf);
+        double[] a = new double[cs.size()];
+        for (int i = 0; i < cs.size(); i++) {
+            JumpConstraint c = cs.get(i);
+            JumpPhysicsInputs.Axis ax = c.mode == JumpConstraint.Mode.X
+                    ? JumpPhysicsInputs.Axis.X : JumpPhysicsInputs.Axis.Z;
+            double got = p.getPos(c.t1, ax);
+            if (c.cmp == JumpConstraint.Cmp.GE) a[i] = got - c.rhs;
+            else if (c.cmp == JumpConstraint.Cmp.LE) a[i] = c.rhs - got;
+            else a[i] = -Math.abs(got - c.rhs);
+        }
+        return a;
+    }
+
+    private static double[][] jacobian(JumpPhysicsInputs sc, double[] y, List<JumpConstraint> cs, boolean[] keep) {
+        JumpLinearModel lin = new JumpLinearModel(sc);
+        int n = y.length;
+        double[] gf = sc.toGameFacings(Angles.wrapAll(y));
+        double rad = Math.PI / 180.0;
+        double[] ux = new double[n];
+        double[] uz = new double[n];
+        for (int t = 0; t < n; t++) {
+            double phi = lin.baseArg(t) + gf[t] * rad;
+            ux[t] = lin.mMag(t) * Math.cos(phi);
+            uz[t] = lin.mMag(t) * Math.sin(phi);
+        }
+        List<double[]> rows = new ArrayList<>();
+        for (int i = 0; i < cs.size(); i++) {
+            if (!keep[i]) continue;
+            JumpLinearModel.Wall w = lin.compileWall(cs.get(i), 0.0, null);
+            double[] row = new double[n];
+            for (int t = 0; t < n; t++) {
+                double du = w.axis == 0 ? -uz[t] : ux[t];
+                row[t] = -w.coef[t] * du * rad;
+            }
+            rows.add(row);
+        }
+        return rows.toArray(new double[0][]);
+    }
+
+    private static double[][] smoothMetric(int[] free, int n) {
+        int f = free.length;
+        double[][] a = new double[f][f];
+        int[] pos = new int[n];
+        for (int i = 0; i < n; i++) pos[i] = -1;
+        for (int i = 0; i < f; i++) pos[free[i]] = i;
+        double[] cf = {1.0, -2.0, 1.0};
+        for (int t = 1; t < n - 1; t++) {
+            int[] idx = {t - 1, t, t + 1};
+            for (int i = 0; i < 3; i++) {
+                int pi = pos[idx[i]];
+                if (pi < 0) continue;
+                for (int k = 0; k < 3; k++) {
+                    int pk = pos[idx[k]];
+                    if (pk < 0) continue;
+                    a[pi][pk] += cf[i] * cf[k];
+                }
+            }
+        }
+        for (int i = 0; i < f; i++) a[i][i] += METRIC_EPS;
+        return invert(a);
+    }
+
+    private static double[][] invert(double[][] a) {
+        int n = a.length;
+        double[][] w = new double[n][2 * n];
+        for (int i = 0; i < n; i++) {
+            System.arraycopy(a[i], 0, w[i], 0, n);
+            w[i][n + i] = 1.0;
+        }
+        for (int c = 0; c < n; c++) {
+            int piv = c;
+            for (int r = c + 1; r < n; r++) if (Math.abs(w[r][c]) > Math.abs(w[piv][c])) piv = r;
+            double[] tmp = w[c];
+            w[c] = w[piv];
+            w[piv] = tmp;
+            double d = w[c][c];
+            if (Math.abs(d) < 1.0e-14) d = d >= 0.0 ? 1.0e-14 : -1.0e-14;
+            for (int k = 0; k < 2 * n; k++) w[c][k] /= d;
+            for (int r = 0; r < n; r++) {
+                if (r == c) continue;
+                double f = w[r][c];
+                if (f == 0.0) continue;
+                for (int k = 0; k < 2 * n; k++) w[r][k] -= f * w[c][k];
+            }
+        }
+        double[][] out = new double[n][n];
+        for (int i = 0; i < n; i++) System.arraycopy(w[i], n, out[i], 0, n);
+        return out;
+    }
+
+    private static double[] solveSym(double[][] a, double[] b, double reg) {
+        int m = b.length;
+        double[][] w = new double[m][m + 1];
+        for (int i = 0; i < m; i++) {
+            System.arraycopy(a[i], 0, w[i], 0, m);
+            w[i][i] += reg;
+            w[i][m] = b[i];
+        }
+        for (int c = 0; c < m; c++) {
+            int piv = c;
+            for (int r = c + 1; r < m; r++) if (Math.abs(w[r][c]) > Math.abs(w[piv][c])) piv = r;
+            double[] tmp = w[c];
+            w[c] = w[piv];
+            w[piv] = tmp;
+            if (Math.abs(w[c][c]) < 1.0e-14) continue;
+            for (int r = 0; r < m; r++) {
+                if (r == c) continue;
+                double f = w[r][c] / w[c][c];
+                if (f == 0.0) continue;
+                for (int k = c; k <= m; k++) w[r][k] -= f * w[c][k];
+            }
+        }
+        double[] x = new double[m];
+        for (int i = 0; i < m; i++) x[i] = Math.abs(w[i][i]) < 1.0e-14 ? 0.0 : w[i][m] / w[i][i];
+        return x;
+    }
+
+    private static double violation(ForwardModel model, JumpPhysicsInputs sc,
+                                    JumpConstraintCompiler.Compiled compiled, double[] y) {
+        double[] gf = sc.toGameFacings(Angles.wrapAll(y));
+        return compiled.maxViolation(gf, model.forward(sc, gf));
+    }
+
+    private static double delta(double anchor, double[] y, int t) {
+        return Angles.wrapDelta(y[t] - (t == 0 ? anchor : y[t - 1]));
+    }
+
+    private static double mass(double anchor, double[] y, int lo, int hi) {
+        double s = 0.0;
+        for (int t = lo; t <= hi; t++) s += delta(anchor, y, t);
+        return s;
+    }
+
+    public static List<int[]> runs(double anchor, double[] y) {
+        List<int[]> out = new ArrayList<>();
+        int last = 0;
+        int start = 0;
+        for (int t = 0; t < y.length; t++) {
+            double d = delta(anchor, y, t);
+            if (Math.abs(d) <= FLOOR_DEG) continue;
+            int s = d > 0.0 ? 1 : -1;
+            if (last == 0) {
+                last = s;
+                start = t;
+                continue;
+            }
+            if (s != last) {
+                out.add(new int[] {start, t - 1});
+                last = s;
+                start = t;
+            }
+        }
+        if (last != 0) out.add(new int[] {start, y.length - 1});
+        return out;
+    }
+}

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/DeWiggleTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/DeWiggleTest.java
@@ -1,0 +1,124 @@
+package de.legoshi.parkourcalc.anglesolver;
+
+import de.legoshi.parkourcalc.core.anglesolver.solver.Angles;
+import de.legoshi.parkourcalc.core.anglesolver.solver.DeWiggle;
+import de.legoshi.parkourcalc.core.anglesolver.solver.ExactJumpModel;
+import de.legoshi.parkourcalc.core.anglesolver.solver.ForwardModel;
+import de.legoshi.parkourcalc.core.anglesolver.solver.JumpConstraint;
+import de.legoshi.parkourcalc.core.anglesolver.solver.JumpConstraintCompiler;
+import de.legoshi.parkourcalc.core.anglesolver.solver.JumpPhysicsInputs;
+import de.legoshi.parkourcalc.core.anglesolver.solver.JumpSpec;
+import de.legoshi.parkourcalc.core.anglesolver.solver.Objective;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * A feasibility repair leaves short same-sign turn runs behind, which read as flicks. The de-wiggle
+ * pass must collapse those runs while staying strictly feasible, and must be an exact no-op wherever
+ * it cannot: it may never hand back a path with more turn runs than it was given.
+ */
+public class DeWiggleTest {
+
+    private static final int N = 12;
+    private static final ForwardModel MODEL = ExactJumpModel.forMcVersion("1.8.9");
+
+    /** All-air, W-held segment from rest at facing 180 (running -Z). */
+    private static JumpPhysicsInputs airScenario() {
+        JumpPhysicsInputs sc = new JumpPhysicsInputs(N);
+        sc.startYaw = 180f;
+        sc.jumpTick = -1;
+        sc.jumpPerTick = new boolean[N];
+        sc.strafePerTick = new boolean[N];
+        sc.speedAmplifier = new int[N];
+        sc.slipPerTick = new double[N];
+        for (int t = 0; t < N; t++) sc.slipPerTick[t] = Double.NaN;
+        sc.yawLockedPerTick = new boolean[N];
+        return sc;
+    }
+
+    private static JumpSpec specWithLooseWall(JumpPhysicsInputs sc, double slack) {
+        double[] straight = new double[N];
+        Arrays.fill(straight, 180.0);
+        double z0 = sc.startPos.z;
+        double reach = MODEL.forward(sc, sc.toGameFacings(straight)).getPos(N, JumpPhysicsInputs.Axis.Z) - z0;
+        List<JumpConstraint> cons = new ArrayList<JumpConstraint>();
+        cons.add(new JumpConstraint(JumpConstraint.Mode.Z, N, null, JumpConstraint.Op.PLUS,
+                JumpConstraint.Cmp.GE, z0 + reach * slack, "zwall"));
+        return new JumpSpec(sc, cons, new Objective(JumpPhysicsInputs.Axis.Z, Objective.Sense.MIN, N));
+    }
+
+    private static double violation(JumpPhysicsInputs sc, JumpSpec spec, double[] y) {
+        double[] gf = sc.toGameFacings(Angles.wrapAll(y));
+        return JumpConstraintCompiler.compile(spec).maxViolation(gf, MODEL.forward(sc, gf));
+    }
+
+    @Test
+    public void collapsesAShortSpuriousRunAndStaysFeasible() {
+        JumpPhysicsInputs sc = airScenario();
+        JumpSpec spec = specWithLooseWall(sc, 1.5);
+
+        double[] start = new double[N];
+        Arrays.fill(start, 180.0);
+        start[5] = Angles.wrap(180.5);
+        assertEquals("the flicked start must be feasible", 0.0, violation(sc, spec, start), 0.0);
+
+        int startRuns = DeWiggle.runs(sc.startYaw, start).size();
+        assertTrue("the flick must show up as extra turn runs", startRuns >= 2);
+
+        double[] out = DeWiggle.run(MODEL, spec, start.clone(), new AtomicBoolean(false));
+
+        assertEquals("de-wiggling must stay strictly feasible", 0.0, violation(sc, spec, out), 0.0);
+        assertTrue("the short run must be gone (was " + startRuns
+                        + ", now " + DeWiggle.runs(sc.startYaw, out).size() + ")",
+                DeWiggle.runs(sc.startYaw, out).size() < startRuns);
+    }
+
+    @Test
+    public void longRunsAreLeftAlone() {
+        JumpPhysicsInputs sc = airScenario();
+        JumpSpec spec = specWithLooseWall(sc, 1.5);
+
+        double[] start = new double[N];
+        for (int t = 0; t < N; t++) {
+            double turn = t < N / 2 ? -10.0 * (t + 1) : -10.0 * (N - t);
+            start[t] = Angles.wrap(180.0 + turn);
+        }
+        assertEquals("the arc path must be feasible", 0.0, violation(sc, spec, start), 0.0);
+        for (int[] r : DeWiggle.runs(sc.startYaw, start)) {
+            double mass = 0.0;
+            double prev = r[0] == 0 ? sc.startYaw : start[r[0] - 1];
+            for (int t = r[0]; t <= r[1]; t++) {
+                mass += Angles.wrapDelta(start[t] - prev);
+                prev = start[t];
+            }
+            assertTrue("every run must clear the short-run threshold", Math.abs(mass) >= DeWiggle.MIN_ARC_DEG);
+        }
+
+        double[] out = DeWiggle.run(MODEL, spec, start.clone(), new AtomicBoolean(false));
+        assertArrayEquals("a path of long arcs must pass through bit for bit", start, out, 0.0);
+    }
+
+    @Test
+    public void infeasibleStartIsLeftUntouched() {
+        JumpPhysicsInputs sc = airScenario();
+        List<JumpConstraint> cons = new ArrayList<JumpConstraint>();
+        cons.add(new JumpConstraint(JumpConstraint.Mode.Z, N, null, JumpConstraint.Op.PLUS,
+                JumpConstraint.Cmp.GE, sc.startPos.z + 50.0, "unreachable"));
+        JumpSpec spec = new JumpSpec(sc, cons, new Objective(JumpPhysicsInputs.Axis.Z, Objective.Sense.MIN, N));
+
+        double[] start = new double[N];
+        Arrays.fill(start, 180.0);
+        start[5] = Angles.wrap(180.5);
+        double[] out = DeWiggle.run(MODEL, spec, start.clone(), new AtomicBoolean(false));
+        assertArrayEquals("a failed solve must pass through unchanged for honest reporting",
+                start, out, 0.0);
+    }
+}


### PR DESCRIPTION
Closes #414.

## What was wrong

Two independent causes, both measured on `mopus/1-dev.json` (X-MAX, THOROUGH, 10 s, smoothLambda 0.01, 22 constraints, 4 jumps, T1015 to T1064).

**1. The final smoothing pass never got any budget.** `GraphRunner` set `wrapPending` when the graph merely *contained* a `wrapIls` node and only cleared it when that node actually executed. When a router branched around it (`rWrapLegal FALSE -> rTrans`), the 2.5 s wrap reserve was never released, so every later node got `deadline = overall - wrapReserve`, already in the past. Measured: `smoothFinal` entered with `remainingMs=0` while the overall budget still had **2478 ms**, the watchdog set the token and the first eval threw `SolveCancelledException`.

**2. The repair creates the flicks, not the search.** The dual already returns the right shape:

| | turn runs | shortest run | reversals | jerk | violation |
| --- | --- | --- | --- | --- | --- |
| raw dual | 8 | 11.5 deg | 7 | 998 | 3.77e-2 |
| after `SlpSolve.optimize` | 13 | **0.60 deg** | 12 | 1078 | 0 |

Closing those few centimetres invents six short runs (`-0.60, +6.52, +23.38, +7.03, -3.45, +0.60`). `TrustRegionLp.run` in phase 1 minimises the violation slack and returns immediately, so `obj` is never used there and the result is the raw simplex **vertex** of the step polytope. A vertex drives as few variables as possible to their bounds, which in yaw terms means spiking a few ticks: among all steps that close the gap equally well the simplex picks the spikiest by construction.

## What this does

- `GraphRunner`: release the wrap reserve as soon as `wrapIls` is unreachable from the current node (BFS over the graph edges). Without this nothing downstream runs at all.
- `DeWiggle` (new): take each same-sign turn run carrying less than 45 degrees, replace its tick span with a constant turn rate, and restore byte-exact feasibility with a Gauss-Newton step that (a) holds the flattened span frozen and (b) measures correction size in second differences rather than magnitude, so the restore cannot re-introduce a flick. A candidate is kept only when it is strictly feasible **and** carries fewer runs than before, so the pass can never return a worse path.
- Wired through a new `deWiggle` param on the existing `smoothing` node type, set true only on the final smoothing node.

## Scope

It runs **only when Smooth (TAS) is on** (`smoothLambda > 0`). Verified on the reported TAS:

| | turn runs | reversals | jerk | objective |
| --- | --- | --- | --- | --- |
| Smooth off | 13 | 12 | 1184.1 | 4799.7000000 (exact cap) |
| Smooth on | 7 | 6 | 902.5 | 4799.6818477 |

Smoothing off is unchanged bit for bit and keeps the exact cap objective. With smoothing on the path costs 0.015 blocks of X, which is the trade the toggle exists to make.

Against the released 1.9.0 on the same TAS (8 runs, 7 reversals, jerk 772): this is better on runs and reversals, still behind on jerk.

## Constants

Swept, not guessed. `MARGIN = 2e-4` (1e-3 always fails to keep the arc reduction, 1e-4 also works); `METRIC_EPS = 5e-3` (3e-3 to 5e-2 all reach 7 runs; 1e-2 gives the lowest jerk at 970 but a shortest run of 10.2, 5e-3 gives 13.8). `MIN_ARC_DEG = 45` is the threshold that gets runs 11 to 7 on this file.

## Tests

`DeWiggleTest`: a short spurious run collapses and the result stays strictly feasible; a path of long arcs passes through bit for bit; an infeasible input is left untouched.

Full `:core:check -PslowTests` green: 127 classes, 690 tests, 0 failures, 0 errors, 32 skipped. `tableStyleCheck` clean.

## Known limits

- On a 6-file corpus this helps the reported TAS substantially and is **inert on the other five**, never worse. Two traced causes: (a) when `wrap` returns `Guarantee.ADOPTED` it edges straight to `emit`, skipping `rTrans`/`translate`/`smoothFinal` entirely, and `WrapIlsNode` also sets `stageLocked(true)`, so a wrap-adopted path is never de-wiggled. Changing that needs a ruling on whether a wrap-adopted path may be perturbed at all. (b) some short runs are genuinely load-bearing: on `ben-test` the 0.342 degree run at the last four ticks survives 93 flatten attempts and 10 repairs.
- A short run below the sine-bucket-limited freedom of its neighbours cannot always be removed. The pass reports no change rather than forcing one.
