### PR TITLE
fix(solver): score Smooth (TAS) on turn-direction changes, not jerk

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/Angles.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/Angles.java
@@ -66,6 +66,33 @@ public final class Angles {
         return jerk;
     }
 
+    public static final double REVERSAL_COST_DEG = 90.0;
+    public static final double RATE_TIEBREAK = 0.02;
+
+    public static int reversals(double anchorYaw, double[] f, double floorDeg) {
+        int count = 0;
+        int lastSign = 0;
+        double prev = anchorYaw;
+        for (double v : f) {
+            double d = v - prev;
+            d -= 360.0 * Math.round(d / 360.0);
+            prev = v;
+            if (Math.abs(d) <= floorDeg) continue;
+            int sign = d > 0.0 ? 1 : -1;
+            if (lastSign != 0 && sign != lastSign) count++;
+            lastSign = sign;
+        }
+        return count;
+    }
+
+    /** The turn-direction cost the Smooth (TAS) objective minimises: a fixed charge per sign change in
+     *  the per-tick yaw deltas. A run that keeps turning one way is free whatever its rates do, so
+     *  10 10 10 10 and 10 20 30 40 both cost nothing and 10 -10 10 -10 costs three reversals. */
+    public static double turnCost(double anchorYaw, double[] f) {
+        return REVERSAL_COST_DEG * reversals(anchorYaw, f, REVERSAL_FLOOR_DEG)
+                + RATE_TIEBREAK * wiggleDeg(anchorYaw, f);
+    }
+
     public static double wiggleDeg(double anchorYaw, double[] f) {
         if (f.length < 2) return 0.0;
         double jerk = 0.0;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/Objective.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/Objective.java
@@ -27,7 +27,7 @@ public final class Objective {
 
     public double smoothPenalty(double anchorYaw, double[] yawsAbs) {
         if (smoothLambda <= 0.0 || yawsAbs == null || yawsAbs.length < 2) return 0.0;
-        return smoothLambda * Angles.wiggleDeg(anchorYaw, yawsAbs);
+        return smoothLambda * Angles.turnCost(anchorYaw, yawsAbs);
     }
 
     public double scored(double raw, double anchorYaw, double[] yawsAbs) {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/SolveProgress.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/SolveProgress.java
@@ -114,7 +114,7 @@ public final class SolveProgress {
 
     private double scoredOf(double objective, double[] yaws) {
         if (smoothLambda <= 0.0 || yaws == null || yaws.length < 2) return objective;
-        double pen = smoothLambda * Angles.wiggleDeg(anchorYaw, yaws);
+        double pen = smoothLambda * Angles.turnCost(anchorYaw, yaws);
         return maximize ? objective - pen : objective + pen;
     }
 

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/graph/SmoothLambdaScoringTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/graph/SmoothLambdaScoringTest.java
@@ -33,15 +33,41 @@ public class SmoothLambdaScoringTest {
 
     @Test
     public void scoredAppliesLambdaBySense() {
+        // deltas +10 then -10: one sign change, so one reversal at REVERSAL_COST_DEG.
         double[] yaws = {0.0, 10.0, 0.0};
+        double pen = 0.01 * Angles.turnCost(0.0, yaws);
         Objective maxObj = new Objective(JumpPhysicsInputs.Axis.X, Objective.Sense.MAX, 3, 0.01);
-        assertEquals(5.0 - 0.3, maxObj.scored(5.0, 0.0, yaws), 1.0e-12);
+        assertEquals(5.0 - pen, maxObj.scored(5.0, 0.0, yaws), 1.0e-12);
         Objective minObj = new Objective(JumpPhysicsInputs.Axis.X, Objective.Sense.MIN, 3, 0.01);
-        assertEquals(5.0 + 0.3, minObj.scored(5.0, 0.0, yaws), 1.0e-12);
+        assertEquals(5.0 + pen, minObj.scored(5.0, 0.0, yaws), 1.0e-12);
         Objective zero = new Objective(JumpPhysicsInputs.Axis.X, Objective.Sense.MAX, 3);
         assertEquals(0.0, zero.smoothLambda, 0.0);
         assertEquals(5.0, zero.scored(5.0, 0.0, yaws), 0.0);
         assertEquals(0.0, zero.smoothPenalty(0.0, yaws), 0.0);
+    }
+
+
+    @Test
+    public void turnCostChargesSignChangesAndIgnoresRateChanges() {
+        // Relative yaw values are the deltas between consecutive absolute yaws. A run that keeps
+        // turning one way costs at most the rate tiebreak, far below a single reversal.
+        assertEquals(0.0, Angles.turnCost(0.0, new double[] {10.0, 20.0, 30.0, 40.0}), 0.0);   // 10 10 10 10
+        assertTrue(Angles.turnCost(0.0, new double[] {10.0, 30.0, 60.0, 100.0})                // 10 20 30 40
+                < Angles.REVERSAL_COST_DEG / 10.0);
+        assertTrue(Angles.turnCost(0.0, new double[] {10.0, 30.0, 40.0, 60.0})                 // 10 20 10 20
+                < Angles.REVERSAL_COST_DEG / 10.0);
+
+        // Flipping direction costs a fixed charge per flip, whatever the size of the flip.
+        assertEquals(3, Angles.reversals(0.0, new double[] {10.0, 0.0, 10.0, 0.0},             // 10 -10 10 -10
+                Angles.REVERSAL_FLOOR_DEG));
+        assertEquals(2, Angles.reversals(0.0, new double[] {10.0, 30.0, 29.0, 69.0},           // 10 20 -1 40
+                Angles.REVERSAL_FLOOR_DEG));
+        assertEquals(Angles.reversals(0.0, new double[] {10.0, 30.0, 29.0, 69.0}, Angles.REVERSAL_FLOOR_DEG),
+                Angles.reversals(0.0, new double[] {10.0, 30.0, 20.0, 60.0}, Angles.REVERSAL_FLOOR_DEG));
+
+        // A single reversal always outweighs any rate variation within one direction.
+        assertTrue(Angles.turnCost(0.0, new double[] {10.0, 30.0, 29.0, 69.0})
+                > Angles.turnCost(0.0, new double[] {10.0, 30.0, 60.0, 100.0}));
     }
 
     @Test


### PR DESCRIPTION
Closes #416.

## The problem

Smooth (TAS) minimised `Angles.wiggleDeg`, the sum of absolute second differences of the yaw. Taking the per-tick relative yaw values:

| relative yaw values | verdict | jerk cost |
| --- | --- | --- |
| `10 10 10 10` | good | 0 |
| `10 20 30 40` | good, steady acceleration | 30 |
| `10 20 10 20` | acceptable, never turns back | 30 |
| `10 -10 10 -10` | bad | 60 |
| `10 20 -1 40` | bad, the `-1` is as unwanted as a `-10` | shrinks with the flip |

Jerk charges rate variation as if it were a defect, and charges a reversal in proportion to its size. So a clean ramp is penalised and a small flip is nearly free, which means the search buys a small reversal whenever it gains any objective.

## The change

`Angles.turnCost` charges a fixed `REVERSAL_COST_DEG` per sign change in the deltas, plus `RATE_TIEBREAK * jerk` as a tiebreak only, three orders below a single reversal.

The tiebreak is not cosmetic: a pure integer count is flat almost everywhere and leaves the search with no direction to follow. Dropping it costs three reversals on the longest corpus file (`jvel` 20 to 23).

`Objective.smoothPenalty` and `SolveProgress` use it. `wiggleDeg` stays, since it is still what the panel reports as "Yaw jerk" and what `SolveRunRecord` records; only the objective changes.

## Measured

Reversal count in the solved window, 6 saves, THOROUGH, 10 s, smoothLambda 0.01:

| file | jerk objective | turn cost |
| --- | --- | --- |
| mopus/1-dev | 10 | **6** |
| thousand/1 | 8 | **6** |
| ben-test | 4 | **1** |
| dsfdsffds | 2 | 2 |
| ben-one-turn | 1 | 1 |
| jvel_Linkcraft | 19 | 20 |

Net 8 fewer reversals, one file one worse. Deterministic across repeats (checked 3x on `jvel`).

Full `:core:check -PslowTests` green: 128 classes, 693 tests, 0 failures, 0 errors, 32 skipped.

## Known limits

- `jvel_Linkcraft` goes 19 to 20. It is the longest file (123 ticks, 43 constraints) and has around 20 genuine redirects, so this is one extra flip on a file that is mostly real turning.
- The reversal term is integer and non-differentiable, so it works at the derivative-free ranking sites only. It cannot enter an ALM/BFGS gradient path if one is ever reintroduced.
- The panel's "Yaw jerk" uses the unanchored `wiggleDeg(yaws)` while the objective uses the anchored `wiggleDeg(anchor, yaws)`, so the two differ by the launch-yaw term. Pre-existing, not addressed here.
