### PR TITLE
fix(sim): apply per-tick pitch so water trajectory matches replay

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/sim/LazyEntitySimulator.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/sim/LazyEntitySimulator.java
@@ -1,6 +1,7 @@
 package de.legoshi.parkourcalc.core.sim;
 
 import de.legoshi.parkourcalc.core.DebugFlags;
+import de.legoshi.parkourcalc.core.PlaybackController;
 import de.legoshi.parkourcalc.core.anglesolver.Medium;
 import de.legoshi.parkourcalc.core.ports.Simulator;
 import de.legoshi.parkourcalc.core.ui.InputRow;
@@ -40,6 +41,7 @@ public abstract class LazyEntitySimulator<E> implements Simulator {
                 applyYaw(e, row.getYaw());
             }
         }
+        setEntityPitch(e, PlaybackController.applyPitch(getEntityPitch(e), row));
     }
 
     @Override
@@ -237,6 +239,13 @@ public abstract class LazyEntitySimulator<E> implements Simulator {
     protected abstract void applyYaw(E entity, float yaw);
 
     protected abstract void setYawAbsolute(E entity, float yaw);
+
+    protected float getEntityPitch(E entity) {
+        return 0f;
+    }
+
+    protected void setEntityPitch(E entity, float pitch) {
+    }
 
     /** UI amplifiers are 1-based (1 = level I); 0 means the effect is not active this tick. */
     protected abstract void applyTickEffects(E entity, int speedAmplifier, int jumpBoostAmplifier);

--- a/core/src/test/java/de/legoshi/parkourcalc/core/MediumWorldFakeSimulator.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/MediumWorldFakeSimulator.java
@@ -121,6 +121,7 @@ public class MediumWorldFakeSimulator extends LazyEntitySimulator<MediumWorldFak
         double x, y, z;
         double vx, vy, vz;
         float yaw;
+        float pitch;
         boolean onGround;
         boolean horizontalCollision;
         boolean pendingStuck;
@@ -302,6 +303,7 @@ public class MediumWorldFakeSimulator extends LazyEntitySimulator<MediumWorldFak
     private static final class FakeCheckpoint implements Checkpoint {
         final double x, y, z, vx, vy, vz;
         final float yaw;
+        final float pitch;
         final boolean onGround, horizontalCollision, pendingStuck, sprinting;
         final int noJumpDelay;
         final InputRow row;
@@ -314,6 +316,7 @@ public class MediumWorldFakeSimulator extends LazyEntitySimulator<MediumWorldFak
             vy = e.vy;
             vz = e.vz;
             yaw = e.yaw;
+            pitch = e.pitch;
             onGround = e.onGround;
             horizontalCollision = e.horizontalCollision;
             pendingStuck = e.pendingStuck;
@@ -330,6 +333,7 @@ public class MediumWorldFakeSimulator extends LazyEntitySimulator<MediumWorldFak
             e.vy = vy;
             e.vz = vz;
             e.yaw = yaw;
+            e.pitch = pitch;
             e.onGround = onGround;
             e.horizontalCollision = horizontalCollision;
             e.pendingStuck = pendingStuck;
@@ -340,6 +344,7 @@ public class MediumWorldFakeSimulator extends LazyEntitySimulator<MediumWorldFak
     }
 
     private final World world;
+    private float startPitch;
 
     public MediumWorldFakeSimulator(World world) {
         this.world = world;
@@ -349,6 +354,8 @@ public class MediumWorldFakeSimulator extends LazyEntitySimulator<MediumWorldFak
         return world;
     }
 
+    @Override public void setStartPitch(float pitch) { this.startPitch = pitch; }
+
     @Override
     protected FakeEntity createEntity(Vec3dCore pendingStart, Vec3dCore pendingVelocity, Float pendingYaw) {
         Vec3dCore start = pendingStart != null ? pendingStart : Vec3dCore.ZERO;
@@ -357,7 +364,10 @@ public class MediumWorldFakeSimulator extends LazyEntitySimulator<MediumWorldFak
         return new FakeEntity(world, start, vel, yaw);
     }
 
-    @Override protected void resetEntity(FakeEntity e, StartResumeState resume) { e.reset(resume); }
+    @Override protected void resetEntity(FakeEntity e, StartResumeState resume) {
+        e.reset(resume);
+        e.pitch = startPitch;
+    }
 
     @Override
     protected StartResumeState describeResume(Checkpoint checkpoint) {
@@ -416,6 +426,10 @@ public class MediumWorldFakeSimulator extends LazyEntitySimulator<MediumWorldFak
     @Override protected int getTickSoulsandCells(FakeEntity e) { return 0; }
 
     @Override protected float getYaw(FakeEntity e) { return e.yaw; }
+
+    @Override protected float getEntityPitch(FakeEntity e) { return e.pitch; }
+
+    @Override protected void setEntityPitch(FakeEntity e, float pitch) { e.pitch = pitch; }
 
     @Override protected List<Vec3dCore> getSubtickPath(FakeEntity e) { return Collections.emptyList(); }
 

--- a/core/src/test/java/de/legoshi/parkourcalc/core/SimulatorPitchTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/SimulatorPitchTest.java
@@ -1,0 +1,154 @@
+package de.legoshi.parkourcalc.core;
+
+import de.legoshi.parkourcalc.core.sim.Checkpoint;
+import de.legoshi.parkourcalc.core.sim.LazyEntitySimulator;
+import de.legoshi.parkourcalc.core.sim.SimulationRunner;
+import de.legoshi.parkourcalc.core.sim.StartResumeState;
+import de.legoshi.parkourcalc.core.sim.Vec3dCore;
+import de.legoshi.parkourcalc.core.ui.InputData;
+import de.legoshi.parkourcalc.core.ui.InputRow;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class SimulatorPitchTest {
+
+    private static final class Entity {
+        float pitch;
+    }
+
+    private static final class PitchCheckpoint implements Checkpoint {
+        final float pitch;
+        PitchCheckpoint(float pitch) { this.pitch = pitch; }
+    }
+
+    private static final class PitchRecordingSimulator extends LazyEntitySimulator<Entity> {
+        final List<Float> tickPitch = new ArrayList<>();
+        private float startPitch;
+
+        @Override public void setStartPitch(float pitch) { startPitch = pitch; }
+
+        @Override protected Entity createEntity(Vec3dCore s, Vec3dCore v, Float y) { return new Entity(); }
+
+        @Override protected void resetEntity(Entity e, StartResumeState resume) { e.pitch = startPitch; }
+
+        @Override protected StartResumeState describeResume(Checkpoint checkpoint) { return null; }
+
+        @Override protected void setInput(Entity e, InputRow row) { }
+
+        @Override protected void applyYaw(Entity e, float yaw) { }
+
+        @Override protected void setYawAbsolute(Entity e, float yaw) { }
+
+        @Override protected float getEntityPitch(Entity e) { return e.pitch; }
+
+        @Override protected void setEntityPitch(Entity e, float pitch) { e.pitch = pitch; }
+
+        @Override protected void applyTickEffects(Entity e, int s, int j) { }
+
+        @Override protected void tickEntity(Entity e) { tickPitch.add(e.pitch); }
+
+        @Override protected Vec3dCore getPos(Entity e) { return Vec3dCore.ZERO; }
+        @Override protected boolean isOnGround(Entity e) { return false; }
+        @Override protected boolean isSneaking(Entity e) { return false; }
+        @Override protected boolean isSprinting(Entity e) { return false; }
+        @Override protected float getMoveForward(Entity e) { return Float.NaN; }
+        @Override protected float getMoveStrafe(Entity e) { return Float.NaN; }
+        @Override protected boolean isWallCollision(Entity e) { return false; }
+        @Override protected Vec3dCore getVelocity(Entity e) { return Vec3dCore.ZERO; }
+        @Override protected boolean isSoftCollision(Entity e) { return false; }
+        @Override protected double getCollisionAngleDegrees(Entity e) { return Double.NaN; }
+        @Override protected de.legoshi.parkourcalc.core.anglesolver.Medium getTickMedium(Entity e) { return null; }
+        @Override protected double getTickGroundFriction(Entity e) { return Double.NaN; }
+        @Override protected int getTickSoulsandCells(Entity e) { return 0; }
+        @Override protected float getYaw(Entity e) { return 0f; }
+        @Override protected List<Vec3dCore> getSubtickPath(Entity e) { return Collections.emptyList(); }
+        @Override protected Vec3dCore getStart(Entity e) { return Vec3dCore.ZERO; }
+        @Override protected void setStart(Entity e, Vec3dCore pos) { }
+        @Override protected Vec3dCore getStartVel(Entity e) { return Vec3dCore.ZERO; }
+        @Override protected void setStartVel(Entity e, Vec3dCore vel) { }
+        @Override protected float getStartYawValue(Entity e) { return 0f; }
+        @Override protected void setStartYawValue(Entity e, float yaw) { }
+        @Override protected Checkpoint saveCheckpoint(Entity e) { return new PitchCheckpoint(e.pitch); }
+        @Override protected void restoreCheckpoint(Entity e, Checkpoint c) { e.pitch = ((PitchCheckpoint) c).pitch; }
+    }
+
+    private static InputRow deltaRow(float delta) {
+        InputRow r = new InputRow();
+        r.setPitch(delta);
+        return r;
+    }
+
+    private static InputRow lockedRow(float absolute) {
+        InputRow r = new InputRow();
+        r.setPitchLocked(true);
+        r.setPitch(absolute);
+        return r;
+    }
+
+    private static InputData data(InputRow... rows) {
+        InputData d = new InputData();
+        for (InputRow r : rows) d.getRows().add(r);
+        return d;
+    }
+
+    @Test
+    public void feedsFoldedPitchToEntityEachTick() {
+        PitchRecordingSimulator sim = new PitchRecordingSimulator();
+        SimulationRunner runner = new SimulationRunner(sim);
+        runner.setStartPitch(40f);
+
+        InputData d = data(deltaRow(10f), new InputRow(), deltaRow(-5f), lockedRow(12f));
+        runner.simulate(d);
+
+        assertEquals(4, sim.tickPitch.size());
+        assertEquals(50f, sim.tickPitch.get(0), 0f);
+        assertEquals(50f, sim.tickPitch.get(1), 0f);
+        assertEquals(45f, sim.tickPitch.get(2), 0f);
+        assertEquals(12f, sim.tickPitch.get(3), 0f);
+    }
+
+    @Test
+    public void startPitchReachesEntityWithNoPitchRows() {
+        PitchRecordingSimulator sim = new PitchRecordingSimulator();
+        SimulationRunner runner = new SimulationRunner(sim);
+        runner.setStartPitch(-25f);
+
+        runner.simulate(data(new InputRow(), new InputRow()));
+
+        assertEquals(-25f, sim.tickPitch.get(0), 0f);
+        assertEquals(-25f, sim.tickPitch.get(1), 0f);
+    }
+
+    @Test
+    public void pitchClampedToRange() {
+        PitchRecordingSimulator sim = new PitchRecordingSimulator();
+        SimulationRunner runner = new SimulationRunner(sim);
+        runner.setStartPitch(40f);
+
+        runner.simulate(data(deltaRow(100f)));
+
+        assertEquals(90f, sim.tickPitch.get(0), 0f);
+    }
+
+    @Test
+    public void incrementalResumeRestoresFoldedPitchBase() {
+        PitchRecordingSimulator sim = new PitchRecordingSimulator();
+        SimulationRunner runner = new SimulationRunner(sim);
+        runner.setStartPitch(40f);
+
+        InputData d = data(deltaRow(10f), new InputRow(), deltaRow(-5f), lockedRow(12f));
+        runner.simulate(d);
+
+        sim.tickPitch.clear();
+        runner.simulateFrom(2, d);
+
+        assertEquals(2, sim.tickPitch.size());
+        assertEquals(45f, sim.tickPitch.get(0), 0f);
+        assertEquals(12f, sim.tickPitch.get(1), 0f);
+    }
+}

--- a/core/src/test/java/de/legoshi/parkourcalc/core/SimulatorPitchTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/SimulatorPitchTest.java
@@ -1,80 +1,28 @@
 package de.legoshi.parkourcalc.core;
 
-import de.legoshi.parkourcalc.core.sim.Checkpoint;
-import de.legoshi.parkourcalc.core.sim.LazyEntitySimulator;
 import de.legoshi.parkourcalc.core.sim.SimulationRunner;
-import de.legoshi.parkourcalc.core.sim.StartResumeState;
-import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.InputData;
 import de.legoshi.parkourcalc.core.ui.InputRow;
 import org.junit.Test;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
 public class SimulatorPitchTest {
 
-    private static final class Entity {
-        float pitch;
-    }
-
-    private static final class PitchCheckpoint implements Checkpoint {
-        final float pitch;
-        PitchCheckpoint(float pitch) { this.pitch = pitch; }
-    }
-
-    private static final class PitchRecordingSimulator extends LazyEntitySimulator<Entity> {
+    private static final class PitchRecordingSimulator extends MediumWorldFakeSimulator {
         final List<Float> tickPitch = new ArrayList<>();
-        private float startPitch;
 
-        @Override public void setStartPitch(float pitch) { startPitch = pitch; }
+        PitchRecordingSimulator() {
+            super(new World());
+        }
 
-        @Override protected Entity createEntity(Vec3dCore s, Vec3dCore v, Float y) { return new Entity(); }
-
-        @Override protected void resetEntity(Entity e, StartResumeState resume) { e.pitch = startPitch; }
-
-        @Override protected StartResumeState describeResume(Checkpoint checkpoint) { return null; }
-
-        @Override protected void setInput(Entity e, InputRow row) { }
-
-        @Override protected void applyYaw(Entity e, float yaw) { }
-
-        @Override protected void setYawAbsolute(Entity e, float yaw) { }
-
-        @Override protected float getEntityPitch(Entity e) { return e.pitch; }
-
-        @Override protected void setEntityPitch(Entity e, float pitch) { e.pitch = pitch; }
-
-        @Override protected void applyTickEffects(Entity e, int s, int j) { }
-
-        @Override protected void tickEntity(Entity e) { tickPitch.add(e.pitch); }
-
-        @Override protected Vec3dCore getPos(Entity e) { return Vec3dCore.ZERO; }
-        @Override protected boolean isOnGround(Entity e) { return false; }
-        @Override protected boolean isSneaking(Entity e) { return false; }
-        @Override protected boolean isSprinting(Entity e) { return false; }
-        @Override protected float getMoveForward(Entity e) { return Float.NaN; }
-        @Override protected float getMoveStrafe(Entity e) { return Float.NaN; }
-        @Override protected boolean isWallCollision(Entity e) { return false; }
-        @Override protected Vec3dCore getVelocity(Entity e) { return Vec3dCore.ZERO; }
-        @Override protected boolean isSoftCollision(Entity e) { return false; }
-        @Override protected double getCollisionAngleDegrees(Entity e) { return Double.NaN; }
-        @Override protected de.legoshi.parkourcalc.core.anglesolver.Medium getTickMedium(Entity e) { return null; }
-        @Override protected double getTickGroundFriction(Entity e) { return Double.NaN; }
-        @Override protected int getTickSoulsandCells(Entity e) { return 0; }
-        @Override protected float getYaw(Entity e) { return 0f; }
-        @Override protected List<Vec3dCore> getSubtickPath(Entity e) { return Collections.emptyList(); }
-        @Override protected Vec3dCore getStart(Entity e) { return Vec3dCore.ZERO; }
-        @Override protected void setStart(Entity e, Vec3dCore pos) { }
-        @Override protected Vec3dCore getStartVel(Entity e) { return Vec3dCore.ZERO; }
-        @Override protected void setStartVel(Entity e, Vec3dCore vel) { }
-        @Override protected float getStartYawValue(Entity e) { return 0f; }
-        @Override protected void setStartYawValue(Entity e, float yaw) { }
-        @Override protected Checkpoint saveCheckpoint(Entity e) { return new PitchCheckpoint(e.pitch); }
-        @Override protected void restoreCheckpoint(Entity e, Checkpoint c) { e.pitch = ((PitchCheckpoint) c).pitch; }
+        @Override protected void tickEntity(FakeEntity e) {
+            tickPitch.add(e.pitch);
+            super.tickEntity(e);
+        }
     }
 
     private static InputRow deltaRow(float delta) {

--- a/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/sim/FabricSimulator.java
+++ b/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/sim/FabricSimulator.java
@@ -149,6 +149,7 @@ public final class FabricSimulator extends LazyEntitySimulator<SimulatorEntity> 
         } else {
             e.resetPlayer(resume);
         }
+        e.setXRot(startPitch);
     }
 
     @Override
@@ -189,6 +190,14 @@ public final class FabricSimulator extends LazyEntitySimulator<SimulatorEntity> 
 
     @Override protected void setYawAbsolute(SimulatorEntity e, float yaw) {
         e.setYRot(yaw);
+    }
+
+    @Override protected float getEntityPitch(SimulatorEntity e) {
+        return e.getXRot();
+    }
+
+    @Override protected void setEntityPitch(SimulatorEntity e, float pitch) {
+        e.setXRot(pitch);
     }
 
     @Override

--- a/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/sim/SimulatorEntity.java
+++ b/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/sim/SimulatorEntity.java
@@ -431,6 +431,7 @@ public class SimulatorEntity extends Player {
         c.pos = this.position();
         c.velocity = this.getDeltaMovement();
         c.yaw = this.getYRot();
+        c.pitch = this.getXRot();
         c.onGround = this.onGround();
         c.horizontalCollision = this.horizontalCollision;
         c.collidedSoftly = this.minorHorizontalCollision;
@@ -455,6 +456,7 @@ public class SimulatorEntity extends Player {
         this.setPos(c.pos);
         this.setDeltaMovement(c.velocity);
         this.setYRot(c.yaw);
+        this.setXRot(c.pitch);
         this.setOnGround(c.onGround);
         this.horizontalCollision = c.horizontalCollision;
         this.minorHorizontalCollision = c.collidedSoftly;
@@ -482,6 +484,7 @@ public class SimulatorEntity extends Player {
         Vec3 pos;
         Vec3 velocity;
         float yaw;
+        float pitch;
         boolean onGround;
         boolean horizontalCollision;
         boolean collidedSoftly;

--- a/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/sim/SimulatorEntity.java
+++ b/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/sim/SimulatorEntity.java
@@ -436,6 +436,7 @@ public class SimulatorEntity extends Player {
         c.horizontalCollision = this.horizontalCollision;
         c.collidedSoftly = this.minorHorizontalCollision;
         c.sprinting = this.isSprinting();
+        c.swimming = this.isSwimming();
         c.ticksLeftToDoubleTapSprint = this.sprintTriggerTime;
         c.playerInput = this.input.keyPresses;
         c.jumpingCooldown = this.noJumpDelay;
@@ -461,6 +462,7 @@ public class SimulatorEntity extends Player {
         this.horizontalCollision = c.horizontalCollision;
         this.minorHorizontalCollision = c.collidedSoftly;
         this.setSprinting(c.sprinting);
+        this.setSwimming(c.swimming);
         this.sprintTriggerTime = c.ticksLeftToDoubleTapSprint;
         this.input.seedKeyPresses(c.playerInput);
         this.noJumpDelay = c.jumpingCooldown;
@@ -489,6 +491,7 @@ public class SimulatorEntity extends Player {
         boolean horizontalCollision;
         boolean collidedSoftly;
         boolean sprinting;
+        boolean swimming;
         int ticksLeftToDoubleTapSprint;
         Input playerInput;
         int jumpingCooldown;

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/sim/FabricSimulator.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/sim/FabricSimulator.java
@@ -149,6 +149,7 @@ public final class FabricSimulator extends LazyEntitySimulator<SimulatorEntity> 
         } else {
             e.resetPlayer(resume);
         }
+        e.setXRot(startPitch);
     }
 
     @Override
@@ -189,6 +190,14 @@ public final class FabricSimulator extends LazyEntitySimulator<SimulatorEntity> 
 
     @Override protected void setYawAbsolute(SimulatorEntity e, float yaw) {
         e.setYRot(yaw);
+    }
+
+    @Override protected float getEntityPitch(SimulatorEntity e) {
+        return e.getXRot();
+    }
+
+    @Override protected void setEntityPitch(SimulatorEntity e, float pitch) {
+        e.setXRot(pitch);
     }
 
     @Override

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/sim/SimulatorEntity.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/sim/SimulatorEntity.java
@@ -459,6 +459,7 @@ public class SimulatorEntity extends Player {
         c.horizontalCollision = this.horizontalCollision;
         c.collidedSoftly = this.minorHorizontalCollision;
         c.sprinting = this.isSprinting();
+        c.swimming = this.isSwimming();
         c.ticksLeftToDoubleTapSprint = this.sprintTriggerTime;
         c.playerInput = this.input.keyPresses;
         c.jumpingCooldown = this.noJumpDelay;
@@ -484,6 +485,7 @@ public class SimulatorEntity extends Player {
         this.horizontalCollision = c.horizontalCollision;
         this.minorHorizontalCollision = c.collidedSoftly;
         this.setSprinting(c.sprinting);
+        this.setSwimming(c.swimming);
         this.sprintTriggerTime = c.ticksLeftToDoubleTapSprint;
         this.input.seedKeyPresses(c.playerInput);
         this.noJumpDelay = c.jumpingCooldown;
@@ -512,6 +514,7 @@ public class SimulatorEntity extends Player {
         boolean horizontalCollision;
         boolean collidedSoftly;
         boolean sprinting;
+        boolean swimming;
         int ticksLeftToDoubleTapSprint;
         Input playerInput;
         int jumpingCooldown;

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/sim/SimulatorEntity.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/sim/SimulatorEntity.java
@@ -454,6 +454,7 @@ public class SimulatorEntity extends Player {
         c.pos = this.position();
         c.velocity = this.getDeltaMovement();
         c.yaw = this.getYRot();
+        c.pitch = this.getXRot();
         c.onGround = this.onGround();
         c.horizontalCollision = this.horizontalCollision;
         c.collidedSoftly = this.minorHorizontalCollision;
@@ -478,6 +479,7 @@ public class SimulatorEntity extends Player {
         this.setPos(c.pos);
         this.setDeltaMovement(c.velocity);
         this.setYRot(c.yaw);
+        this.setXRot(c.pitch);
         this.setOnGround(c.onGround);
         this.horizontalCollision = c.horizontalCollision;
         this.minorHorizontalCollision = c.collidedSoftly;
@@ -505,6 +507,7 @@ public class SimulatorEntity extends Player {
         Vec3 pos;
         Vec3 velocity;
         float yaw;
+        float pitch;
         boolean onGround;
         boolean horizontalCollision;
         boolean collidedSoftly;


### PR DESCRIPTION
In 1.13+, swimming moves the player along the look vector, so pitch changes the trajectory in water (also lava and elytra). The simulator ignored per-tick pitch while playback applied it, so editing a water tick's pitch left the boxes unchanged and desynced the replay.

- Fold each tick's pitch onto the real `SimulatorEntity` in `LazyEntitySimulator.applyInput` via the shared `PlaybackController.applyPitch`, the same accumulation playback uses, so the boxes and the replay stay in lockstep.
- Apply the start pitch on reset; carry pitch through the entity checkpoint for incremental resume.
- Core stays Minecraft-free (no-op `getEntityPitch`/`setEntityPitch` overridden to `getXRot`/`setXRot` in both Fabric loaders). The Forge loaders inherit the no-ops, so their pre-1.13 trajectory is unaffected.

Testing: `:core:build`, `:core:test` (plus new `SimulatorPitchTest`), and all four loaders compile.

QA needed (real MC water physics, not coverable headlessly): on 1.21.3 or 26.2, make a TAS that swims, change a tick's pitch, and confirm the boxes follow the look vector and the replay stays synced.

Closes #423
