### PR TITLE
refactor(anglesolver): remove copy-to-tick and move-to-tick from constraint menu

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverTable.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverTable.java
@@ -689,24 +689,6 @@ public final class AngleSolverTable {
             ImGui.closeCurrentPopup();
         }
         ThemeManager.paddedSeparator();
-        ThemeManager.pushTextColor(ThemeManager.textDimColor());
-        ImGui.text("Copy to tick");
-        ThemeManager.popTextColor();
-        int copyPick = tickGrid("copy", tick);
-        if (copyPick >= 0) {
-            state.copyConstraint(tick, index, copyPick);
-            ImGui.closeCurrentPopup();
-        }
-        ThemeManager.pushTextColor(ThemeManager.textDimColor());
-        ImGui.text("Move to tick");
-        ThemeManager.popTextColor();
-        int movePick = tickGrid("move", tick);
-        if (movePick >= 0) {
-            state.moveConstraint(tick, index, movePick);
-            clearConstraintSelection();
-            ImGui.closeCurrentPopup();
-        }
-        ThemeManager.paddedSeparator();
         ThemeManager.pushTextColor(ThemeManager.dangerColor());
         boolean del = ImGui.menuItem("Delete");
         ThemeManager.popTextColor();
@@ -715,23 +697,6 @@ public final class AngleSolverTable {
             clearConstraintSelection();
             ImGui.closeCurrentPopup();
         }
-    }
-
-    /** Renders a wrapped grid of tick buttons (excluding current). Returns the picked tick, or -1. */
-    private int tickGrid(String id, int currentTick) {
-        int pick = -1;
-        int n = Math.max(1, rowCount.getAsInt());
-        ImGui.pushID(id);
-        int col = 0;
-        for (int t = 0; t < n; t++) {
-            if (t == currentTick) continue;
-            if (col > 0) ImGui.sameLine();
-            if (ImGui.button("T" + (t + 1))) pick = t;
-            col++;
-            if (col >= 6) col = 0;
-        }
-        ImGui.popID();
-        return pick;
     }
 
     private static final class StateChipSpec {


### PR DESCRIPTION
Removes the "Copy to tick" and "Move to tick" items from the constraint right-click menu; they obstructed the rest of the menu. Full removal, as requested in the issue.

- Deleted both menu sections and the now-unused `tickGrid` helper from `AngleSolverTable`.
- Kept `copyConstraint`/`moveConstraint`: the chip drag-and-drop (plain drag = move, Alt-drag = copy) still uses them, so they are not dead.
- No copy/move-menu-specific tests existed to remove (`CopyPasteTicksTest` is unrelated row-clipboard).

Testing: `:core:build` (tableStyleCheck) and `:core:test` green.

Closes #420
