### PR TITLE
feat: add pressure plate hitbox constraint (Ctrl+B)

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
@@ -185,7 +185,7 @@ public final class Application {
         ExactJumpModel forwardModel = ExactJumpModel.forMcVersion(mcVersion);
         constraintKeyController = new ConstraintKeyController(
                 mc, angleSolverState, selection, constraintSelection, saveController::markDirty,
-                forwardModel.modern(), inputData::size);
+                forwardModel.modern(), inputData::size, settings);
         saveController.setAngleSolver(angleSolverState);
         saveController.setDebugSource(boxController, settings);
         AngleSolverTable angleSolverTable = new AngleSolverTable(angleSolverState, settings, selection, constraintSelection, inputData::size);

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ports/MinecraftAccess.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ports/MinecraftAccess.java
@@ -50,6 +50,10 @@ public interface MinecraftAccess {
         return false;
     }
 
+    default double[] getPressurePlateFootprint(int x, int y, int z) {
+        return null;
+    }
+
     default Face getLookedAtFace() {
         return null;
     }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/render/PathRenderPlan.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/render/PathRenderPlan.java
@@ -255,6 +255,7 @@ public final class PathRenderPlan {
         h = 31 * h + (settings.showSubtick ? 8 : 0);
         h = 31 * h + (settings.showConstraints ? 16 : 0);
         h = 31 * h + (settings.constraintExpandByHitbox ? 32 : 0);
+        h = 31 * h + (settings.pressurePlateFullBlock ? 256 : 0);
         h = 31 * h + (settings.showHitDistanceLines ? 64 : 0);
         h = 31 * h + (settings.hitDistanceSelectedOnly ? 128 : 0);
         h = 31 * h + Float.hashCode(settings.constraintFrontWidth);

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/ConstraintKeyController.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/ConstraintKeyController.java
@@ -147,10 +147,11 @@ public final class ConstraintKeyController {
     }
 
     private double[] pressurePlateFootprint(int bx, int bz, double[] interaction) {
+        double h = ConstraintDeriver.HALF;
         if (settings != null && settings.pressurePlateFullBlock) {
-            return new double[] {bx, bx + 1.0, bz, bz + 1.0};
+            return new double[] {bx - h, bx + 1.0 + h, bz - h, bz + 1.0 + h};
         }
-        return new double[] {interaction[0], interaction[1], interaction[2], interaction[3]};
+        return new double[] {interaction[0] - h, interaction[1] + h, interaction[2] - h, interaction[3] + h};
     }
 
     private int selectedTick() {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/ConstraintKeyController.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/ConstraintKeyController.java
@@ -23,10 +23,11 @@ public final class ConstraintKeyController {
     private final Runnable onChanged;
     private final boolean modernCollision;
     private final IntSupplier rowCount;
+    private final Settings settings;
 
     public ConstraintKeyController(MinecraftAccess mc, AngleSolverState state, SelectionManager selection,
                                    ConstraintSelection constraintSelection, Runnable onChanged,
-                                   boolean modernCollision, IntSupplier rowCount) {
+                                   boolean modernCollision, IntSupplier rowCount, Settings settings) {
         this.mc = mc;
         this.state = state;
         this.selection = selection;
@@ -34,6 +35,7 @@ public final class ConstraintKeyController {
         this.onChanged = onChanged;
         this.modernCollision = modernCollision;
         this.rowCount = rowCount;
+        this.settings = settings;
     }
 
     public void onKey(boolean enter, boolean remove) {
@@ -48,6 +50,16 @@ public final class ConstraintKeyController {
 
         boolean merge = mc.isAltDown();
         if (merge) remove = false;
+
+        if (remove) {
+            double[] plate = mc.getPressurePlateFootprint(bx, by, bz);
+            if (plate != null) {
+                double[] r = pressurePlateFootprint(bx, bz, plate);
+                state.setFootprint(tick, r[0], r[1], r[2], r[3]);
+                onChanged.run();
+                return;
+            }
+        }
 
         if (remove && mc.isClimbable(bx, by, bz)) {
             List<AABB> obstacles = mc.getCollisionBoxes(bx - 1, by, bz - 1, bx + 1, by + 1, bz + 1);
@@ -132,6 +144,13 @@ public final class ConstraintKeyController {
         }
         if (best != null) return ConstraintDeriver.mergeCoplanarSupport(best, boxes);
         return new AABB(new Vec3dCore(bx, by, bz), new Vec3dCore(bx + 1.0, by + 1.0, bz + 1.0));
+    }
+
+    private double[] pressurePlateFootprint(int bx, int bz, double[] interaction) {
+        if (settings != null && settings.pressurePlateFullBlock) {
+            return new double[] {bx, bx + 1.0, bz, bz + 1.0};
+        }
+        return new double[] {interaction[0], interaction[1], interaction[2], interaction[3]};
     }
 
     private int selectedTick() {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/Settings.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/Settings.java
@@ -31,6 +31,7 @@ public final class Settings {
     private static final float[] DEFAULT_CONSTRAINT_HIGHLIGHT = {0.996f, 0.996f, 0.996f, 1.000f};
 
     private static final boolean DEFAULT_CONSTRAINT_EXPAND_BY_HITBOX = true;
+    private static final boolean DEFAULT_PRESSURE_PLATE_FULL_BLOCK = false;
     private static final float DEFAULT_CONSTRAINT_FRONT_WIDTH = 0.6f;
     private static final float DEFAULT_CONSTRAINT_FRONT_HEIGHT = 0.15f;
     private static final float DEFAULT_CONSTRAINT_FRONT_LENGTH = 0.01f;
@@ -148,6 +149,7 @@ public final class Settings {
     public final float[] constraintHighlight = DEFAULT_CONSTRAINT_HIGHLIGHT.clone();
 
     public boolean constraintExpandByHitbox = DEFAULT_CONSTRAINT_EXPAND_BY_HITBOX;
+    public boolean pressurePlateFullBlock = DEFAULT_PRESSURE_PLATE_FULL_BLOCK;
     public float constraintFrontWidth = DEFAULT_CONSTRAINT_FRONT_WIDTH;
     public float constraintFrontHeight = DEFAULT_CONSTRAINT_FRONT_HEIGHT;
     public float constraintFrontLength = DEFAULT_CONSTRAINT_FRONT_LENGTH;
@@ -262,6 +264,7 @@ public final class Settings {
         System.arraycopy(DEFAULT_CONSTRAINT_BACK, 0, constraintBack, 0, 4);
         System.arraycopy(DEFAULT_CONSTRAINT_HIGHLIGHT, 0, constraintHighlight, 0, 4);
         constraintExpandByHitbox = DEFAULT_CONSTRAINT_EXPAND_BY_HITBOX;
+        pressurePlateFullBlock = DEFAULT_PRESSURE_PLATE_FULL_BLOCK;
         constraintFrontWidth = DEFAULT_CONSTRAINT_FRONT_WIDTH;
         constraintFrontHeight = DEFAULT_CONSTRAINT_FRONT_HEIGHT;
         constraintFrontLength = DEFAULT_CONSTRAINT_FRONT_LENGTH;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/SettingsModal.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/SettingsModal.java
@@ -38,6 +38,7 @@ public final class SettingsModal {
     private static final String TT_COL_HOTBAR = "Adds a per-tick hotbar slot column (1-9). During playback the held slot switches on ticks that set one; empty keeps the previous slot.";
     private static final String TT_CONSTRAINTS = "Draws Angle Solver position constraints (X/Z) as translucent plates at the tick they apply to. The front plate sits on the constraint; the back fades out toward the open/free direction. Only visible while the Angle Solver is open.";
     private static final String TT_C_EXPAND = "Grow each plate outward by the player hitbox half-width (0.3) so the plate covers your hitbox: your hitbox fits inside the plate exactly when the tick is valid.";
+    private static final String TT_PRESSURE_PLATE_FULL = "When adding a pressure plate constraint (Ctrl+B while looking at a pressure plate), use the full block footprint from .0 to 1.0 on X and Z instead of the version's inset interaction hitbox. Legacy versions inset the interaction box by 0.125, modern by 0.0625.";
     private static final String TT_C_DIM = "Size in blocks. Width is across the constraint, height is vertical, length is along the plate (front depth from the boundary / back reach behind it).";
     private static final String TT_GROUND_HIGHLIGHT = "Tints input rows whose simulated tick ended on the ground. Color is editable in Render Colors.";
     private static final String TT_COL_W = "W (forward) is always shown and can't be hidden.";
@@ -416,6 +417,7 @@ public final class SettingsModal {
         if (beginLayoutTable("##settings_constraint_shape")) {
             checkboxRow("Show constraints", "##show_constraints", settings.showConstraints, TT_CONSTRAINTS, v -> settings.showConstraints = v);
             checkboxRow("Expand by player hitbox", "##c_expand", settings.constraintExpandByHitbox, TT_C_EXPAND, v -> settings.constraintExpandByHitbox = v);
+            checkboxRow("Pressure plate full block", "##pressure_plate_full", settings.pressurePlateFullBlock, TT_PRESSURE_PLATE_FULL, v -> settings.pressurePlateFullBlock = v);
             ThemeManager.endStandardFormTable();
         }
 

--- a/core/src/test/java/de/legoshi/parkourcalc/core/FakeMinecraftAccess.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/FakeMinecraftAccess.java
@@ -21,6 +21,7 @@ public class FakeMinecraftAccess implements MinecraftAccess {
     public Vec3dCore lookedAtHitVec;
     public float playerYaw;
     public boolean ready = true;
+    public double[] pressurePlateFootprint;
 
     public void addBlock(int x, int y, int z, AABB... boxes) {
         List<AABB> own = new ArrayList<>(Arrays.asList(boxes));
@@ -35,6 +36,7 @@ public class FakeMinecraftAccess implements MinecraftAccess {
     @Override public int[] getLookedAtBlock() { return lookedAtBlock; }
     @Override public Face getLookedAtFace() { return lookedAtFace; }
     @Override public Vec3dCore getLookedAtHitVec() { return lookedAtHitVec; }
+    @Override public double[] getPressurePlateFootprint(int x, int y, int z) { return pressurePlateFootprint; }
 
     @Override
     public List<AABB> getCollisionBoxes(int minX, int minY, int minZ, int maxX, int maxY, int maxZ) {

--- a/core/src/test/java/de/legoshi/parkourcalc/ui/ConstraintKeyControllerTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/ui/ConstraintKeyControllerTest.java
@@ -10,6 +10,7 @@ import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.ConstraintKeyController;
 import de.legoshi.parkourcalc.core.ui.ConstraintSelection;
 import de.legoshi.parkourcalc.core.ui.SelectionManager;
+import de.legoshi.parkourcalc.core.ui.Settings;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -27,6 +28,7 @@ public class ConstraintKeyControllerTest {
 
     private FakeMinecraftAccess mc;
     private AngleSolverState state;
+    private Settings settings;
     private ConstraintKeyController controller;
 
     private static AABB box(double x0, double y0, double z0, double x1, double y1, double z1) {
@@ -38,8 +40,9 @@ public class ConstraintKeyControllerTest {
         mc = new FakeMinecraftAccess();
         state = new AngleSolverState();
         state.setLandingTick(TICK);
+        settings = new Settings();
         controller = new ConstraintKeyController(
-                mc, state, new SelectionManager(mc), new ConstraintSelection(), () -> { }, false, () -> TICK + 1);
+                mc, state, new SelectionManager(mc), new ConstraintSelection(), () -> { }, false, () -> TICK + 1, settings);
     }
 
     private List<Constraint> constraints() {
@@ -163,5 +166,51 @@ public class ConstraintKeyControllerTest {
         Constraint z = range(Constraint.Field.Z);
         assertEquals(8 - HALF, z.getLo(), EPS);
         assertEquals(9 + HALF, z.getHi(), EPS);
+    }
+
+    @Test
+    public void pressurePlateConstraintUsesTheInsetInteractionFootprint() {
+        mc.lookedAtBlock = new int[] {5, 64, 8};
+        mc.lookedAtFace = Face.POS_Y;
+        mc.pressurePlateFootprint = new double[] {5.125, 5.875, 8.125, 8.875};
+
+        controller.onKey(false, true);
+
+        assertEquals("one X range and one Z range", 2, constraints().size());
+        Constraint x = range(Constraint.Field.X);
+        assertEquals(5.125, x.getLo(), EPS);
+        assertEquals(5.875, x.getHi(), EPS);
+        Constraint z = range(Constraint.Field.Z);
+        assertEquals(8.125, z.getLo(), EPS);
+        assertEquals(8.875, z.getHi(), EPS);
+    }
+
+    @Test
+    public void pressurePlateFullBlockSettingOverridesToTheFullBlockFootprint() {
+        settings.pressurePlateFullBlock = true;
+        mc.lookedAtBlock = new int[] {5, 64, 8};
+        mc.lookedAtFace = Face.POS_Y;
+        mc.pressurePlateFootprint = new double[] {5.125, 5.875, 8.125, 8.875};
+
+        controller.onKey(false, true);
+
+        Constraint x = range(Constraint.Field.X);
+        assertEquals(5.0, x.getLo(), EPS);
+        assertEquals(6.0, x.getHi(), EPS);
+        Constraint z = range(Constraint.Field.Z);
+        assertEquals(8.0, z.getLo(), EPS);
+        assertEquals(9.0, z.getHi(), EPS);
+    }
+
+    @Test
+    public void nonPressurePlateBlockIgnoresThePressurePlatePath() {
+        mc.worldBoxes.add(box(5.0, 64.0, 8.0, 6.0, 65.0, 9.0));
+        mc.lookedAtBlock = new int[] {5, 64, 8};
+        mc.lookedAtFace = Face.POS_Y;
+        mc.pressurePlateFootprint = null;
+
+        controller.onKey(false, true);
+
+        assertNull("Ctrl on a plain top face clears rather than adds", state.tickConstraintsOrNull(TICK));
     }
 }

--- a/core/src/test/java/de/legoshi/parkourcalc/ui/ConstraintKeyControllerTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/ui/ConstraintKeyControllerTest.java
@@ -178,11 +178,11 @@ public class ConstraintKeyControllerTest {
 
         assertEquals("one X range and one Z range", 2, constraints().size());
         Constraint x = range(Constraint.Field.X);
-        assertEquals(5.125, x.getLo(), EPS);
-        assertEquals(5.875, x.getHi(), EPS);
+        assertEquals(5.125 - HALF, x.getLo(), EPS);
+        assertEquals(5.875 + HALF, x.getHi(), EPS);
         Constraint z = range(Constraint.Field.Z);
-        assertEquals(8.125, z.getLo(), EPS);
-        assertEquals(8.875, z.getHi(), EPS);
+        assertEquals(8.125 - HALF, z.getLo(), EPS);
+        assertEquals(8.875 + HALF, z.getHi(), EPS);
     }
 
     @Test
@@ -195,11 +195,11 @@ public class ConstraintKeyControllerTest {
         controller.onKey(false, true);
 
         Constraint x = range(Constraint.Field.X);
-        assertEquals(5.0, x.getLo(), EPS);
-        assertEquals(6.0, x.getHi(), EPS);
+        assertEquals(5.0 - HALF, x.getLo(), EPS);
+        assertEquals(6.0 + HALF, x.getHi(), EPS);
         Constraint z = range(Constraint.Field.Z);
-        assertEquals(8.0, z.getLo(), EPS);
-        assertEquals(9.0, z.getHi(), EPS);
+        assertEquals(8.0 - HALF, z.getLo(), EPS);
+        assertEquals(9.0 + HALF, z.getHi(), EPS);
     }
 
     @Test

--- a/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/FabricMinecraftAccess.java
+++ b/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/FabricMinecraftAccess.java
@@ -10,6 +10,7 @@ import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.ClipContext;
+import net.minecraft.world.level.block.BasePressurePlateBlock;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.server.MinecraftServer;
@@ -115,6 +116,15 @@ public final class FabricMinecraftAccess implements MinecraftAccess {
         BlockState state = world.getBlockState(new BlockPos(x, y, z));
         return state.is(Blocks.ICE) || state.is(Blocks.PACKED_ICE)
                 || state.is(Blocks.BLUE_ICE) || state.is(Blocks.FROSTED_ICE);
+    }
+
+    @Override
+    public double[] getPressurePlateFootprint(int x, int y, int z) {
+        ClientLevel world = Minecraft.getInstance().level;
+        if (world == null) return null;
+        if (!(world.getBlockState(new BlockPos(x, y, z)).getBlock() instanceof BasePressurePlateBlock)) return null;
+        double inset = 0.0625;
+        return new double[] {x + inset, x + 1.0 - inset, z + inset, z + 1.0 - inset};
     }
 
     @Override

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricMinecraftAccess.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricMinecraftAccess.java
@@ -10,6 +10,7 @@ import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.ClipContext;
+import net.minecraft.world.level.block.BasePressurePlateBlock;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.server.MinecraftServer;
@@ -115,6 +116,15 @@ public final class FabricMinecraftAccess implements MinecraftAccess {
         BlockState state = world.getBlockState(new BlockPos(x, y, z));
         return state.is(Blocks.ICE) || state.is(Blocks.PACKED_ICE)
                 || state.is(Blocks.BLUE_ICE) || state.is(Blocks.FROSTED_ICE);
+    }
+
+    @Override
+    public double[] getPressurePlateFootprint(int x, int y, int z) {
+        ClientLevel world = Minecraft.getInstance().level;
+        if (world == null) return null;
+        if (!(world.getBlockState(new BlockPos(x, y, z)).getBlock() instanceof BasePressurePlateBlock)) return null;
+        double inset = 0.0625;
+        return new double[] {x + inset, x + 1.0 - inset, z + inset, z + 1.0 - inset};
     }
 
     @Override

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12MinecraftAccess.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12MinecraftAccess.java
@@ -7,6 +7,7 @@ import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.forge.core.lwjgl2.Lwjgl2InputState;
 import de.legoshi.parkourcalc.forge12.sim.Forge12Simulator;
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockBasePressurePlate;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.entity.Entity;
@@ -111,6 +112,16 @@ public final class Forge12MinecraftAccess implements MinecraftAccess {
         if (world == null) return false;
         Block block = world.getBlockState(new BlockPos(x, y, z)).getBlock();
         return block == Blocks.ICE || block == Blocks.PACKED_ICE || block == Blocks.FROSTED_ICE;
+    }
+
+    @Override
+    public double[] getPressurePlateFootprint(int x, int y, int z) {
+        World world = Minecraft.getMinecraft().world;
+        if (world == null) return null;
+        Block block = world.getBlockState(new BlockPos(x, y, z)).getBlock();
+        if (!(block instanceof BlockBasePressurePlate)) return null;
+        double inset = 0.125;
+        return new double[] {x + inset, x + 1.0 - inset, z + inset, z + 1.0 - inset};
     }
 
     @Override

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8MinecraftAccess.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8MinecraftAccess.java
@@ -7,6 +7,7 @@ import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.forge.core.lwjgl2.Lwjgl2InputState;
 import de.legoshi.parkourcalc.forge8.sim.Forge8Simulator;
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockBasePressurePlate;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
@@ -113,6 +114,16 @@ public final class Forge8MinecraftAccess implements MinecraftAccess {
         if (world == null) return false;
         Block block = world.getBlockState(new BlockPos(x, y, z)).getBlock();
         return block == Blocks.ice || block == Blocks.packed_ice;
+    }
+
+    @Override
+    public double[] getPressurePlateFootprint(int x, int y, int z) {
+        World world = Minecraft.getMinecraft().theWorld;
+        if (world == null) return null;
+        Block block = world.getBlockState(new BlockPos(x, y, z)).getBlock();
+        if (!(block instanceof BlockBasePressurePlate)) return null;
+        double inset = 0.125;
+        return new double[] {x + inset, x + 1.0 - inset, z + inset, z + 1.0 - inset};
     }
 
     @Override


### PR DESCRIPTION
Ctrl+B while looking at a pressure plate now adds the plate's entity-sensitive interaction footprint as an X/Z landing-pad constraint at the selected tick, reusing the existing constraint path and pad visualization.

- Handled as a new block type on the existing Ctrl+B branch (alongside slime/ice/climbable cells), so existing bindings are unchanged.
- The version-specific inset is supplied per loader via a new `MinecraftAccess.getPressurePlateFootprint` port, read from each version's decompiled block class: 0.125 on 1.8.9 and 1.12.2 (`PRESSURE_AABB` / `getSensitiveAABB`), 0.0625 on 1.21.3 and 26.2 (`TOUCH_AABB = Block.column(14,0,4)`).
- New `Settings.pressurePlateFullBlock` preference overrides the inset box with the full `[0,1]x[0,1]` block footprint, matching the 1.8.9 slime-block cell.

Testing: `:core:build`, `:core:test` (plus 3 new `ConstraintKeyController` cases), and all four loaders compile.

QA needed: smoke-test against a real pressure plate on one legacy and one modern loader (each supplies its own inset).

Closes #437
