### PR TITLE
docs(research): audit why the closed form fails to certify

### DIFF
--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/CostateScreen.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/CostateScreen.java
@@ -1,0 +1,132 @@
+package de.legoshi.parkourcalc.anglesolver;
+
+import de.legoshi.parkourcalc.anglesolver.harness.Fixtures;
+import de.legoshi.parkourcalc.core.anglesolver.AngleSolverEngine;
+import de.legoshi.parkourcalc.core.anglesolver.AngleSolverState;
+import de.legoshi.parkourcalc.core.anglesolver.solver.Angles;
+import de.legoshi.parkourcalc.core.anglesolver.solver.CostateDualSolver;
+import de.legoshi.parkourcalc.core.anglesolver.solver.ExactJumpModel;
+import de.legoshi.parkourcalc.core.anglesolver.solver.JumpConstraint;
+import de.legoshi.parkourcalc.core.anglesolver.solver.JumpLinearModel;
+import de.legoshi.parkourcalc.core.anglesolver.solver.JumpPhysicsInputs;
+import de.legoshi.parkourcalc.core.anglesolver.solver.JumpSpec;
+import de.legoshi.parkourcalc.core.save.SaveFile;
+import de.legoshi.parkourcalc.core.save.SaveIO;
+import de.legoshi.parkourcalc.core.ui.InputData;
+import org.junit.Assume;
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * gh-418 screen: the dual recovers each tick as u_t = m_t * g_t / sqrt(|g_t|^2 + EPS2). Where |g_t| is
+ * small the direction is arbitrary and the magnitude falls below m_t, so the wall values the dual
+ * believes are not the wall values the recovered yaws actually produce. This prints |g_t| per tick and
+ * both wall evaluations side by side.
+ */
+public class CostateScreen {
+
+    private static final double EPS2 = 1.0e-14;
+
+    @Test
+    public void screen() throws Exception {
+        Assume.assumeTrue("set PKC_SCREENS=1", "1".equals(System.getenv("PKC_SCREENS")));
+        String path = System.getenv("PKC_CS_FILE");
+        Assume.assumeTrue("set PKC_CS_FILE", path != null && !path.isEmpty());
+
+        SaveFile file = SaveIO.parseSafe(new String(Files.readAllBytes(new File(path).toPath()),
+                StandardCharsets.UTF_8));
+        ExactJumpModel model = ExactJumpModel.forMcVersion(file.mcVersion);
+        InputData inputs = new InputData();
+        SaveIO.applyRowsTo(file, inputs);
+        AngleSolverState state = new AngleSolverState();
+        SaveIO.applyAngleSolverTo(file, state);
+        state.clearResult();
+        AngleSolverEngine engine = new AngleSolverEngine(state, Fixtures.buildBoxes(file), inputs, t -> { }, model);
+        JumpSpec spec = engine.debugBuildSpec();
+        JumpPhysicsInputs sc = spec.asScenario();
+        int n = sc.numTicks;
+
+        JumpLinearModel lin = new JumpLinearModel(sc);
+        List<JumpConstraint> ineq = new ArrayList<JumpConstraint>();
+        List<JumpLinearModel.Wall> walls = new ArrayList<JumpLinearModel.Wall>();
+        for (JumpConstraint c : spec.constraints) {
+            if (c.mode == JumpConstraint.Mode.F) continue;
+            JumpLinearModel.Wall w = lin.compileWall(c, 0.0, null);
+            if (w != null) {
+                ineq.add(c);
+                walls.add(w);
+            }
+        }
+        double[] cx = new double[n];
+        double[] cz = new double[n];
+        lin.objectiveVectors(spec.objective, cx, cz);
+
+        System.out.println("=== CS file=" + new File(path).getName() + " n=" + n + " walls=" + walls.size()
+                + " EPS2=" + EPS2 + " ===");
+        CostateDualSolver dual = new CostateDualSolver(n, cx, cz, lin.mMagAll(), walls);
+        double margin = Double.parseDouble(System.getenv("PKC_CS_MARGIN") == null
+                ? "0" : System.getenv("PKC_CS_MARGIN"));
+        CostateDualSolver.Result r = dual.solve(margin, null);
+        System.out.printf("CS margin=%.4g iters=%d pgres=%.4e stalled=%s dualValue=%.9f%n",
+                margin, dual.lastIters, dual.lastPgres, dual.lastStalled, r.value);
+
+        System.out.println("CS --- per tick: costate norm and the recovered magnitude ---");
+        double[] ux = new double[n];
+        double[] uz = new double[n];
+        double[] yaw = new double[n];
+        int degenerate = 0;
+        for (int t = 0; t < n; t++) {
+            double gx = r.gx[t];
+            double gz = r.gz[t];
+            double nrm = Math.sqrt(gx * gx + gz * gz);
+            double smoothed = Math.sqrt(gx * gx + gz * gz + EPS2);
+            double mm = lin.mMag(t);
+            ux[t] = mm / smoothed * gx;
+            uz[t] = mm / smoothed * gz;
+            double recovered = Math.hypot(ux[t], uz[t]);
+            double ratio = mm == 0.0 ? 1.0 : recovered / mm;
+            yaw[t] = lin.recoverYawDeg(t, gx, gz);
+            boolean weak = nrm < 1.0e-6;
+            if (weak) degenerate++;
+            if (weak || ratio < 0.999999 || "1".equals(System.getenv("PKC_CS_ALL"))) {
+                System.out.printf("CS   t=%-4d |g|=%12.6e mMag=%10.6f recovered=%10.6f ratio=%.9f yaw=%9.4f%s%n",
+                        t, nrm, mm, recovered, ratio, yaw[t], weak ? "  <-WEAK" : "");
+            }
+        }
+        System.out.printf("CS ticks with |g| < 1e-6: %d of %d%n", degenerate, n);
+
+        System.out.println("CS --- per wall: what the dual believes vs what the recovered yaws give ---");
+        double[] tx = new double[n];
+        double[] tz = new double[n];
+        for (int t = 0; t < n; t++) {
+            double phi = lin.baseArg(t) + yaw[t] * Math.PI / 180.0;
+            tx[t] = lin.mMag(t) * Math.cos(phi);
+            tz[t] = lin.mMag(t) * Math.sin(phi);
+        }
+        double worst = 0.0;
+        for (int j = 0; j < walls.size(); j++) {
+            JumpLinearModel.Wall w = walls.get(j);
+            double[] u = w.axis == 0 ? ux : uz;
+            double[] tu = w.axis == 0 ? tx : tz;
+            double believed = 0.0;
+            double actual = 0.0;
+            for (int t = 0; t < n; t++) {
+                believed += w.coef[t] * u[t];
+                actual += w.coef[t] * tu[t];
+            }
+            double slackBelieved = w.bPrime - believed;
+            double slackActual = w.bPrime - actual;
+            if (slackActual < worst) worst = slackActual;
+            System.out.printf("CS   wall %-3d %-2s t=%-4d lam=%12.6e bPrime=%14.7f believed=%14.7f actual=%14.7f "
+                            + "slackBelieved=%11.3e slackActual=%11.3e %s%n",
+                    j, w.axis == 0 ? "X" : "Z", ineq.get(j).t1, r.lambda[j], w.bPrime, believed, actual,
+                    slackBelieved, slackActual, slackActual < 0 ? "VIOLATED" : "");
+        }
+        System.out.printf("CS worst actual linear slack = %.9e%n", worst);
+    }
+}

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/DualCertScreen.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/DualCertScreen.java
@@ -1,0 +1,149 @@
+package de.legoshi.parkourcalc.anglesolver;
+
+import de.legoshi.parkourcalc.anglesolver.harness.Fixtures;
+import de.legoshi.parkourcalc.core.anglesolver.AngleSolverEngine;
+import de.legoshi.parkourcalc.core.anglesolver.AngleSolverState;
+import de.legoshi.parkourcalc.core.anglesolver.solver.Angles;
+import de.legoshi.parkourcalc.core.anglesolver.solver.ClosedFormSolve;
+import de.legoshi.parkourcalc.core.anglesolver.solver.ExactJumpModel;
+import de.legoshi.parkourcalc.core.anglesolver.solver.ForwardPath;
+import de.legoshi.parkourcalc.core.anglesolver.solver.JumpConstraint;
+import de.legoshi.parkourcalc.core.anglesolver.solver.JumpConstraintCompiler;
+import de.legoshi.parkourcalc.core.anglesolver.solver.JumpLinearModel;
+import de.legoshi.parkourcalc.core.anglesolver.solver.JumpPhysicsInputs;
+import de.legoshi.parkourcalc.core.anglesolver.solver.JumpSpec;
+import de.legoshi.parkourcalc.core.save.SaveFile;
+import de.legoshi.parkourcalc.core.save.SaveIO;
+import de.legoshi.parkourcalc.core.ui.InputData;
+import org.junit.Assume;
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * gh-418 screen: why does the closed form fail to certify? At the dual's own answer this prints the
+ * linear model's predicted position against the byte-exact forward for every tick and every
+ * constraint, plus the per-tick velocity against the inertia threshold, so the divergence is
+ * localised rather than guessed at. Skipped unless PKC_SCREENS is set; PKC_DC_FILE names the save.
+ */
+public class DualCertScreen {
+
+    private static final double RAD = Math.PI / 180.0;
+
+    static double uAxis(JumpLinearModel lin, int axis, int s, double gfDeg) {
+        double phi = lin.baseArg(s) + gfDeg * RAD;
+        return lin.mMag(s) * (axis == 0 ? Math.cos(phi) : Math.sin(phi));
+    }
+
+    static double linPos(JumpLinearModel lin, int axis, int k, double[] gf) {
+        double p = lin.constPos(k, axis);
+        for (int s = 0; s < k; s++) {
+            double c = lin.coefAxis(axis, s, k);
+            if (c == 0.0) continue;
+            p += c * uAxis(lin, axis, s, gf[s]);
+        }
+        return p;
+    }
+
+    @Test
+    public void screen() throws Exception {
+        Assume.assumeTrue("set PKC_SCREENS=1", "1".equals(System.getenv("PKC_SCREENS")));
+        String path = System.getenv("PKC_DC_FILE");
+        Assume.assumeTrue("set PKC_DC_FILE", path != null && !path.isEmpty());
+
+        SaveFile file = SaveIO.parseSafe(new String(Files.readAllBytes(new File(path).toPath()),
+                StandardCharsets.UTF_8));
+        ExactJumpModel model = ExactJumpModel.forMcVersion(file.mcVersion);
+        InputData inputs = new InputData();
+        SaveIO.applyRowsTo(file, inputs);
+        AngleSolverState state = new AngleSolverState();
+        SaveIO.applyAngleSolverTo(file, state);
+        state.clearResult();
+        AngleSolverEngine engine = new AngleSolverEngine(state, Fixtures.buildBoxes(file), inputs, t -> { }, model);
+        JumpSpec spec = engine.debugBuildSpec();
+        JumpPhysicsInputs sc = spec.asScenario();
+        int n = sc.numTicks;
+        AtomicBoolean cancel = new AtomicBoolean(false);
+
+        System.out.println("=== DC file=" + new File(path).getName() + " mc=" + file.mcVersion
+                + " n=" + n + " cons=" + spec.constraints.size()
+                + " thr=" + model.inertiaThreshold() + " perAxis=" + model.perAxisInertia()
+                + " startTick=" + state.getStartTick() + " ===");
+        System.out.printf("DC start pos=(%.9f, %.9f) vel=(%.9f, %.9f) startYaw=%.6f%n",
+                sc.startPos.x, sc.startPos.z, sc.initialVelocity.x, sc.initialVelocity.z, sc.startYaw);
+
+        ClosedFormSolve.Result r = ClosedFormSolve.optimizeRobustGraded(model, spec, 0.0, cancel);
+        if (r == null || r.yaws == null) {
+            System.out.println("DC dual returned null");
+            return;
+        }
+        System.out.printf("DC dual viol=%.9e feasible=%s%n", r.violation, r.feasible);
+
+        double[] y = Angles.wrapAll(r.yaws);
+        double[] gf = sc.toGameFacings(y);
+        ForwardPath p = model.forward(sc, gf);
+        JumpLinearModel lin = new JumpLinearModel(sc);
+
+        System.out.println("DC --- per-tick: linear model vs byte-exact ---");
+        System.out.printf("DC %-4s %9s %9s %14s %14s %11s %14s %14s %11s %11s %-5s%n",
+                "tick", "yawAbs", "gameFace", "linX", "exactX", "dX", "linZ", "exactZ", "dZ", "dist", "grnd");
+        double worst = 0.0;
+        int worstTick = -1;
+        double prevD = 0.0;
+        for (int k = 0; k <= n; k++) {
+            double lx = linPos(lin, 0, k, gf);
+            double lz = linPos(lin, 1, k, gf);
+            double ex = p.getPos(k, JumpPhysicsInputs.Axis.X);
+            double ez = p.getPos(k, JumpPhysicsInputs.Axis.Z);
+            double dx = lx - ex;
+            double dz = lz - ez;
+            double d = Math.hypot(dx, dz);
+            boolean grounded = k < n && !Double.isNaN(sc.slipAt(k));
+            String jump = k < n && sc.jumpAt(k) && grounded ? " JUMP" : "";
+            String step = d - prevD > 1.0e-4 ? "  <-STEP" : "";
+            System.out.printf("DC %-4d %9.4f %9.4f %14.9f %14.9f %11.3e %14.9f %14.9f %11.3e %11.3e %-5s%s%s%n",
+                    k, k < n ? y[k] : Double.NaN, k < n ? gf[k] : Double.NaN,
+                    lx, ex, dx, lz, ez, dz, d, grounded ? "yes" : "air", jump, step);
+            if (d > worst) {
+                worst = d;
+                worstTick = k;
+            }
+            prevD = d;
+        }
+        System.out.printf("DC worst per-tick divergence %.9e at tick %d%n", worst, worstTick);
+
+        System.out.println("DC --- per-tick velocity against the inertia gate ---");
+        boolean[] zx = new boolean[n];
+        boolean[] zz = new boolean[n];
+        lin.zeroingPattern(y, model.inertiaThreshold(), model.perAxisInertia(), zx, zz);
+        double thr = model.inertiaThreshold();
+        for (int k = 0; k < n; k++) {
+            double vx = p.velX == null ? Double.NaN : p.velX[k];
+            double vz = p.velZ == null ? Double.NaN : p.velZ[k];
+            boolean nearX = Math.abs(vx) < 2.0 * thr;
+            boolean nearZ = Math.abs(vz) < 2.0 * thr;
+            if (zx[k] || zz[k] || nearX || nearZ) {
+                System.out.printf("DC   t=%-4d vx=%14.9f vz=%14.9f linZeroX=%-5s linZeroZ=%-5s %s%s%n",
+                        k, vx, vz, zx[k], zz[k], nearX ? "vxUNDER2xTHR " : "", nearZ ? "vzUNDER2xTHR" : "");
+            }
+        }
+
+        System.out.println("DC --- per-constraint: linear prediction vs exact ---");
+        JumpConstraintCompiler.Compiled comp = JumpConstraintCompiler.compile(spec);
+        for (JumpConstraint c : spec.constraints) {
+            if (c.t2 != null) continue;
+            if (c.mode != JumpConstraint.Mode.X && c.mode != JumpConstraint.Mode.Z) continue;
+            int axis = c.mode == JumpConstraint.Mode.X ? 0 : 1;
+            double lv = linPos(lin, axis, c.t1, gf);
+            double ev = p.getPos(c.t1, axis == 0 ? JumpPhysicsInputs.Axis.X : JumpPhysicsInputs.Axis.Z);
+            double slackLin = c.cmp == JumpConstraint.Cmp.GE ? lv - c.rhs : c.rhs - lv;
+            double slackEx = c.cmp == JumpConstraint.Cmp.GE ? ev - c.rhs : c.rhs - ev;
+            System.out.printf("DC   %s t=%-4d %-2s rhs=%14.7f lin=%14.7f exact=%14.7f linSlack=%11.3e exactSlack=%11.3e %s%n",
+                    c.mode, c.t1, c.cmp, c.rhs, lv, ev, slackLin, slackEx, slackEx < 0 ? "VIOLATED" : "");
+        }
+        System.out.printf("DC exact maxViolation=%.9e%n", comp.maxViolation(gf, p));
+    }
+}

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/TESTS.md
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/TESTS.md
@@ -15,6 +15,11 @@ anglesolver/
                            panel moves and Cancel keeps the best found so far
   HpkDualRecoveryScreen.java  dev miss-screen over captures/hpk/ (dual bound + full chain per capture);
                               skipped unless PKC_SCREENS is set; report at build/reports/hpk-screen.txt
+  DualCertScreen.java      dev gh-418 diagnostic: at the dual's own answer, prints the linear model's
+                           predicted position against the byte-exact forward per tick, the per-tick
+                           velocity against the inertia gate, and every constraint as the linear model
+                           and the exact model each see it; skipped unless PKC_SCREENS is set,
+                           PKC_DC_FILE names the save. Findings in docs/research/dual-certification-audit.md
   RelaxDiagScreen.java     dev per-capture recovery diagnostic (stall margins, recorded-path replay);
                            skipped unless PKC_SCREENS is set; report at build/reports/relax-diag.txt
   LoopmmReachScreen.java   dev reach diagnostic on loopmm (pattern-branched B&B loose/tight, engine

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/TESTS.md
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/TESTS.md
@@ -20,6 +20,11 @@ anglesolver/
                            velocity against the inertia gate, and every constraint as the linear model
                            and the exact model each see it; skipped unless PKC_SCREENS is set,
                            PKC_DC_FILE names the save. Findings in docs/research/dual-certification-audit.md
+  CostateScreen.java       dev gh-418 diagnostic: runs CostateDualSolver directly on the walls the
+                           closed form builds and prints, per tick, the costate norm against the
+                           magnitude the recovery actually produces, then per wall what the dual
+                           believes against what the recovered yaws give; skipped unless PKC_SCREENS
+                           is set, PKC_CS_FILE names the save
   RelaxDiagScreen.java     dev per-capture recovery diagnostic (stall margins, recorded-path replay);
                            skipped unless PKC_SCREENS is set; report at build/reports/relax-diag.txt
   LoopmmReachScreen.java   dev reach diagnostic on loopmm (pattern-branched B&B loose/tight, engine

--- a/docs/research/dual-certification-audit.md
+++ b/docs/research/dual-certification-audit.md
@@ -1,0 +1,82 @@
+# Why the closed form fails to certify (gh-418)
+
+Measured 2026-08-23 on dev `3ba6d3c4`. Tool: `core/src/test/.../anglesolver/DualCertScreen.java`
+(`PKC_SCREENS=1 PKC_DC_FILE=<save.json>`).
+
+## Result
+
+**The failure is the dual returning a primal point that is infeasible in its own linear model. It is
+not a linear-versus-byte-exact model gap.**
+
+At the dual's own answer, for six solved saves, comparing the dual's exact violation against the
+worst violation the *linear* model itself reports on the same yaws, and against the largest
+per-tick divergence between the linear prediction and the byte-exact forward:
+
+| save | dual violation | worst linear-model violation | worst model divergence | certifies |
+| --- | --- | --- | --- | --- |
+| dsfdsffds | 0 | none | 8.6e-4 | yes |
+| ben-one-turn | 0 | none | **1.46e-1** | yes |
+| mopus/1-dev | 3.77e-2 | -3.47e-2 | 3.0e-3 | no |
+| ben-test | 7.25e-2 | -2.11e-2 | 8.39e-2 | no |
+| thousand/1 | 1.116 | **-1.116** | **6.9e-4** | no |
+| jvel_Linkcraft | 1.840 | **-1.860** | 2.86e-2 | no |
+
+Two readings settle it:
+
+- On `thousand/1` the dual violation and the dual's own linear violation agree to three digits
+  (1.116) while the physics divergence is **1600x smaller** (6.9e-4). The dual is not being betrayed
+  by the physics; it never solved its own problem.
+- `ben-one-turn` **certifies while carrying the largest model divergence in the corpus** (1.46e-1).
+  Divergence does not predict certification. Linear feasibility does: the two certifying saves are
+  exactly the two with zero linear-model violations.
+
+This reproduces and generalises the 2026-06-10 finding on `speedrun_nightmare_v3` ("a recovery that
+violates the LINEAR model's own X@102 wall by ~0.19, dual recovery gap, unrelated to quantization")
+and on `_v7` ("linViol==exactViol to ~1e-3, so model-independent"). See
+`closedform-recovery-gap` notes and gh-204.
+
+## Ruled out, with numbers
+
+Each of these was tried on `mopus/1-dev` before the linear-feasibility check pointed elsewhere.
+
+- **Margin ladder too short.** `ClosedFormSolve.Config.margins` tops out at 1.0e-2 and its comment
+  sizes it for "the ~1e-4 sine-table perturbation". Seventeen single margins from 0 to 0.5 blocks:
+  **none certify**. The ladder cannot bridge a gap that is not a tolerance.
+- **Sine-table quantization.** Measured drift before the first inertia event is ~5e-6 per tick,
+  1.3e-4 over 26 ticks. That matches the 8e-6/tick measured in 2026-06 and is three to four orders
+  below the observed failures.
+- **Dual Newton iteration cap.** Every rung reports `iters=100` (`CostateDualSolver.MAX_ITER`).
+  Raising it: 100 gives 3.77e-2, 300 gives 3.08e-2, 1000 / 3000 / 10000 all give 3.50e-2. It reaches
+  its own fixed point. Note gh-384 measured *cuts* to this cap and found them load-bearing; this is
+  the opposite direction and it is equally dead.
+- **Inertia zeroing pattern.** Inertia is respected via a fixed-point walk that re-derives the
+  pattern from each answer, capped at `maxInertiaPasses = 4`. On `mopus/1-dev` it never settles:
+  `free -> x@26+z@0 -> x@15+z@0-7 -> x@15-16,@26+z@0-7`. The `if (pass > 0 && !improved) break` bail
+  stops it after the first non-improving pass; removing that bail alone moves the violation
+  3.77e-2 to 1.20e-2, but the shape gets worse (reversals 7 to 12) and five of six saves are
+  unaffected, so it is not a fix.
+- **Pattern neighbourhood search.** Twenty-seven patterns around the walk (every pattern visited,
+  their union, their intersection, the empty pattern, every single-tick flip off the union), through
+  `optimizeWithPattern`: **0 certified**, best 3.39e-2, worse than the walk's 1.20e-2.
+
+## Where the model divergence does come from
+
+Worth recording even though it is not the failure mode. On `mopus/1-dev` the linear-versus-exact
+divergence is not accumulation: it sits at ~1.3e-4 through tick 26, then **steps** at tick 27 from
++9.75e-5 to -8.32e-4 on X and compounds to 3.0e-3 by tick 49. Tick 26 is where the exact model
+zeroes `vx` (-0.000919, under the 0.005 legacy per-axis threshold) and the linear model agrees
+`zeroX[26] = true`. The step immediately after a zeroing tick is the signature of the two models
+applying the gate at different points within the tick. Pre-event drift is the sine table; the step is
+the inertia gate.
+
+## What to do next
+
+The lever is `CostateDualSolver` primal recovery, not the physics model, not the margins, and not
+the inertia pattern. `RelaxationRecovery` (gh-204) already exists downstream to repair degenerate
+dual recoveries; the open question is whether the dual can be made to return a linear-feasible point
+directly, since a certifying dual returns from `runLadder` immediately and `SlpSolve` never runs,
+which is what preserves the turn structure (gh-414).
+
+A cheap detector already falls out of this audit: after the dual, evaluate its answer against the
+linear walls. If the linear model itself reports a violation, the margin ladder is pointless and the
+inertia passes are pointless, and the run should go straight to recovery.

--- a/docs/research/dual-certification-audit.md
+++ b/docs/research/dual-certification-audit.md
@@ -69,14 +69,89 @@ zeroes `vx` (-0.000919, under the 0.005 legacy per-axis threshold) and the linea
 applying the gate at different points within the tick. Pre-event drift is the sine table; the step is
 the inertia gate.
 
+## Inside the dual: where the infeasibility comes from
+
+Tool: `CostateScreen` (`PKC_SCREENS=1 PKC_CS_FILE=<save.json>`), which runs `CostateDualSolver`
+directly on the same walls `ClosedFormSolve` builds and prints, per tick, the costate norm and the
+magnitude the recovery actually produces, then per wall what the dual believes its value is against
+what the recovered yaws really give.
+
+`grad` recovers each tick as `u_t = m_t * g_t / sqrt(|g_t|^2 + EPS2)` with `EPS2 = 1e-14`. Where
+`|g_t|` approaches `sqrt(EPS2) = 1e-7` the smoothing term stops being negligible and the recovered
+vector falls **inside** the circle of radius `m_t` instead of sitting on it. On `mopus/1-dev`, tick 41
+has `|g| = 1.945e-07`, so the recovery returns magnitude 0.291182 against `m_t = 0.327400`, a ratio
+of **0.889**. Every wall whose coefficients reach past tick 41 is then evaluated against a vector
+11 percent short:
+
+| wall | tick | dual believes | recovered yaws give | slack believed | slack actual |
+| --- | --- | --- | --- | --- | --- |
+| 27 X | 49 | 4.2769175 | 4.4187883 | +8.62e-3 | **-1.33e-1** |
+| 29 Z | 49 | 5.5574759 | 5.5696812 | +4.33e-3 | **-7.87e-3** |
+
+So the dual converges believing wall 27 has slack and it does not.
+
+**Shrinking EPS2 does not fix it.** Sweeping `1e-14 / 1e-18 / 1e-22 / 1e-26 / 1e-30`, dual violation:
+
+| save | 1e-14 | 1e-18 | 1e-22 | 1e-26 | 1e-30 |
+| --- | --- | --- | --- | --- | --- |
+| mopus/1-dev | 3.77e-2 | 1.47e-1 | 5.03e-2 | 5.14e-2 | 6.07e-2 |
+| ben-test | 7.25e-2 | 7.31e-2 | 2.16e-1 | 9.70e-2 | 9.68e-2 |
+| thousand/1 | 1.116 | 6.39e-1 | 1.91e-1 | 2.60e-1 | 3.49e-1 |
+| jvel | 1.840 | 1.363 | 1.312 | 1.799 | 1.799 |
+
+Nothing certifies at any value, and the ranking is not even monotone: `thousand/1` improves sixfold
+at 1e-22 while `mopus/1-dev` gets worse. The shrinkage is a symptom of sitting at a degenerate point,
+not the cause; removing the smoothing just relocates the degeneracy.
+
+## Why: this is a duality gap, not a bug
+
+Each tick's decision is an angle, so `u_t` is constrained to a **circle** of radius `m_t`, not a
+disc. That primal is nonconvex. The Lagrangian decouples per tick and its maximiser is
+`u_t = m_t * g_t / |g_t|`, which is exactly the recovery above. For a nonconvex primal the Lagrangian
+maximiser is primal-feasible only when the multipliers happen to make it so; in general the dual
+returns a bound it cannot attain.
+
+The gap is directly measurable on `mopus/1-dev`: the dual reports `dualValue = 4.285996460` while the
+cap wall `X t=49` has `bPrime = 4.2855385`. Every primal-feasible point satisfies that wall, so the
+primal optimum is at most 4.2855385 and the dual bound sits **4.6e-4 above it**. The bound is not
+attained, so no amount of converging the dual will produce a feasible recovery.
+
+Active-wall counts line up with this. Cold solve at margin 0, no inertia pattern:
+
+| save | walls | active multipliers | worst actual linear slack |
+| --- | --- | --- | --- |
+| dsfdsffds | 17 | 4 | -2.9e-10 |
+| ben-one-turn | 20 | 8 | -1.59 |
+| thousand/1 | 19 | 10 | -0.82 |
+| ben-test | 16 | 11 | -0.29 |
+| mopus/1-dev | 36 | 13 | -0.13 |
+| jvel | 64 | 39 | -1.65 |
+
+With four active walls the maximiser lands feasible to 1e-10. As the active set grows it stops doing
+so. (These single-shot numbers are not the ladder's: `ben-one-turn` certifies through the full ladder,
+which sweeps margins and inertia patterns, despite this cold margin-0 probe being far off.)
+
 ## What to do next
 
-The lever is `CostateDualSolver` primal recovery, not the physics model, not the margins, and not
-the inertia pattern. `RelaxationRecovery` (gh-204) already exists downstream to repair degenerate
-dual recoveries; the open question is whether the dual can be made to return a linear-feasible point
-directly, since a certifying dual returns from `runLadder` immediately and `SlpSolve` never runs,
-which is what preserves the turn structure (gh-414).
+Making the dual itself return a linear-feasible point on these windows is **not reachable by tuning**.
+Margins, the iteration cap, the inertia pattern and the norm smoothing were each measured and each
+failed, and the duality gap above explains why: the bound is not attained, so a converged dual still
+recovers an infeasible point.
 
-A cheap detector already falls out of this audit: after the dual, evaluate its answer against the
-linear walls. If the linear model itself reports a violation, the margin ladder is pointless and the
-inertia passes are pointless, and the run should go straight to recovery.
+That leaves two honest directions, both larger than a patch:
+
+- **Convexify the per-tick set.** Relax `u_t` from the circle to the disc `|u_t| <= m_t`, which makes
+  the primal convex and closes the gap, then handle the radial slack (the relaxed answer will want to
+  move less than full speed on some ticks). This changes what the closed form means, so it needs a
+  ruling before anyone builds it.
+- **Accept the gap and repair downstream.** This is what happens today: `RelaxationRecovery` (gh-204)
+  and `SlpSolve` pick up infeasible recoveries. The cost is that `SlpSolve` phase 1 returns a simplex
+  vertex and shatters the turn structure (gh-414). A repair that preserves turn direction would be
+  worth more here than a better dual.
+
+Do not re-attempt: margin ladder extension, `MAX_ITER` increases, `EPS2` changes, inertia pattern
+enumeration. All four are measured dead above.
+
+A cheap detector still falls out of this audit: after the dual, evaluate its answer against the
+linear walls. If the linear model itself reports a violation, the margin ladder and the inertia
+passes are both provably pointless for that solve, and the run should go straight to recovery.

--- a/docs/research/dual-certification-audit.md
+++ b/docs/research/dual-certification-audit.md
@@ -103,54 +103,86 @@ Nothing certifies at any value, and the ranking is not even monotone: `thousand/
 at 1e-22 while `mopus/1-dev` gets worse. The shrinkage is a symptom of sitting at a degenerate point,
 not the cause; removing the smoothing just relocates the degeneracy.
 
-## Why: this is a duality gap, not a bug
+## There is no duality gap. The dual optimum is fully degenerate.
 
-Each tick's decision is an angle, so `u_t` is constrained to a **circle** of radius `m_t`, not a
-disc. That primal is nonconvex. The Lagrangian decouples per tick and its maximiser is
-`u_t = m_t * g_t / |g_t|`, which is exactly the recovery above. For a nonconvex primal the Lagrangian
-maximiser is primal-feasible only when the multipliers happen to make it so; in general the dual
-returns a bound it cannot attain.
+An earlier revision of this document claimed a duality gap. **That was wrong**, and the correction
+matters because it changes what the fix is.
 
-The gap is directly measurable on `mopus/1-dev`: the dual reports `dualValue = 4.285996460` while the
-cap wall `X t=49` has `bPrime = 4.2855385`. Every primal-feasible point satisfies that wall, so the
-primal optimum is at most 4.2855385 and the dual bound sits **4.6e-4 above it**. The bound is not
-attained, so no amount of converging the dual will produce a feasible recovery.
+The relaxation from the circle `|u_t| = m_t` to the disc `|u_t| <= m_t` is **lossless**: both sets
+have the same support function, `max g·u = m|g|`. So the Lagrangian dual here is the dual of the
+convex disc problem, strong duality holds, and the bound is attained.
 
-Active-wall counts line up with this. Cold solve at margin 0, no inertia pattern:
+The measurements confirm it once the dual is allowed to converge. `MAX_ITER = 100` was truncating it
+at 42 iterations short of convergence:
 
-| save | walls | active multipliers | worst actual linear slack |
+| MAX_ITER | iters used | pgres | dualValue |
 | --- | --- | --- | --- |
-| dsfdsffds | 17 | 4 | -2.9e-10 |
-| ben-one-turn | 20 | 8 | -1.59 |
-| thousand/1 | 19 | 10 | -0.82 |
-| ben-test | 16 | 11 | -0.29 |
-| mopus/1-dev | 36 | 13 | -0.13 |
-| jvel | 64 | 39 | -1.65 |
+| 100 | 100 | 6.5875e-02 | 4.285996460 |
+| 1000 | **142** | **3.5151e-07** | **4.285538558** |
+| 10000 | 142 | 3.5151e-07 | 4.285538558 |
+| 100000 | 142 | 3.5151e-07 | 4.285538558 |
 
-With four active walls the maximiser lands feasible to 1e-10. As the active set grows it stops doing
-so. (These single-shot numbers are not the ladder's: `ben-one-turn` certifies through the full ladder,
-which sweeps margins and inertia patterns, despite this cold margin-0 probe being far off.)
+The cap wall `X t=49` has `bPrime = 4.2855385`. The converged dual value matches it to seven digits.
+The bound is tight.
+
+**The real problem is that the primal maximiser is undetermined.** At the converged optimum
+`|g_t| -> 0` for essentially every tick, so `c = A^T lambda` and the Lagrangian value is `lambda·b'`
+*whatever u is*. Every direction maximises it equally. The recovery `u_t = m_t g_t / |g_t|` is then
+dividing noise by noise, which is why it lands half a block infeasible.
+
+The smoothing constant sets the tradeoff, and neither end wins:
+
+| EPS2 | converged | dualValue | ticks with abs(g) < 1e-6 | worst recovery slack |
+| --- | --- | --- | --- | --- |
+| 1e-14 | yes, 142 it | 4.285538558 | 38 of 49 | -5.09e-1 |
+| 1e-20 | yes, 179 it | 4.285538467 | **49 of 49** | -5.09e-1 |
+| 1e-26 | no, pgres 2.1e-2 | 4.290575351 | 1 of 49 | -1.31e-1 |
+| 1e-32 | no, pgres 3.0e-2 | 4.293139044 | 1 of 49 | -1.50e-2 |
+
+Converging the dual makes the bound tight and the directions meaningless; keeping the directions
+meaningful stops the dual converging.
+
+## The optimal face is large, and that is the opportunity
+
+Because `|g_t| -> 0` everywhere, the dual determines **which walls are active** and nothing else. Any
+`u` on the circles that holds the active walls tight attains the optimum. With around 13 active walls
+against 49 tick angles, that is a large set of *equally optimal* solutions.
+
+That is exactly where turn-direction smoothness should be chosen. Recovering an arbitrary member and
+repairing it downstream is what shatters the shape (gh-414). Choosing the smoothest member of the
+optimal face would certify and be smooth in a single step, which removes the need for the downstream
+repair rather than patching it.
+
+Concretely, the recovery becomes: given the active set from the dual, find per-tick angles satisfying
+the active walls, minimising sign changes in the yaw deltas. Underdetermined and nonconvex in the
+angles, but 49 unknowns against ~13 equations is a lot of freedom to spend on shape.
 
 ## What to do next
 
-Making the dual itself return a linear-feasible point on these windows is **not reachable by tuning**.
-Margins, the iteration cap, the inertia pattern and the norm smoothing were each measured and each
-failed, and the duality gap above explains why: the bound is not attained, so a converged dual still
-recovers an infeasible point.
+The lever is the **primal recovery**, and it is a real opportunity rather than a dead end.
 
-That leaves two honest directions, both larger than a patch:
+The dual gives a tight bound and a correct active set. It does not give directions, and no amount of
+tuning will make it: at the optimum every direction maximises the Lagrangian equally. So build the
+recovery as its own step:
 
-- **Convexify the per-tick set.** Relax `u_t` from the circle to the disc `|u_t| <= m_t`, which makes
-  the primal convex and closes the gap, then handle the radial slack (the relaxed answer will want to
-  move less than full speed on some ticks). This changes what the closed form means, so it needs a
-  ruling before anyone builds it.
-- **Accept the gap and repair downstream.** This is what happens today: `RelaxationRecovery` (gh-204)
-  and `SlpSolve` pick up infeasible recoveries. The cost is that `SlpSolve` phase 1 returns a simplex
-  vertex and shatters the turn structure (gh-414). A repair that preserves turn direction would be
-  worth more here than a better dual.
+1. Take the active set from the converged dual.
+2. Solve for per-tick angles that hold the active walls tight.
+3. Among the solutions, pick the one minimising sign changes in the per-tick yaw deltas (gh-416).
 
-Do not re-attempt: margin ladder extension, `MAX_ITER` increases, `EPS2` changes, inertia pattern
-enumeration. All four are measured dead above.
+That certifies and is smooth in one step, which is strictly better than today's arrangement where an
+arbitrary member of the optimal face is recovered and then repaired by `SlpSolve` phase 1, whose
+simplex vertex shatters the turn structure (gh-414).
+
+Two notes for whoever builds it:
+
+- **`MAX_ITER = 100` truncates convergence** on this window; it needs 142. gh-384 measured *cuts* to
+  this cap and found them load-bearing on the corpus, so raising it needs its own corpus run rather
+  than a blind change.
+- **`EPS2` cannot be tuned to fix the recovery.** Converging the dual and keeping the directions
+  meaningful are opposed; see the table above.
+
+Do not re-attempt: margin ladder extension, inertia pattern enumeration, or `EPS2` changes as a route
+to certification. All measured dead above.
 
 A cheap detector still falls out of this audit: after the dual, evaluate its answer against the
 linear walls. If the linear model itself reports a violation, the margin ladder and the inertia

--- a/docs/research/smooth-tas-handoff-2026-08-23.md
+++ b/docs/research/smooth-tas-handoff-2026-08-23.md
@@ -195,7 +195,104 @@ is the right home and the probe is not.
 Run them via direct `java -cp $(printTestCp)`; the init-script recipe is in the post-CMA cleanup
 notes. `-Dpkc.cf.repair=0` is a dev kill switch and should not ship as is.
 
-## 8. Open
+## 8. Target architecture: the direction to build next
+
+**User ruling, 2026-08-23.** The solver should be **as simple as possible: the dual, branching on
+inertia, and nothing else.** If a solve exists it must be **exact**, meaning violation at or below
+about 1e-5, so the recovery is genuinely minimal. Everything in sections 5 and 6 is a bandaid stacked
+on a bandaid, and the belief driving this is that the true optimum and the smoothest yaw sequence live
+at the dual's own answer, not at some point a repair dragged it to.
+
+That reading is right, and the code supports it. What follows is design grounded in the source, **not
+yet measured**. The experiment was cut short deliberately; run it first.
+
+### What is actually a bandaid today
+
+| thing | where | size |
+| --- | --- | --- |
+| ascending margin ladder | `ClosedFormSolve.Config.margins` | 8 rungs, `0` to `1e-2` |
+| robust margin ladder | `Config.marginsRobust` | 7 rungs, `5e-2` down to `0` |
+| inertia passes | `Config.maxInertiaPasses` | 4 |
+| rung stall bail | `Config.rungStallLimit` | 2 |
+| post-loop repair | `repairRecovery` (scratch `a93af643`) | 4 more margins |
+| shape cleanup | `DeWiggle` (PR #415) | a whole pass |
+
+The margins are the load-bearing bandaid, and everything downstream exists because they cost objective
+and shape. The ladder's own comment sizes them for "the ~1e-4 sine-table perturbation", yet the rungs
+run to 1e-2, a hundred times that. That gap is the tell: the margins are absorbing **linear-model
+error**, not quantization.
+
+### The replacement: defect correction
+
+`JumpLinearModel` already carries an **analytic Jacobian** of every X/Z wall with respect to the
+per-tick facings, and it needs no forward simulation. From the `baseArg` doc comment
+(`JumpLinearModel.java:163-169`): an input at absolute yaw `y` is `mMag * e^(i*(baseArg + y))`, so
+`d(addX)/dy = -addZ` and `d(addZ)/dy = addX`. Chained through `coefAxis(axis, s, k)`, that gives
+`d(pos_k)/d(yaw_t)` in closed form.
+
+So the residual and the Jacobian can come from **different models**:
+
+- **residual** from the byte-exact `ExactJumpModel.forward`, via `JumpConstraintCompiler.evaluate`
+- **Jacobian** from `JumpLinearModel`
+
+That is textbook defect correction. The linear model is wrong in *value* by about 1e-4 but its
+*derivative* is accurate, which is exactly the regime where defect correction converges fast: error
+should fall roughly 1e-4 per step, so 1e-4 to 1e-8 to 1e-12 in about three iterations. The whole
+margin ladder collapses into **one dual solve at margin 0 plus a Newton polish**, and the polish lands
+about 1e-5 inside the wall instead of the ladder's 1e-4 to 1e-2 or the repair's 1e-3 to 6e-2. Landing
+a hundred to a thousand times closer to the wall is what preserves both objective and shape, and it
+is why the repair and `DeWiggle` should both become unnecessary rather than being tuned.
+
+### The one hard caveat, and why 1e-5 is the right target
+
+**The exact model is a staircase in yaw, not a smooth function.** `ExactJumpModel` reads MC's
+65536-bucket sine table, so yaw enters through buckets about 0.0055 degrees wide. Inside a bucket the
+realized position does not move at all. A single-tick, single-bucket step moves the final position by
+roughly `m_t * coef * bucket_in_radians`, on the order of **3e-5 blocks**.
+
+Consequences to design around:
+
+- A plain Newton iteration will stall once its step is under a bucket. The polish must detect that and
+  stop, not thrash.
+- Driving the violation to exactly 0 is a **lattice** problem, not a continuous one. Combining ticks
+  reaches far finer than 3e-5, but the single-tick granularity is 3e-5.
+- **So "exact or maybe 1e-5" is not a compromise, it is the physical floor of the model.** The ask and
+  the mathematics agree. Do not chase 1e-9.
+- `LatticeRepair` and `FacingLattice` already exist in the solver package and are the natural home for
+  the final sub-bucket step if one is ever needed.
+
+### Facing constraints: fold them into the polish, not around it
+
+Today F-mode walls are handled by `FacingPrefold` pinning ticks before the dual runs, and anything it
+cannot take bails to `scannable` plus a 240-candidate anchor scan (`candidateThetas`). The polish can
+carry F walls directly instead: `evaluate` gives the F residual as `wrap(F[t1] +/- F[t2] - rhs)`, and
+`d(F[t])/d(yaw[t])` is 1 through `toGameFacings` for any unlocked tick. Rows with gradient `+/-1` are
+trivial to add, strictly more general than pinning, and would let the polish keep facing walls
+satisfied while it moves position walls. Check the locked-tick branch in
+`JumpPhysicsInputs.toGameFacings:196-199` before assuming the gradient is 1 everywhere.
+
+### Order to build it
+
+1. Write the polish standalone and measure it **as an add-on** to the existing margin-0 rung only.
+   Certified count over the 58 hpk captures is the number that decides everything.
+2. Only if it holds: cut `margins` to `{0.0}`, then delete `marginsRobust`, `rungStallLimit`,
+   `repairRecovery`, and re-measure at each step.
+3. Keep `maxInertiaPasses`. Inertia branching is not a bandaid, it is the piecewise structure of the
+   real problem, and the user's target keeps it.
+4. Re-measure reversals on the six saves in section 3 before touching `DeWiggle`. If the polish lands
+   at the dual's answer, `DeWiggle` should have nothing left to do, and that is the test of whether
+   this direction actually delivered.
+
+### Why this is expected to be smoother, not just simpler
+
+Section 4 established the dual's answer is the true optimum of the convex relaxation, with a tight
+bound and exact complementary slackness. Every margin rung deliberately walks **off** that answer. If
+the polish only has to move about 1e-5 rather than 5e-3, the recovered yaws stay essentially at the
+optimum, which is precisely where the user expects the smoothest yaw sequence to be. That expectation
+is consistent with everything measured in sections 4 and 6, but it is a **prediction, not a result**,
+until the hpk run in step 1 exists.
+
+## 9. Open
 
 - `ben-test` and `thousand/1` still do not certify through the production path.
 - The variant that gains hpk 40/38 is available if the three `loopmm` captures can be re-pinned.
@@ -204,4 +301,6 @@ notes. `-Dpkc.cf.repair=0` is a dev kill switch and should not ship as is.
   start are already modelled, is the piece that would let the downstream repair, and with it the need
   for `DeWiggle`, be dropped entirely.
 - `MAX_ITER = 100` truncates dual convergence at 142 on the reported window. Raising it is untested
-  against the corpus in the direction that matters.
+  against the corpus in the direction that matters. Note the target architecture makes this **more**
+  important, not less: with no margin ladder to paper over a half-converged dual, the dual's own
+  answer has to be right the first time.

--- a/docs/research/smooth-tas-handoff-2026-08-23.md
+++ b/docs/research/smooth-tas-handoff-2026-08-23.md
@@ -1,0 +1,207 @@
+# Smooth (TAS) regression and the closed form's degenerate recovery: handoff 2026-08-23
+
+Session worked from one report: **Smooth (TAS) on dev produces visibly choppier facing paths than the
+released 1.9.0.** It ended in the closed form's primal recovery. This file is the whole trail, so the
+next session does not repeat the four dead ends.
+
+Baseline dev `3ba6d3c4`. Reproduction files `parkourcalculator/mopus/1-dev.json` and `1-main.json`
+(same TAS, same settings, solved on dev and on 1.9.0 respectively).
+
+## 1. What smooth means here (user rulings, these override any earlier note)
+
+**Only the yaw values matter.** They are stored in the TAS as per-tick relative changes. Not the flown
+XZ path, not the velocity heading. An earlier phrasing about "wiggles in the air trajectory" meant the
+yaw over the airborne ticks, not a path metric. Do not build path or curvature metrics.
+
+The defect is a **change of turn direction**. Rate variation inside one direction is not a defect:
+
+| relative yaw values | verdict |
+| --- | --- |
+| `10 10 10 10` | good |
+| `10 20 30 40` | good, steady acceleration |
+| `10 20 10 20` | acceptable, never turns back |
+| `10 -10 10 -10` | bad |
+| `10 20 -1 40` | bad, and the `-1` is as unwanted as a `-10` |
+
+**The objective does not matter at all**, as long as every constraint is met.
+
+Two measurement traps found the hard way:
+
+- The "typical 44 degree arc" in the hand-made part of the TAS is largely **45-strafes**, not a
+  smoothness target. `DeWiggle.MIN_ARC_DEG = 45` survives only because a parameter sweep picked it.
+- The panel's "Yaw jerk" uses the **unanchored** `Angles.wiggleDeg(yaws)` while the objective uses the
+  **anchored** `wiggleDeg(anchor, yaws)`. Panel and objective numbers differ by the launch-yaw term.
+  Every jerk figure in this file and in the PRs is anchored.
+
+## 2. Why dev regressed against 1.9.0
+
+`538c92bf` (the CMA-ES removal) deleted every stage whose **inner fitness** contained the smooth
+penalty. Count of `smoothPenalty` / `objective.scored` sites per stage:
+
+| stage | v1.9.0 | dev |
+| --- | --- | --- |
+| `CmaesJumpHarness` | 2 | deleted |
+| `SolveCore` | 5 | deleted |
+| `SnapRepairPolish` | 3 | deleted |
+| `AlmSnapStage` | 1 | deleted |
+| `BucketAscentPolish` | 1 | 1, only reachable via ILS |
+| `IlsPolish` | 1 | 1 |
+| `SeamSweepRecovery` | 0 | 0 |
+| `BoundPrunedRecovery` | 0 | 0 |
+| `SlpSolve` | 0 | 0 |
+
+On the reported file 1.9.0's chain reads *"CMA-ES (better objective), optimal at constraint cap"* with
+**654,851 evaluations**. Every one of those samples was ranked on a fitness containing the turn
+penalty. dev's replacements (seam sweep, B&B) score `path.getPos(obj.tick, obj.axis)` and nothing
+else, so turn direction only enters afterwards as a filter over candidates generated blind to it.
+
+## 3. Three PRs open against dev
+
+| PR | issue | contents | state |
+| --- | --- | --- | --- |
+| #415 | #414 | `GraphRunner` wrap-reserve fix, new `DeWiggle` pass | green |
+| #417 | #416 | `Angles.turnCost` replaces jerk in the objective | green |
+| #419 | #418 | this audit, `DualCertScreen`, `CostateScreen` | green |
+
+**#415.** Two things. `GraphRunner` set `wrapPending` when the graph merely *contained* a `wrapIls`
+node and only cleared it when that node executed, so a route branching around wrap never released the
+2.5 s reserve and every later node got a deadline already in the past: `smoothFinal` entered with
+`remainingMs=0` while the overall budget still had **2478 ms**. And `DeWiggle` collapses same-sign turn
+runs below 45 degrees to a constant turn rate, restoring feasibility with a Gauss-Newton step that
+freezes the flattened span and measures the correction in second differences. Gated to the final
+smoothing node and to `smoothLambda > 0`, so a solve with Smooth off is unchanged bit for bit. On the
+reported file: turn runs 11 to 7, reversals 10 to 6, jerk 1040 to 902.
+
+**#417.** `turnCost = REVERSAL_COST_DEG * (sign changes) + RATE_TIEBREAK * jerk`, with
+`REVERSAL_COST_DEG = 90` and `RATE_TIEBREAK = 0.02`. The tiebreak is not cosmetic: a pure integer
+count is flat almost everywhere and leaves the search no direction to follow, and dropping it costs
+three reversals on the longest corpus file. Reversals over six saves: 1-dev 10 to 6, thousand/1 8 to
+6, ben-test 4 to 1, two unchanged, jvel 19 to 20.
+
+## 4. Why the closed form fails to certify
+
+**The recovery, not the dual.** The closed form recovers each tick from the costate direction,
+`u_t = m_t g_t / ‖g_t‖`. At the optimum `c = A^T lambda`, which is plain stationarity, so the costate
+vanishes: measured `‖g‖ ~ 1e-7` on **49 of 49 ticks**. `atan2` of a vanishing vector is noise, and
+that noise is what fails the byte-exact check.
+
+The dual is correct throughout:
+
+- converges in **142 iterations**, `pgres` 3.5e-07 (`MAX_ITER = 100` truncates it 42 short)
+- bound tight: `dualValue = 4.285538558` against the binding wall's `bPrime = 4.2855385`
+- complementary slackness exact: every active wall reads `believed == bPrime` to eight digits
+
+It produces correct multipliers and a correct **active set**. It has no rule for choosing a point on
+the optimal face, because at the optimum the Lagrangian is flat in every tick direction. The
+information about which point to take lives in the active walls, not the costate.
+
+**There is no duality gap.** Relaxing each tick from the circle `|u_t| = m_t` to the disc
+`|u_t| <= m_t` is lossless, since both have support function `m‖g‖`. This dual is the convex problem's
+dual and its bound is attained. An earlier revision of the audit claimed a gap; that was wrong.
+
+### Measured dead, do not re-attempt
+
+- **Margin ladder.** `Config.margins` tops out at 1.0e-2 and its comment sizes it for "the ~1e-4
+  sine-table perturbation". Seventeen single margins from 0 to 0.5 blocks: none certify.
+- **Sine table.** Drift before the first inertia event is about 5e-6 per tick, 1.3e-4 over 26 ticks.
+  Three to four orders below the failures. The code comment overstates it.
+- **`MAX_ITER`.** 100 gives 3.77e-2, 1000 / 3000 / 10000 all give 3.50e-2 on the ladder's violation.
+  Raising it makes the dual converge but does not fix the recovery. (gh-384 measured *cuts* and found
+  them load-bearing, so any change here still needs its own corpus run.)
+- **`EPS2` smoothing.** Magnitude shrinkage is real (ratio 0.889 at one tick) but secondary. A
+  warm-started continuation from 1e-6 down to 1e-34 moves the violation only 0.509 to 0.175, and at
+  1e-34 the magnitude ratio is 0.999965 with the violation still 0.175. Converging the dual and
+  keeping the directions meaningful are opposed.
+- **Inertia pattern enumeration.** The fixed-point walk never settles
+  (`free -> x@26+z@0 -> x@15+z@0-7 -> x@15-16,@26+z@0-7`). Removing its `!improved` bail moves
+  3.77e-2 to 1.20e-2 but worsens the shape and leaves five of six saves untouched. Twenty-seven
+  patterns around the walk certify none.
+
+## 5. The production fix
+
+`ClosedFormSolve.repairRecovery`, on `scratch/smooth-primal-recovery` at **`a93af643`**. Not merged.
+
+Damped Gauss-Newton on the violated walls of the same linear model the ladder used, correction
+measured in second differences (`secondDifferenceMetric`) so a repair cannot flick the facing path it
+is fixing, over `repairMargins = {1e-3, 5e-3, 2e-2, 6e-2}`.
+
+Certified solves over the 58 hpk captures: **ascending 25 to 37, robust 20 to 35**, 2.2 s to 3.1 s.
+Full `:core:check -PslowTests` green, 131 classes, 695 tests, 0 failures.
+
+### Ordering is load-bearing. Three variants measured
+
+1. **Repair inside a rung**: hpk 41/42, but regresses five `closedform/*` captures by 0.02 to 0.03
+   blocks. An inward-margin answer wins a rung that a **later inertia pass** would have certified
+   cleanly. Note `ProblemsTest.runClosedForm` calls `ClosedFormSolve.optimize` cold and direct, so
+   there is no downstream stage to blame for this.
+2. **After all rungs and passes, seeded from every rung recovery**: hpk 40/38, but breaks the three
+   `loopmm` captures.
+3. **Shipped**: after all rungs and all passes, seeded from the best point and the running best only.
+   hpk 37/35, suite green.
+
+Holding a repaired certificate back *inside* the pass loop does not work: pass N+1 then derives its
+inertia zeroing pattern from the repaired path and never finds the clean certificate. The repair must
+be fully outside the loop.
+
+### The j008 golden was regenerated and that is correct
+
+`J008VelocityFieldGoldenTest` drifted. Checked before regenerating: cells that land with constraints
+met go **40 to 42 of 71**, same size and same cell count. The new field is strictly better. Always
+verify with a probe before regenerating a golden; do not just delete and re-run.
+
+## 6. Prototype: choosing the smooth member of the optimal face
+
+Also on `scratch/smooth-primal-recovery`, in `SmoothRecoveryProbe` (test tree). Commits `c48fb4d9`
+(recovery that certifies), `734ec2a2` (smooth-metric repair), `784731bd` (null-space face walk),
+`f4e60c6a` (Pareto flooring), `7363d726` (multi-start).
+
+On `mopus/1-dev` it reaches **exactViol 0.0 at 7 reversals** against the dual seed's 9, and because it
+certifies, `runLadder` returns immediately and `SlpSolve` never runs, so nothing shatters the shape.
+
+Key mechanics, each measured:
+
+- **Flatten and repair fight.** Of 170 reversal-killing attempts, 147 had the repair fail outright and
+  23 had it succeed while re-adding the reversals. The flatten was never wrong (it dropped reversals
+  9 to 5 or 7 every time); the least-norm correction undid it. Projecting the flatten direction onto
+  the **null space of the active walls** before stepping fixes this: the step is feasible to first
+  order so the repair only removes second-order drift.
+- **Pareto flooring.** Feasibility outranks shape, since a certifying result skips `SlpSolve`
+  entirely. Between two feasible candidates the smoother wins. Between two infeasible candidates a
+  violation gain that costs reversals is refused, because an infeasible result goes to the downstream
+  repair anyway and only its shape survives as a seed. Without this, thousand/1 went 8 reversals to 16
+  and jvel 23 to 38.
+- **Multi-start.** The Gauss-Newton restore is local and stalls in a basin. Multi-starting from
+  coherent perturbations reaches feasibility where one start cannot: jvel 1.90 to 0.0 (1 of 48 starts).
+- **`-Dpkc.sr.usesaved`** seeds from the save's own recorded answer. That turns thousand/1 into 0.0 at
+  3 reversals and jvel into 0.0 at 12. **Circular as a benchmark** and off by default. It is not
+  circular in the engine, where the recovery would warm-start from the incumbent earlier graph stages
+  produced, so those numbers indicate what that wiring would be worth.
+
+The probe models a **subset** of the real problem and this is why it stalls on some saves. On
+`ben-test` it covers 16 walls out of 80 constraints, ignores 64 facing constraints, and treats the
+start as fixed when the spec has `freeStart=true` with a 0.725 by 1.6 block box. `ClosedFormSolve`
+handles all of that already (`FacingPrefold`, `freeP0`), which is why the production fix in section 5
+is the right home and the probe is not.
+
+## 7. Tools
+
+| tool | what | how |
+| --- | --- | --- |
+| `DualCertScreen` | per tick, linear model vs byte-exact position; per tick velocity vs the inertia gate; per constraint as each model sees it | `PKC_SCREENS=1 PKC_DC_FILE=<save>` |
+| `CostateScreen` | costate norm and recovered magnitude per tick; per wall what the dual believes vs what the recovered yaws give | `PKC_SCREENS=1 PKC_CS_FILE=<save>` |
+| `HpkCertifyScreen` | certification over all 58 hpk captures, A/B via `-Dpkc.cf.repair=0` | `PKC_SCREENS=1` |
+| `SmoothRecoveryProbe` | the section 6 prototype | `PKC_SR_FILE=<save>`, `-Dpkc.sr.*` |
+
+Run them via direct `java -cp $(printTestCp)`; the init-script recipe is in the post-CMA cleanup
+notes. `-Dpkc.cf.repair=0` is a dev kill switch and should not ship as is.
+
+## 8. Open
+
+- `ben-test` and `thousand/1` still do not certify through the production path.
+- The variant that gains hpk 40/38 is available if the three `loopmm` captures can be re-pinned.
+- The prototype certifies **and** smooths, but only in the test tree against a subset of the problem.
+  Porting the null-space face walk into `ClosedFormSolve`, where the facing constraints and the free
+  start are already modelled, is the piece that would let the downstream repair, and with it the need
+  for `DeWiggle`, be dropped entirely.
+- `MAX_ITER = 100` truncates dual convergence at 142 on the reported window. Raising it is untested
+  against the corpus in the direction that matters.


### PR DESCRIPTION
Closes #418. Docs and one diagnostic screen, no solver code.

## Finding

**The dual returns a primal point that is infeasible in its own linear model.** It is not a linear-versus-byte-exact model gap, which is what the margin ladder, the sine-table headroom and the inertia pattern passes are all sized against.

At the dual's own answer, per save: its exact violation, the worst violation the *linear* model itself reports on the same yaws, and the largest per-tick divergence between the linear prediction and the byte-exact forward.

| save | dual violation | worst linear violation | worst model divergence | certifies |
| --- | --- | --- | --- | --- |
| dsfdsffds | 0 | none | 8.6e-4 | yes |
| ben-one-turn | 0 | none | **1.46e-1** | yes |
| mopus/1-dev | 3.77e-2 | -3.47e-2 | 3.0e-3 | no |
| ben-test | 7.25e-2 | -2.11e-2 | 8.39e-2 | no |
| thousand/1 | 1.116 | **-1.116** | **6.9e-4** | no |
| jvel_Linkcraft | 1.840 | **-1.860** | 2.86e-2 | no |

Two readings settle it:

- `thousand/1`: dual violation and the dual's own linear violation agree to three digits (1.116), while the physics divergence is **1600x smaller** (6.9e-4). The dual is not being betrayed by the physics; it never solved its own problem.
- `ben-one-turn` **certifies while carrying the largest model divergence in the corpus** (1.46e-1). Divergence does not predict certification. Linear feasibility does, and the two certifying saves are exactly the two with zero linear violations.

This reproduces and generalises the 2026-06-10 `speedrun_nightmare` diagnosis (a recovery violating the linear model's own wall by ~0.19; `linViol==exactViol`, model-independent), now with a corpus rather than one file.

## Ruled out, with numbers

All on `mopus/1-dev`:

- **Margin ladder.** Tops out at 1.0e-2, its comment sizes it for "the ~1e-4 sine-table perturbation". Seventeen single margins from 0 to 0.5 blocks: **none certify**.
- **Sine table.** Measured drift before the first inertia event is ~5e-6/tick, 1.3e-4 over 26 ticks. Three to four orders below the failures, and consistent with the 8e-6/tick measured in 2026-06.
- **Iteration cap.** Every rung reports `iters=100`. Raising `MAX_ITER`: 100 gives 3.77e-2, 300 gives 3.08e-2, 1000/3000/10000 all give 3.50e-2. It reaches its own fixed point. (#384 measured *cuts* and found them load-bearing; this is the untested opposite direction, equally dead.)
- **Inertia pattern.** Respected, via a fixed-point walk capped at `maxInertiaPasses = 4`, which never settles here: `free -> x@26+z@0 -> x@15+z@0-7 -> x@15-16,@26+z@0-7`. Removing the `!improved` bail moves 3.77e-2 to 1.20e-2 but worsens the shape (reversals 7 to 12) and leaves 5 of 6 saves untouched.
- **Pattern neighbourhood.** 27 patterns (every one visited, union, intersection, empty, every single-tick flip off the union): **0 certified**, best 3.39e-2, worse than the walk.

## Where the divergence does come from

Recorded because it is worth knowing, though it is not the failure mode. The divergence is not accumulation: it holds at ~1.3e-4 through tick 26, then **steps** at tick 27 from +9.75e-5 to -8.32e-4 on X and compounds to 3.0e-3 by tick 49. Tick 26 is where the exact model zeroes `vx` (-0.000919, under the 0.005 legacy per-axis threshold). A step immediately after a zeroing tick is the signature of the two models applying the gate at different points within the tick. Pre-event drift is the sine table; the step is the inertia gate.

## Contents

- `docs/research/dual-certification-audit.md`
- `DualCertScreen`, gated on `PKC_SCREENS` like the other screens, `PKC_DC_FILE` names the save. Prints per tick the linear versus exact position with the divergence, per tick the velocity against the inertia gate, and per constraint the value as each model sees it with both slacks.
- `TESTS.md` entry.

Full `:core:check -PslowTests` green: 129 classes, 693 tests, 0 failures, 0 errors, 33 skipped.

## Suggested next step

The lever is `CostateDualSolver` primal recovery, not the physics model, the margins, or the inertia pattern. A cheap detector falls out of this: after the dual, evaluate its answer against the linear walls; if the linear model itself reports a violation, the margin ladder and the inertia passes are both pointless and the run should go straight to recovery.
