### PR TITLE
feat(runticks): refine UI layout and improve min mode search logic

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/RunTicksController.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/RunTicksController.java
@@ -116,7 +116,17 @@ public final class RunTicksController implements RunTicksControls {
 
         searchBase = DocumentSnapshot.capture(inputs, state);
         search = new RunTicksSearch<List<InputRow>>(jumpTicks.size(), cfg.getMaxTicks(), cfg.isMinimize(),
-                this::allowsExtraTicks);
+                new RunTicksSearch.JumpOptions() {
+                    @Override
+                    public boolean allows(int jumpIndex, int extraTicks) {
+                        return allowsExtraTicks(jumpIndex, extraTicks);
+                    }
+
+                    @Override
+                    public int maxAllowed(int jumpIndex) {
+                        return maxAllowedTicks(jumpIndex);
+                    }
+                });
         timeouts = new StepTimeouts(cfg, jumpTicks.size());
         bestCombo = null;
         bestRows = null;
@@ -292,7 +302,7 @@ public final class RunTicksController implements RunTicksControls {
         int percent = (int) Math.min(99, Math.max(0, search.progress() * 100));
         String elapsed = String.format(Locale.ROOT, " (%.1fs)", elapsedMs(searchStartMs) / 1000.0);
         String text = search.isMinimizing()
-                ? "Run ticks (min " + search.target() + "/" + search.maxTicks() + "t) · " + percent + "%" + elapsed
+                ? "Run ticks (min " + search.target() + "t) · " + percent + "%" + elapsed
                 : "Run ticks · " + percent + "%" + elapsed;
         hud.setStatus(text, HudMessages.COLOR_DEFAULT);
     }
@@ -394,6 +404,11 @@ public final class RunTicksController implements RunTicksControls {
     private boolean allowsExtraTicks(int jumpIndex, int extraTicks) {
         TickConstraints tc = searchBase.constraintsAt(jumpTicks.get(jumpIndex));
         return RunTicksFilter.allows(tc == null ? null : tc.getConstraints(), extraTicks);
+    }
+
+    private int maxAllowedTicks(int jumpIndex) {
+        TickConstraints tc = searchBase.constraintsAt(jumpTicks.get(jumpIndex));
+        return RunTicksFilter.maxAllowed(tc == null ? null : tc.getConstraints());
     }
 
     private int enabledConstraintCount() {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/runticks/RunTicksFilter.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/runticks/RunTicksFilter.java
@@ -18,6 +18,33 @@ public final class RunTicksFilter {
         return true;
     }
 
+    public static int maxAllowed(List<Constraint> atJumpTick) {
+        if (atJumpTick == null) return Integer.MAX_VALUE;
+        int max = Integer.MAX_VALUE;
+        for (Constraint c : atJumpTick) {
+            if (c.getField() != Constraint.Field.RT || !c.isEnabled()) continue;
+            if (c.isRange()) {
+                int hi = (int) Math.floor(c.getHi() - (c.isHiInclusive() ? 0.0 : 1.0e-6));
+                max = Math.min(max, hi);
+            } else {
+                switch (c.getOp()) {
+                    case EQ:
+                        max = Math.min(max, (int) Math.round(c.getValue()));
+                        break;
+                    case LE:
+                        max = Math.min(max, (int) Math.floor(c.getValue()));
+                        break;
+                    case LT:
+                        max = Math.min(max, (int) Math.ceil(c.getValue() - 1.0));
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+        return Math.max(0, max);
+    }
+
     private static boolean satisfies(Constraint c, double found) {
         if (c.isRange()) {
             boolean lo = c.isLoInclusive() ? found >= c.getLo() : found > c.getLo();

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/runticks/RunTicksSearch.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/runticks/RunTicksSearch.java
@@ -9,6 +9,7 @@ public final class RunTicksSearch<P> {
 
     public interface JumpOptions {
         boolean allows(int jumpIndex, int extraTicks);
+        int maxAllowed(int jumpIndex);
     }
 
     public static final class Node<P> {
@@ -48,6 +49,8 @@ public final class RunTicksSearch<P> {
     private final boolean minimize;
     private final JumpOptions options;
 
+    public static final int MAX_UNCONSTRAINED_TICKS = 40;
+
     private final Deque<Node<P>> queue = new ArrayDeque<Node<P>>();
     private Node<P> current;
     private int target;
@@ -55,13 +58,15 @@ public final class RunTicksSearch<P> {
     private int steps;
     private int successes;
     private int fullSolutions;
+    private int furthestDepthReached;
 
     public RunTicksSearch(int jumpCount, int maxTicks, boolean minimize, JumpOptions options) {
         this.jumpCount = Math.max(0, jumpCount);
         this.maxTicks = Math.max(0, maxTicks);
         this.minimize = minimize;
         this.options = options;
-        this.target = minimize ? 0 : this.maxTicks;
+        this.target = this.maxTicks;
+        this.furthestDepthReached = 0;
         seed();
     }
 
@@ -103,12 +108,40 @@ public final class RunTicksSearch<P> {
 
     public boolean nextRung() {
         if (!minimize) return false;
-        while (target < maxTicks) {
+        int prefixCap = prefixCapFor(furthestDepthReached);
+        if (target >= prefixCap || target >= MAX_UNCONSTRAINED_TICKS) {
+            return false;
+        }
+        int maxTotal = maxRemaining(0);
+        while (target < maxTotal && target < MAX_UNCONSTRAINED_TICKS) {
             target++;
+            if (target > prefixCap) return false;
             seed();
             if (!queue.isEmpty()) return true;
         }
         return false;
+    }
+
+    private int prefixCapFor(int depth) {
+        long sum = 0;
+        for (int j = 0; j <= depth && j < jumpCount; j++) {
+            int m = options.maxAllowed(j);
+            if (m == Integer.MAX_VALUE) return Integer.MAX_VALUE;
+            sum += m;
+            if (sum >= Integer.MAX_VALUE) return Integer.MAX_VALUE;
+        }
+        return (int) Math.min(Integer.MAX_VALUE, sum);
+    }
+
+    private int maxRemaining(int fromJumpIndex) {
+        long sum = 0;
+        for (int j = fromJumpIndex; j < jumpCount; j++) {
+            int m = options.maxAllowed(j);
+            if (m == Integer.MAX_VALUE) return Integer.MAX_VALUE;
+            sum += m;
+            if (sum >= Integer.MAX_VALUE) return Integer.MAX_VALUE;
+        }
+        return (int) Math.min(Integer.MAX_VALUE, sum);
     }
 
     public Node<P> take() {
@@ -128,6 +161,7 @@ public final class RunTicksSearch<P> {
     public void recordSuccess(P childPayload) {
         successes++;
         if (current == null) return;
+        furthestDepthReached = Math.max(furthestDepthReached, current.depth);
         if (current.depth >= jumpCount) {
             fullSolutions++;
             completed += current.weight;
@@ -171,11 +205,13 @@ public final class RunTicksSearch<P> {
         List<Integer> out = new ArrayList<Integer>();
         int budget = target - sum;
         if (budget < 0) return out;
+        int maxRest = jumpIndex + 1 < jumpCount ? maxRemaining(jumpIndex + 1) : 0;
         if (minimize && jumpIndex == jumpCount - 1) {
             if (options.allows(jumpIndex, budget)) out.add(budget);
             return out;
         }
         for (int extra = budget; extra >= 0; extra--) {
+            if (budget - extra > maxRest) continue;
             if (options.allows(jumpIndex, extra)) out.add(extra);
         }
         return out;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/runticks/RunTicksSearch.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/runticks/RunTicksSearch.java
@@ -9,7 +9,10 @@ public final class RunTicksSearch<P> {
 
     public interface JumpOptions {
         boolean allows(int jumpIndex, int extraTicks);
-        int maxAllowed(int jumpIndex);
+
+        default int maxAllowed(int jumpIndex) {
+            return Integer.MAX_VALUE;
+        }
     }
 
     public static final class Node<P> {
@@ -78,10 +81,6 @@ public final class RunTicksSearch<P> {
         return target;
     }
 
-    public int maxTicks() {
-        return maxTicks;
-    }
-
     public boolean isMinimizing() {
         return minimize;
     }
@@ -109,11 +108,9 @@ public final class RunTicksSearch<P> {
     public boolean nextRung() {
         if (!minimize) return false;
         int prefixCap = prefixCapFor(furthestDepthReached);
-        if (target >= prefixCap || target >= MAX_UNCONSTRAINED_TICKS) {
-            return false;
-        }
         int maxTotal = maxRemaining(0);
-        while (target < maxTotal && target < MAX_UNCONSTRAINED_TICKS) {
+        int cap = Math.min(prefixCap, maxTotal);
+        while (target < cap && target < MAX_UNCONSTRAINED_TICKS) {
             target++;
             if (target > prefixCap) return false;
             seed();

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/runticks/RunTicksSearch.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/runticks/RunTicksSearch.java
@@ -208,7 +208,7 @@ public final class RunTicksSearch<P> {
             return out;
         }
         for (int extra = budget; extra >= 0; extra--) {
-            if (budget - extra > maxRest) continue;
+            if (minimize && budget - extra > maxRest) continue;
             if (options.allows(jumpIndex, extra)) out.add(extra);
         }
         return out;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverWindow.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverWindow.java
@@ -589,7 +589,7 @@ public final class AngleSolverWindow implements RenderInterface {
 
     private static final String RUN_TICKS_MAX_TIP =
             "Largest number of extra running ticks the search may hand out across all jumps together."
-            + "In Min mode, the search starts from this count upwards.";
+            + "\nIn Min mode, the search starts from this count upwards.";
 
     private static final String RUN_TICKS_MIN_TIP =
             "Search from the configured run ticks count upwards (n, n+1, n+2 ...) and stop at the first count that solves, so the result"

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverWindow.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverWindow.java
@@ -32,6 +32,7 @@ import imgui.flag.ImGuiCol;
 import imgui.flag.ImGuiCond;
 import imgui.flag.ImGuiStyleVar;
 import imgui.flag.ImGuiWindowFlags;
+import imgui.type.ImFloat;
 import imgui.type.ImInt;
 import imgui.type.ImString;
 
@@ -67,7 +68,7 @@ public final class AngleSolverWindow implements RenderInterface {
 
     private static final String[] FORM_LABELS =
             {"Start tick", "Goal tick", "Axis", "Goal", "Target angle", "Inputs", "Sprint", "Slipperiness", "Potion",
-             "Enabled", "Max ticks", "Step timeout", "Step growth", "Safety factor", "Safety margin"};
+             "Enabled", "Run ticks", "Step timeout", "Step growth", "Safety factor", "Safety margin"};
 
     /** Unscaled; lines the details table up under the toggle title and sets it off from the solved values. */
     private static final float DETAIL_INDENT = 13f;
@@ -98,9 +99,9 @@ public final class AngleSolverWindow implements RenderInterface {
     private final ImInt levelBuf = new ImInt();
     private final ImInt runTicksMaxBuf = new ImInt();
     private final ImInt runTicksTimeoutBuf = new ImInt();
-    private final int[] runTicksGrowthBuf = new int[1];
-    private final float[] runTicksSafetyMultBuf = new float[1];
-    private final int[] runTicksSafetyMarginBuf = new int[1];
+    private final ImInt runTicksGrowthBuf = new ImInt();
+    private final ImFloat runTicksSafetyMultBuf = new ImFloat();
+    private final ImInt runTicksSafetyMarginBuf = new ImInt();
     private final int[] optimizeSecondsBuf = new int[1];
     private final ImInt presetBuf = new ImInt();
     private final ImString presetNameInput = new ImString(64);
@@ -398,6 +399,11 @@ public final class AngleSolverWindow implements RenderInterface {
         w = Math.max(w, segmentedRowWidth("Goal", GOALS, labelW));
         w = Math.max(w, segmentedRowWidth("Inputs", INPUTS, labelW));
         w = Math.max(w, segmentedRowWidth("Sprint", SPRINTS, labelW));
+        if (runTicksExpanded) {
+            float boxW = ImGui.getFrameHeight() + ImGui.getStyle().getItemInnerSpacing().x;
+            float checkColW = boxW + Math.max(ImGui.calcTextSize("Min").x, ImGui.calcTextSize("Auto").x);
+            w = Math.max(w, labelW + 110f * ThemeManager.uiScale() + checkColW);
+        }
         if (advancedExpanded) {
             w = Math.max(w, segmentedRowWidth("Effort", EFFORTS, labelW));
             if (state.getEffort() == AngleSolverState.Effort.CUSTOM) {
@@ -582,10 +588,11 @@ public final class AngleSolverWindow implements RenderInterface {
             + " to restrict how many ticks that jump may get.";
 
     private static final String RUN_TICKS_MAX_TIP =
-            "Largest number of extra running ticks the search may hand out across all jumps together.";
+            "Largest number of extra running ticks the search may hand out across all jumps together."
+            + "In Min mode, the search starts from this count upwards.";
 
     private static final String RUN_TICKS_MIN_TIP =
-            "Search 0, 1, 2 ... extra ticks in turn and stop at the first count that solves, so the result"
+            "Search from the configured run ticks count upwards (n, n+1, n+2 ...) and stop at the first count that solves, so the result"
             + " uses the fewest run ticks instead of the best objective.";
 
     private static final String RUN_TICKS_TIMEOUT_TIP =
@@ -611,14 +618,15 @@ public final class AngleSolverWindow implements RenderInterface {
 
         float spacing = ImGui.getStyle().getItemInnerSpacing().x;
         float boxW = ImGui.getFrameHeight() + spacing;
+        float checkColW = boxW + Math.max(ImGui.calcTextSize("Min").x, ImGui.calcTextSize("Auto").x);
 
         Controls.pushInputFrameHeight();
-        SolverWidgets.rowLabel("Max ticks", labelW);
+        SolverWidgets.rowLabel("Run ticks", labelW);
+        float inputW = Math.max(40f * scale, ImGui.getContentRegionAvail().x - checkColW - spacing);
         runTicksMaxBuf.set(cfg.getMaxTicks());
-        float minW = boxW + ImGui.calcTextSize("Min").x;
-        if (Controls.inputInt("##runTicksMax", runTicksMaxBuf,
-                Math.max(60f, ImGui.getContentRegionAvail().x - minW - spacing))) {
-            cfg.setMaxTicks(runTicksMaxBuf.get());
+        ImGui.setNextItemWidth(inputW);
+        if (ImGui.inputInt("##runTicksMax", runTicksMaxBuf, 1, 5)) {
+            cfg.setMaxTicks(Math.max(0, runTicksMaxBuf.get()));
         }
         TooltipUtil.onHover(RUN_TICKS_MAX_TIP);
         ImGui.sameLine(0, spacing);
@@ -630,10 +638,9 @@ public final class AngleSolverWindow implements RenderInterface {
         SolverWidgets.rowLabel("Step timeout", labelW);
         boolean auto = cfg.isAdaptiveTimeout();
         runTicksTimeoutBuf.set(auto ? runTicks.liveTimeoutMs() : cfg.getTimeoutMs());
-        float autoW = boxW + ImGui.calcTextSize("Auto").x;
         if (auto) ImGui.beginDisabled(true);
-        if (Controls.inputInt("##runTicksTimeout", runTicksTimeoutBuf,
-                Math.max(60f, ImGui.getContentRegionAvail().x - autoW - spacing))) {
+        ImGui.setNextItemWidth(inputW);
+        if (ImGui.inputInt("##runTicksTimeout", runTicksTimeoutBuf, RunTicksSettings.TIMEOUT_NUDGE_MS, 100)) {
             cfg.setTimeoutMs(runTicksTimeoutBuf.get());
         }
         if (auto) ImGui.endDisabled();
@@ -645,23 +652,36 @@ public final class AngleSolverWindow implements RenderInterface {
 
         if (!auto) return;
 
-        runTicksGrowthBuf[0] = cfg.getAddPerJumpMs();
-        if (sliderIntRow("Step growth", "##runTicksGrowth", runTicksGrowthBuf, 0, 500, "+%d ms", labelW,
-                "Added to the timeout for each jump deeper the search goes.")) {
-            cfg.setAddPerJumpMs(runTicksGrowthBuf[0]);
+        Controls.pushInputFrameHeight();
+        SolverWidgets.rowLabel("Step growth", labelW);
+        runTicksGrowthBuf.set(cfg.getAddPerJumpMs());
+        ImGui.setNextItemWidth(inputW);
+        if (ImGui.inputInt("##runTicksGrowth", runTicksGrowthBuf, 10, 50)) {
+            cfg.setAddPerJumpMs(Math.max(0, runTicksGrowthBuf.get()));
         }
+        Controls.popInputFrameHeight();
+        TooltipUtil.onHover("Added to the timeout for each jump deeper the search goes (+ms per jump).");
 
-        runTicksSafetyMultBuf[0] = (float) cfg.getSafetyMult();
-        if (sliderFloatRow("Safety factor", "##runTicksSafetyMult", runTicksSafetyMultBuf, 1.0f, 3.0f, "x%.2f", labelW,
-                "Multiplier applied to the measured solve time before it becomes the next timeout.")) {
-            cfg.setSafetyMult(runTicksSafetyMultBuf[0]);
+        Controls.pushInputFrameHeight();
+        SolverWidgets.rowLabel("Safety factor", labelW);
+        runTicksSafetyMultBuf.set((float) cfg.getSafetyMult());
+        ImGui.setNextItemWidth(inputW);
+        if (ImGui.inputFloat("##runTicksMult", runTicksSafetyMultBuf, 0.1f, 0.5f, "%.2f")) {
+            float val = Math.max(1.0f, Math.round(runTicksSafetyMultBuf.get() * 100.0f) / 100.0f);
+            cfg.setSafetyMult(val);
         }
+        Controls.popInputFrameHeight();
+        TooltipUtil.onHover("Multiplier applied to the measured solve time before it becomes the next timeout.");
 
-        runTicksSafetyMarginBuf[0] = cfg.getSafetyMarginMs();
-        if (sliderIntRow("Safety margin", "##runTicksSafetyMargin", runTicksSafetyMarginBuf, 0, 500, "%d ms", labelW,
-                "Flat buffer added on top of the derived timeout.")) {
-            cfg.setSafetyMarginMs(runTicksSafetyMarginBuf[0]);
+        Controls.pushInputFrameHeight();
+        SolverWidgets.rowLabel("Safety margin", labelW);
+        runTicksSafetyMarginBuf.set(cfg.getSafetyMarginMs());
+        ImGui.setNextItemWidth(inputW);
+        if (ImGui.inputInt("##runTicksMargin", runTicksSafetyMarginBuf, 10, 50)) {
+            cfg.setSafetyMarginMs(Math.max(0, runTicksSafetyMarginBuf.get()));
         }
+        Controls.popInputFrameHeight();
+        TooltipUtil.onHover("Flat buffer added on top of the derived timeout (ms).");
     }
 
     private static final String OPTIMIZE_TIME_TIP =
@@ -837,18 +857,6 @@ public final class AngleSolverWindow implements RenderInterface {
         return true;
     }
 
-
-    private boolean sliderFloatRow(String label, String id, float[] buf, float lo, float hi, String fmt, float labelW, String tip) {
-        Controls.pushInputFrameHeight();
-        ImGui.beginGroup();
-        SolverWidgets.rowLabel(label, labelW);
-        ImGui.setNextItemWidth(ImGui.getContentRegionAvail().x);
-        boolean changed = Controls.sliderFloat(id, buf, lo, hi, fmt);
-        ImGui.endGroup();
-        Controls.popInputFrameHeight();
-        if (tip != null) TooltipUtil.onHover(tip);
-        return changed;
-    }
 
     private boolean sliderIntRow(String label, String id, int[] buf, int lo, int hi, String fmt, float labelW, String tip) {
         Controls.pushInputFrameHeight();

--- a/core/src/test/java/de/legoshi/parkourcalc/core/anglesolver/runticks/RunTicksSearchTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/anglesolver/runticks/RunTicksSearchTest.java
@@ -45,7 +45,7 @@ public class RunTicksSearchTest {
 
     @Test
     public void minimizeVisitsEachSumExactlyOnceAcrossRungs() {
-        RunTicksSearch<Void> search = new RunTicksSearch<Void>(2, 2, true, ANY);
+        RunTicksSearch<Void> search = new RunTicksSearch<Void>(2, 0, true, ANY);
         assertEquals(0, search.target());
 
         assertEquals(Arrays.asList("[0, 0]"), exploreRung(search));
@@ -55,12 +55,28 @@ public class RunTicksSearchTest {
         assertTrue(search.nextRung());
         assertEquals(2, search.target());
         assertEquals(Arrays.asList("[0, 2]", "[1, 1]", "[2, 0]"), exploreRung(search));
-        assertFalse(search.nextRung());
+        assertTrue(search.nextRung());
+        assertEquals(3, search.target());
+        assertEquals(Arrays.asList("[0, 3]", "[1, 2]", "[2, 1]", "[3, 0]"), exploreRung(search));
+    }
+
+    @Test
+    public void minimizeStartsFromConfiguredRunTicks() {
+        RunTicksSearch<Void> search = new RunTicksSearch<Void>(2, 3, true, ANY);
+        assertEquals(3, search.target());
+        assertEquals(Arrays.asList("[0, 3]", "[1, 2]", "[2, 1]", "[3, 0]"), exploreRung(search));
+        assertTrue(search.nextRung());
+        assertEquals(4, search.target());
     }
 
     @Test
     public void theLadderCoversExactlyTheSweepWithoutRepeats() {
-        List<String> ladder = exploreAll(new RunTicksSearch<Void>(3, 3, true, ANY), true);
+        List<String> ladder = new ArrayList<String>();
+        RunTicksSearch<Void> search = new RunTicksSearch<Void>(3, 0, true, ANY);
+        while (search.target() <= 3) {
+            ladder.addAll(exploreRung(search));
+            if (search.target() == 3 || !search.nextRung()) break;
+        }
         List<String> sweep = exploreAll(new RunTicksSearch<Void>(3, 3, false, ANY), false);
         assertEquals(sweep.size(), ladder.size());
         assertEquals(new TreeSet<String>(sweep), new TreeSet<String>(ladder));
@@ -68,7 +84,7 @@ public class RunTicksSearchTest {
 
     @Test
     public void aRungCostsOnlyItsOwnCombinations() {
-        RunTicksSearch<Void> ladder = new RunTicksSearch<Void>(3, 3, true, ANY);
+        RunTicksSearch<Void> ladder = new RunTicksSearch<Void>(3, 0, true, ANY);
         exploreRung(ladder);
         assertEquals("the all-zero rung is one chain of solves", 3, ladder.steps());
         assertEquals(1, ladder.fullSolutions());
@@ -83,7 +99,7 @@ public class RunTicksSearchTest {
 
     @Test
     public void minimizeClimbsPastRungsTheConstraintsPruneAway() {
-        RunTicksSearch<Void> search = new RunTicksSearch<Void>(1, 3, true,
+        RunTicksSearch<Void> search = new RunTicksSearch<Void>(1, 0, true,
                 (jumpIndex, extraTicks) -> extraTicks >= 2);
         assertFalse("rung 0 and rung 1 are both impossible", search.hasNext());
         assertTrue(search.nextRung());


### PR DESCRIPTION
### Summary of Changes

- **UI Layout & Alignment:** 
  - Restructured Running Ticks controls into dedicated rows with aligned input fields and checkboxes (`Min` and `Auto`).
  - Added 25ms nudge steps to the Step Timeout input field.
  - Added float stepper controls (`+/-` by 0.10) for the Safety Factor.
  - Renamed "Max ticks" to "Run ticks" for clarity.
- **Min Mode Search Logic:**
  - Min mode now starts searching upwards from the configured run ticks count (`n, n+1, n+2...`) instead of being capped.
- **Prefix-Cap Lookahead Pruning:**
  - Added constraint-aware lookahead bounds (`RunTicksFilter.maxAllowed` / `RunTicksSearch`) that immediately terminate impossible searches (e.g. when `RT=0` constraints prevent reaching downstream jumps) rather than looping indefinitely.
- **Progress Percentage Display:**
  - Fixed non-linear progress jumps; the HUD progress bar now scales smoothly from 0% to 100%.