### PR TITLE
test: make graph solve reproducibility check tolerance-based

### DIFF
--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/GraphPathObjectiveGateTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/GraphPathObjectiveGateTest.java
@@ -95,12 +95,13 @@ public class GraphPathObjectiveGateTest {
     }
 
     @Test
-    public void graphSolveIsBitIdenticalAcrossRepeats() {
+    public void graphSolveIsReproducibleAcrossRepeats() {
         Solved a = solveThroughGraph("j021-rinav1-01", AngleSolverState.Effort.THOROUGH, 12, 60_000L);
         Solved b = solveThroughGraph("j021-rinav1-01", AngleSolverState.Effort.THOROUGH, 12, 60_000L);
-        assertTrue("shipped objective not deterministic across repeats (" + a.engineObj + " vs " + b.engineObj + ")",
-                Double.doubleToLongBits(a.engineObj) == Double.doubleToLongBits(b.engineObj));
-        assertTrue("recompute not deterministic across repeats (" + a.recomputeObj + " vs " + b.recomputeObj + ")",
-                Double.doubleToLongBits(a.recomputeObj) == Double.doubleToLongBits(b.recomputeObj));
+        double tol = 1.0e-2;
+        assertTrue("shipped objective not reproducible across repeats within " + tol + " ("
+                + a.engineObj + " vs " + b.engineObj + ")", Math.abs(a.engineObj - b.engineObj) < tol);
+        assertTrue("recompute not reproducible across repeats within " + tol + " ("
+                + a.recomputeObj + " vs " + b.recomputeObj + ")", Math.abs(a.recomputeObj - b.recomputeObj) < tol);
     }
 }


### PR DESCRIPTION
## Problem

`GraphPathObjectiveGateTest.graphSolveIsBitIdenticalAcrossRepeats` flakes on CI (fails on `dev` itself, independent of any feature branch). It ran the **THOROUGH** solve on `j021` twice and asserted the two objectives were **bit-for-bit identical**.

THOROUGH is a wall-clock-budgeted anytime optimizer (`optimizeSeconds`), so the two runs complete a slightly different number of iterations and converge to points a few ×10⁻⁵ apart (observed `1067.86376031` vs `1067.86380207`). Asserting bit-equality of a timed optimizer is unsound, so it fails whenever CI timing doesn't line up.

## Fix

Assert the two runs agree **within 1e-2** (250× the observed divergence — still catches any gross non-determinism, e.g. landing in a different basin), matching the tolerance style the sibling `loopmmGraphSolveLandsPerEngine` check already uses. Renamed to `graphSolveIsReproducibleAcrossRepeats`.

Test-only change. Verified green across repeated local `-PslowTests` runs (3/3).