### PR TITLE
feat: add per-tick teleport destinations

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
@@ -219,6 +219,7 @@ public final class Application {
         AngleSolverWindow angleSolverWindow = new AngleSolverWindow(angleSolverState, settings, inputData::size, angleSolverEngine, velocityMapController.widget(), graphStore, graphEditorWindow);
         angleSolverWindow.setApplySurfaceState(this::applyPathSurfaceState);
         angleSolverWindow.setPlayerYawSupplier(mc::getPlayerYaw);
+        angleSolverWindow.setTeleportAtRow(t -> t >= 0 && t < inputData.size() && inputData.get(t).isTeleportEnabled());
         runTicks = new RunTicksController(angleSolverState, angleSolverEngine, inputData, constraintSelection,
                 hudMessages, this::runSimulation, saveController::markDirty, this::pushHudMessage);
         angleSolverWindow.setRunTicksControls(runTicks);

--- a/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
@@ -592,8 +592,22 @@ public final class Application {
             return;
         }
         if (!mc.isReady()) return;
+        if (solveRangeCrossesTeleport()) {
+            pushHudMessage("Can't solve: the solve range crosses a teleport", HudMessageStyle.COLOR_WARN);
+            return;
+        }
         if (runTicks != null) runTicks.start();
         else solverEngine.solve();
+    }
+
+    private boolean solveRangeCrossesTeleport() {
+        if (angleSolverState == null) return false;
+        int lo = Math.min(angleSolverState.getStartTick(), angleSolverState.getLandingTick());
+        int hi = Math.max(angleSolverState.getStartTick(), angleSolverState.getLandingTick());
+        for (int t = lo; t <= hi; t++) {
+            if (t >= 0 && t < inputData.size() && inputData.get(t).isTeleportEnabled()) return true;
+        }
+        return false;
     }
 
     public void setSolverStartTickFromSelection() {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/PlaybackController.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/PlaybackController.java
@@ -21,6 +21,9 @@ public final class PlaybackController {
     private static final long TICK_NANOS = 50_000_000L;
     private static final float MAX_FRAME_DT_SECONDS = 0.1f;
 
+    private static final long TELEPORT_NOTICE_HOLD_NANOS = 1_000_000_000L;
+    private static final long TELEPORT_NOTICE_FADE_NANOS = 500_000_000L;
+
     public static final float DEFAULT_PITCH = 40f;
 
     private final InputData inputData;
@@ -63,6 +66,8 @@ public final class PlaybackController {
     // Non-zero while the game sits paused: client ticks keep firing but the world does not advance,
     // so the schedule must freeze with it (gh-106). On resume the lerp clocks shift by the pause.
     private long pausedAtNanos;
+
+    private long teleportNoticeNanos;
 
     private final List<String> simTickDumps = new ArrayList<String>();
 
@@ -158,6 +163,7 @@ public final class PlaybackController {
 
         bridge.closeUI();
         pausedAtNanos = 0L;
+        teleportNoticeNanos = 0L;
 
         simTickDumps.clear();
         if (DebugFlags.DUMP_TICK_STATE) {
@@ -231,6 +237,18 @@ public final class PlaybackController {
         lastJumpBoostAmplifier = 0;
     }
 
+    public float teleportNoticeAlpha() {
+        if (teleportNoticeNanos == 0L) return 0f;
+        long age = System.nanoTime() - teleportNoticeNanos;
+        if (age < 0L) {
+            teleportNoticeNanos = 0L;
+            return 0f;
+        }
+        if (age <= TELEPORT_NOTICE_HOLD_NANOS) return 1f;
+        if (age >= TELEPORT_NOTICE_HOLD_NANOS + TELEPORT_NOTICE_FADE_NANOS) return 0f;
+        return 1f - (age - TELEPORT_NOTICE_HOLD_NANOS) / (float) TELEPORT_NOTICE_FADE_NANOS;
+    }
+
     public String statusHint() {
         if (!running) return "";
         boolean fromStart = startTick == 0;
@@ -287,6 +305,12 @@ public final class PlaybackController {
         }
 
         InputRow row = inputData.get(nextTick);
+        if (row.isTeleportEnabled()) {
+            bridge.teleport(
+                    new Vec3dCore(row.getTeleportX(), row.getTeleportY(), row.getTeleportZ()),
+                    Vec3dCore.GROUND_REST_VELOCITY, currentTickYaw, null);
+            teleportNoticeNanos = System.nanoTime();
+        }
         for (InputRow.Key key : InputRow.Key.values()) {
             bridge.setKey(key, row.isKeyActive(key));
         }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/PlaybackController.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/PlaybackController.java
@@ -306,9 +306,9 @@ public final class PlaybackController {
 
         InputRow row = inputData.get(nextTick);
         if (row.isTeleportEnabled()) {
-            bridge.teleport(
+            bridge.teleportInPlace(
                     new Vec3dCore(row.getTeleportX(), row.getTeleportY(), row.getTeleportZ()),
-                    Vec3dCore.GROUND_REST_VELOCITY, currentTickYaw, null);
+                    Vec3dCore.GROUND_REST_VELOCITY, currentTickYaw);
             teleportNoticeNanos = System.nanoTime();
         }
         for (InputRow.Key key : InputRow.Key.values()) {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/PlaybackController.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/PlaybackController.java
@@ -24,6 +24,8 @@ public final class PlaybackController {
     private static final long TELEPORT_NOTICE_HOLD_NANOS = 1_000_000_000L;
     private static final long TELEPORT_NOTICE_FADE_NANOS = 500_000_000L;
 
+    private static final InputRow TELEPORT_NOOP_ROW = new InputRow();
+
     public static final float DEFAULT_PITCH = 40f;
 
     private final InputData inputData;
@@ -305,14 +307,16 @@ public final class PlaybackController {
         }
 
         InputRow row = inputData.get(nextTick);
-        if (row.isTeleportEnabled()) {
+        boolean teleportTick = row.isTeleportEnabled();
+        if (teleportTick) {
             bridge.teleportInPlace(
                     new Vec3dCore(row.getTeleportX(), row.getTeleportY(), row.getTeleportZ()),
                     Vec3dCore.GROUND_REST_VELOCITY, currentTickYaw);
             teleportNoticeNanos = System.nanoTime();
         }
+        InputRow motion = teleportTick ? TELEPORT_NOOP_ROW : row;
         for (InputRow.Key key : InputRow.Key.values()) {
-            bridge.setKey(key, row.isKeyActive(key));
+            bridge.setKey(key, motion.isKeyActive(key));
         }
         int speedAmp = row.getSpeedAmplifier();
         int jumpAmp = row.getJumpBoostAmplifier();
@@ -325,10 +329,10 @@ public final class PlaybackController {
         if (hotbarSlot >= 1) {
             bridge.setHotbarSlot(hotbarSlot - 1);
         }
-        Float yaw = row.getYaw();
+        Float yaw = motion.getYaw();
         prevTickYaw = displayTargetYaw;
         if (yaw != null) {
-            if (row.isYawLocked()) {
+            if (motion.isYawLocked()) {
                 // Physics takes the raw target like setYawAbsolute; only the visible head
                 // turns the short way (e.g. -170 -> 135 turns -55, not +305).
                 currentTickYaw = yaw;
@@ -340,7 +344,7 @@ public final class PlaybackController {
         }
         bridge.setYaw(currentTickYaw);
         prevTickPitch = currentTickPitch;
-        currentTickPitch = applyPitch(currentTickPitch, row);
+        currentTickPitch = applyPitch(currentTickPitch, motion);
         bridge.setPitch(currentTickPitch);
         tickEndNanos = System.nanoTime();
         nextTick++;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ports/PlaybackBridge.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ports/PlaybackBridge.java
@@ -27,6 +27,10 @@ public interface PlaybackBridge {
 
     void teleport(Vec3dCore pos, Vec3dCore vel, float yaw, Checkpoint carry);
 
+    default void teleportInPlace(Vec3dCore pos, Vec3dCore vel, float yaw) {
+        teleport(pos, vel, yaw, null);
+    }
+
     void setKey(InputRow.Key key, boolean pressed);
 
     void setYaw(float absoluteYaw);

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ports/Simulator.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ports/Simulator.java
@@ -16,6 +16,9 @@ public interface Simulator {
 
     void applyInput(InputRow row);
 
+    default void teleport(Vec3dCore pos, Vec3dCore velocity) {
+    }
+
     void tick();
 
     Vec3dCore getCurrentPosition();

--- a/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveFile.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveFile.java
@@ -53,6 +53,10 @@ public final class SaveFile {
         public int speedAmplifier;
         public int jumpBoostAmplifier;
         public int hotbarSlot;
+        public boolean teleport;
+        public double teleportX;
+        public double teleportY;
+        public double teleportZ;
     }
 
     /** Angle Solver problem: defaults, per-tick constraints/overrides, and last solve result. */

--- a/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveIO.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/save/SaveIO.java
@@ -482,6 +482,10 @@ public final class SaveIO {
         r.speedAmplifier = row.getSpeedAmplifier();
         r.jumpBoostAmplifier = row.getJumpBoostAmplifier();
         r.hotbarSlot = row.getHotbarSlot();
+        r.teleport = row.isTeleportEnabled();
+        r.teleportX = row.getTeleportX();
+        r.teleportY = row.getTeleportY();
+        r.teleportZ = row.getTeleportZ();
         return r;
     }
 
@@ -497,7 +501,11 @@ public final class SaveIO {
                 && r.pitchLocked == row.isPitchLocked()
                 && r.speedAmplifier == row.getSpeedAmplifier()
                 && r.jumpBoostAmplifier == row.getJumpBoostAmplifier()
-                && r.hotbarSlot == row.getHotbarSlot();
+                && r.hotbarSlot == row.getHotbarSlot()
+                && r.teleport == row.isTeleportEnabled()
+                && r.teleportX == row.getTeleportX()
+                && r.teleportY == row.getTeleportY()
+                && r.teleportZ == row.getTeleportZ();
     }
 
     private static InputRow toInputRow(SaveFile.Row r) {
@@ -518,6 +526,8 @@ public final class SaveIO {
             row.setSpeedAmplifier(r.speedAmplifier);
             row.setJumpBoostAmplifier(r.jumpBoostAmplifier);
             row.setHotbarSlot(r.hotbarSlot);
+            row.setTeleportDestination(r.teleportX, r.teleportY, r.teleportZ);
+            row.setTeleportEnabled(r.teleport);
         }
         return row;
     }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/sim/LazyEntitySimulator.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/sim/LazyEntitySimulator.java
@@ -43,6 +43,11 @@ public abstract class LazyEntitySimulator<E> implements Simulator {
     }
 
     @Override
+    public final void teleport(Vec3dCore pos, Vec3dCore velocity) {
+        teleportEntity(ensureEntity(), pos, velocity);
+    }
+
+    @Override
     public final void tick() {
         E e = ensureEntity();
         tickEntity(e);
@@ -233,6 +238,8 @@ public abstract class LazyEntitySimulator<E> implements Simulator {
     protected abstract StartResumeState describeResume(Checkpoint checkpoint);
 
     protected abstract void setInput(E entity, InputRow row);
+
+    protected abstract void teleportEntity(E entity, Vec3dCore pos, Vec3dCore velocity);
 
     protected abstract void applyYaw(E entity, float yaw);
 

--- a/core/src/main/java/de/legoshi/parkourcalc/core/sim/SimulationRunner.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/sim/SimulationRunner.java
@@ -10,6 +10,8 @@ import java.util.List;
 
 public final class SimulationRunner {
 
+    private static final InputRow TELEPORT_NOOP_ROW = new InputRow();
+
     private final Simulator simulator;
 
     // path[i] and checkpoints[i] are the snapshot+state captured at the same moment:
@@ -76,8 +78,10 @@ public final class SimulationRunner {
                 simulator.teleport(
                         new Vec3dCore(row.getTeleportX(), row.getTeleportY(), row.getTeleportZ()),
                         Vec3dCore.GROUND_REST_VELOCITY);
+                simulator.applyInput(TELEPORT_NOOP_ROW);
+            } else {
+                simulator.applyInput(row);
             }
-            simulator.applyInput(row);
             simulator.tick();
             serverEvents.addAll(simulator.takeServerSimEvents());
             path.add(snapshot());

--- a/core/src/main/java/de/legoshi/parkourcalc/core/sim/SimulationRunner.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/sim/SimulationRunner.java
@@ -71,7 +71,13 @@ public final class SimulationRunner {
 
     private void replayFrom(int startRow, List<InputRow> rows) {
         for (int i = startRow; i < rows.size(); i++) {
-            simulator.applyInput(rows.get(i));
+            InputRow row = rows.get(i);
+            if (row.isTeleportEnabled()) {
+                simulator.teleport(
+                        new Vec3dCore(row.getTeleportX(), row.getTeleportY(), row.getTeleportZ()),
+                        Vec3dCore.GROUND_REST_VELOCITY);
+            }
+            simulator.applyInput(row);
             simulator.tick();
             serverEvents.addAll(simulator.takeServerSimEvents());
             path.add(snapshot());

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputOverlay.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputOverlay.java
@@ -597,11 +597,7 @@ public final class InputOverlay {
             ImGui.tableSetupColumn(COL_HOTBAR, ImGuiTableColumnFlags.WidthFixed, ThemeManager.tableColumnWidth(COL_HOTBAR, HOTBAR_COLUMN_WIDTH * scale));
         }
         if (isTeleportColumnVisible()) {
-            if (solverActive) {
-                ImGui.tableSetupColumn(COL_TELEPORT, ImGuiTableColumnFlags.WidthFixed, ThemeManager.tableColumnWidth(COL_TELEPORT, TELEPORT_COLUMN_WIDTH * scale));
-            } else {
-                ImGui.tableSetupColumn(COL_TELEPORT, ImGuiTableColumnFlags.WidthStretch, 1.0f);
-            }
+            ImGui.tableSetupColumn(COL_TELEPORT, ImGuiTableColumnFlags.WidthStretch, 1.0f);
         }
         if (isYawColumnVisible()) {
             ImGui.tableSetupColumn(COL_YAW, ImGuiTableColumnFlags.WidthFixed, ThemeManager.tableColumnWidth(COL_YAW, yawColumnWidth()));
@@ -1555,8 +1551,22 @@ public final class InputOverlay {
         if (draggingTeleportRow >= 0 && draggingTeleportRow < data.size()) {
             InputRow src = data.get(draggingTeleportRow);
             String label = "TP " + fmtChip(src.getTeleportX()) + ", " + fmtChip(src.getTeleportY()) + ", " + fmtChip(src.getTeleportZ());
+            String tail = teleportDropRow >= 0 && teleportDropRow != draggingTeleportRow ? "  -> T" + (teleportDropRow + 1) : "";
+            float s = uiScale();
+            float pad = 6f * s;
+            float h = ImGui.getFrameHeight();
+            float labelW = ImGui.calcTextSize(label).x;
+            float tailW = ImGui.calcTextSize(tail).x;
             ImVec2 m = ImGui.getMousePos();
-            ImGui.getForegroundDrawList().addText(m.x + 14f * uiScale(), m.y, ThemeManager.teleportColor(), label);
+            float x = m.x + 12f * s;
+            float y = m.y + 4f * s;
+            float w = pad + labelW + tailW + pad;
+            ImDrawList dl = ImGui.getForegroundDrawList();
+            dl.addRectFilled(x, y, x + w, y + h, ThemeManager.panelColor(), 3f * s);
+            dl.addRect(x, y, x + w, y + h, ThemeManager.teleportColor(), 3f * s, 0, 1f);
+            float ty = y + (h - ImGui.getFontSize()) * 0.5f;
+            dl.addText(x + pad, ty, ThemeManager.teleportColor(), label);
+            dl.addText(x + pad + labelW, ty, ThemeManager.okColor(), tail);
         }
         if (!ImGui.isMouseDown(0)) {
             if (draggingTeleportRow >= 0 && ImGui.isMouseReleased(0)) {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputOverlay.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputOverlay.java
@@ -80,12 +80,17 @@ public final class InputOverlay {
 
     private static final String MENU_SET_TO_PLAYER = "Set to user position";
     private static final String MENU_TELEPORT_TO_TICK = "Teleport player to tick %d";
-    private static final String MENU_TELEPORT_DEST_ENABLE = "Teleport at this tick";
-    private static final String MENU_TELEPORT_DEST_TO_PLAYER = "Set destination to user position";
+    private static final String COL_TELEPORT = "Teleport";
     private static final String TELEPORT_X_LABEL = "X";
     private static final String TELEPORT_Y_LABEL = "Y";
     private static final String TELEPORT_Z_LABEL = "Z";
-    private static final float TELEPORT_COORD_INPUT_WIDTH = 200;
+    private static final String ID_TELEPORT_ENABLE = "##tpEnable";
+    private static final String ID_TELEPORT_X = "##tpx";
+    private static final String ID_TELEPORT_Y = "##tpy";
+    private static final String ID_TELEPORT_Z = "##tpz";
+    private static final String TELEPORT_SET_BTN = "Set";
+    private static final float TELEPORT_FIELD_WIDTH = 64;
+    private static final float TELEPORT_COLUMN_WIDTH = 320;
     private static final String LABEL_ROWS = "Rows:";
     private static final String MENU_ADD_AT_END = "Add %d row(s) at end";
     private static final String MENU_ADD_ABOVE = "Add %d row(s) above";
@@ -328,6 +333,10 @@ public final class InputOverlay {
         return settings.showColHotbar;
     }
 
+    private boolean isTeleportColumnVisible() {
+        return settings.showColTeleport;
+    }
+
     private int potionColumnCount() {
         return (isSpeedColumnVisible() ? 1 : 0) + (isJumpBoostColumnVisible() ? 1 : 0);
     }
@@ -338,6 +347,7 @@ public final class InputOverlay {
         for (InputRow.Key key : MODIFIER_KEYS) if (isKeyColumnVisible(key)) count++;
         for (InputRow.Key key : MOUSE_KEYS) if (isKeyColumnVisible(key)) count++;
         if (isHotbarColumnVisible()) count++;
+        if (isTeleportColumnVisible()) count++;
         if (isYawColumnVisible()) count++;
         if (isPitchColumnVisible()) count++;
         return count;
@@ -372,6 +382,7 @@ public final class InputOverlay {
             if (isKeyColumnVisible(key)) columnSum += ThemeManager.tableColumnWidth(headerLabel(key), 0f);
         }
         if (isHotbarColumnVisible()) columnSum += ThemeManager.tableColumnWidth(COL_HOTBAR, HOTBAR_COLUMN_WIDTH * scale);
+        if (isTeleportColumnVisible()) columnSum += ThemeManager.tableColumnWidth(COL_TELEPORT, TELEPORT_COLUMN_WIDTH * scale);
         boolean speed = isSpeedColumnVisible();
         boolean jump = isJumpBoostColumnVisible();
         if (speed) {
@@ -581,6 +592,9 @@ public final class InputOverlay {
         if (isHotbarColumnVisible()) {
             ImGui.tableSetupColumn(COL_HOTBAR, ImGuiTableColumnFlags.WidthFixed, ThemeManager.tableColumnWidth(COL_HOTBAR, HOTBAR_COLUMN_WIDTH * scale));
         }
+        if (isTeleportColumnVisible()) {
+            ImGui.tableSetupColumn(COL_TELEPORT, ImGuiTableColumnFlags.WidthFixed, ThemeManager.tableColumnWidth(COL_TELEPORT, TELEPORT_COLUMN_WIDTH * scale));
+        }
         if (isYawColumnVisible()) {
             ImGui.tableSetupColumn(COL_YAW, ImGuiTableColumnFlags.WidthFixed, ThemeManager.tableColumnWidth(COL_YAW, yawColumnWidth()));
         }
@@ -621,6 +635,11 @@ public final class InputOverlay {
             ImGui.tableSetColumnIndex(col++);
             ThemeManager.tableHeaderCentered(COL_HOTBAR);
             TooltipUtil.onHover(headerColTooltip(COL_HOTBAR));
+        }
+        if (isTeleportColumnVisible()) {
+            ImGui.tableSetColumnIndex(col++);
+            ThemeManager.tableHeaderCentered(COL_TELEPORT);
+            TooltipUtil.onHover(headerColTooltip(COL_TELEPORT));
         }
         if (isYawColumnVisible()) {
             ImGui.tableSetColumnIndex(col++);
@@ -677,6 +696,7 @@ public final class InputOverlay {
             case COL_SPEED: return "Speed potion amplifier (none = no effect).";
             case COL_JUMP_BOOST: return "Jump Boost potion amplifier (none = no effect).";
             case COL_HOTBAR: return "Held hotbar slot (1-9) to switch to during playback. Empty = keep the previous slot.";
+            case COL_TELEPORT: return "Teleport the player to X/Y/Z at the start of this tick, before its inputs. Applies to both the simulation and the replay.";
             default: return col;
         }
     }
@@ -884,6 +904,7 @@ public final class InputOverlay {
 
         renderKeyColumns(row, index, rowH);
         if (isHotbarColumnVisible()) renderHotbarColumn(row, index);
+        if (isTeleportColumnVisible()) renderTeleportColumn(row, index);
         if (isYawColumnVisible()) renderYawColumn(row, index, centerY);
         if (isPitchColumnVisible()) renderPitchColumn(row, index, centerY);
         renderPotionColumns(row, index);
@@ -1378,7 +1399,6 @@ public final class InputOverlay {
         renderApplyPotionOptions();
         renderYawLockOption();
         renderPitchLockOption();
-        renderTeleportDestinationOption();
 
         // Segment 3: destructive action, kept at the very bottom.
         renderDeleteOption();
@@ -1397,48 +1417,53 @@ public final class InputOverlay {
         }
     }
 
-    private void renderTeleportDestinationOption() {
-        int row = selection.singleSelectedRow();
-        if (row < 0 || row >= data.size()) return;
-        InputRow r = data.get(row);
-
-        ThemeManager.paddedSeparator();
-        boolean enabled = r.isTeleportEnabled();
-        if (Controls.checkbox(MENU_TELEPORT_DEST_ENABLE, enabled)) {
-            r.setTeleportEnabled(!enabled);
-            if (!enabled) syncTeleportInputs(r);
-            notifyChange(row);
+    private void renderTeleportColumn(InputRow row, int rowIndex) {
+        ImGui.tableNextColumn();
+        boolean enabled = row.isTeleportEnabled();
+        if (Controls.checkbox(ID_TELEPORT_ENABLE, enabled)) {
+            row.setTeleportEnabled(!enabled);
+            notifyChange(rowIndex);
         }
-        if (!r.isTeleportEnabled()) return;
+        TooltipUtil.onHover(headerColTooltip(COL_TELEPORT));
+        if (!row.isTeleportEnabled()) return;
 
-        if (ImGui.isWindowAppearing()) syncTeleportInputs(r);
+        teleportXInput.set(formatCoord(row.getTeleportX()));
+        teleportYInput.set(formatCoord(row.getTeleportY()));
+        teleportZInput.set(formatCoord(row.getTeleportZ()));
 
-        float width = TELEPORT_COORD_INPUT_WIDTH * uiScale();
+        float width = TELEPORT_FIELD_WIDTH * uiScale();
         boolean changed = false;
-        changed |= Controls.decimalField(TELEPORT_X_LABEL, teleportXInput, width);
-        changed |= Controls.decimalField(TELEPORT_Y_LABEL, teleportYInput, width);
-        changed |= Controls.decimalField(TELEPORT_Z_LABEL, teleportZInput, width);
+        ImGui.sameLine();
+        changed |= teleportField(TELEPORT_X_LABEL, ID_TELEPORT_X, teleportXInput, width);
+        ImGui.sameLine();
+        changed |= teleportField(TELEPORT_Y_LABEL, ID_TELEPORT_Y, teleportYInput, width);
+        ImGui.sameLine();
+        changed |= teleportField(TELEPORT_Z_LABEL, ID_TELEPORT_Z, teleportZInput, width);
         if (changed) {
-            r.setTeleportDestination(
-                    parseCoord(teleportXInput, r.getTeleportX()),
-                    parseCoord(teleportYInput, r.getTeleportY()),
-                    parseCoord(teleportZInput, r.getTeleportZ()));
-            notifyChange(row);
+            row.setTeleportDestination(
+                    parseCoord(teleportXInput, row.getTeleportX()),
+                    parseCoord(teleportYInput, row.getTeleportY()),
+                    parseCoord(teleportZInput, row.getTeleportZ()));
+            notifyChange(rowIndex);
         }
 
-        if (mc != null && mc.isReady()
-                && Controls.secondaryButton(MENU_TELEPORT_DEST_TO_PLAYER, ImGui.getContentRegionAvail().x)) {
-            Vec3dCore p = mc.getPlayerPosition();
-            r.setTeleportDestination(p.x, p.y, p.z);
-            syncTeleportInputs(r);
-            notifyChange(row);
+        if (mc != null && mc.isReady()) {
+            ImGui.sameLine();
+            if (Controls.secondaryButton(TELEPORT_SET_BTN)) {
+                Vec3dCore p = mc.getPlayerPosition();
+                row.setTeleportDestination(p.x, p.y, p.z);
+                notifyChange(rowIndex);
+            }
+            TooltipUtil.onHover(MENU_SET_TO_PLAYER);
         }
     }
 
-    private void syncTeleportInputs(InputRow r) {
-        teleportXInput.set(formatCoord(r.getTeleportX()));
-        teleportYInput.set(formatCoord(r.getTeleportY()));
-        teleportZInput.set(formatCoord(r.getTeleportZ()));
+    private boolean teleportField(String label, String id, ImString buf, float width) {
+        ImGui.alignTextToFramePadding();
+        ImGui.text(label);
+        ImGui.sameLine(0f, 3f * uiScale());
+        ImGui.setNextItemWidth(width);
+        return ImGui.inputText(id, buf, ImGuiInputTextFlags.CharsDecimal);
     }
 
     private static String formatCoord(double value) {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputOverlay.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputOverlay.java
@@ -84,13 +84,11 @@ public final class InputOverlay {
     private static final String TELEPORT_X_LABEL = "X";
     private static final String TELEPORT_Y_LABEL = "Y";
     private static final String TELEPORT_Z_LABEL = "Z";
-    private static final String ID_TELEPORT_ENABLE = "##tpEnable";
-    private static final String ID_TELEPORT_X = "##tpx";
-    private static final String ID_TELEPORT_Y = "##tpy";
-    private static final String ID_TELEPORT_Z = "##tpz";
-    private static final String TELEPORT_SET_BTN = "Set";
-    private static final float TELEPORT_FIELD_WIDTH = 64;
-    private static final float TELEPORT_COLUMN_WIDTH = 320;
+    private static final String TELEPORT_ADD_LABEL = "+";
+    private static final String TELEPORT_ADD_TOOLTIP = "Add a teleport to this tick";
+    private static final String TELEPORT_REMOVE_BTN = "Remove";
+    private static final float TELEPORT_FIELD_WIDTH = 110;
+    private static final float TELEPORT_COLUMN_WIDTH = 190;
     private static final String LABEL_ROWS = "Rows:";
     private static final String MENU_ADD_AT_END = "Add %d row(s) at end";
     private static final String MENU_ADD_ABOVE = "Add %d row(s) above";
@@ -1419,26 +1417,73 @@ public final class InputOverlay {
 
     private void renderTeleportColumn(InputRow row, int rowIndex) {
         ImGui.tableNextColumn();
-        boolean enabled = row.isTeleportEnabled();
-        if (Controls.checkbox(ID_TELEPORT_ENABLE, enabled)) {
-            row.setTeleportEnabled(!enabled);
-            notifyChange(rowIndex);
+        String popupId = "tpedit" + rowIndex;
+        if (row.isTeleportEnabled()) {
+            renderTeleportChip(row, rowIndex, popupId);
+        } else {
+            renderTeleportAddChip(row, rowIndex, popupId);
         }
+        renderTeleportPopup(row, rowIndex, popupId);
+    }
+
+    private void renderTeleportChip(InputRow row, int rowIndex, String popupId) {
+        float s = uiScale();
+        float h = ImGui.getFrameHeight();
+        float pad = 6f * s;
+        ImDrawList dl = ImGui.getWindowDrawList();
+        String label = "TP " + fmtChip(row.getTeleportX()) + ", " + fmtChip(row.getTeleportY()) + ", " + fmtChip(row.getTeleportZ());
+        float w = pad + ImGui.calcTextSize(label).x + pad;
+
+        ImGui.invisibleButton("tpchip" + rowIndex, w, h);
+        ImVec2 mn = ImGui.getItemRectMin();
+        ImVec2 mx = ImGui.getItemRectMax();
+        boolean hover = ImGui.isItemHovered();
+        dl.addRectFilled(mn.x, mn.y, mx.x, mx.y, ThemeManager.panelColor(), 3f * s);
+        dl.addRectFilled(mn.x, mn.y, mx.x, mx.y, ThemeManager.teleportTintColor(hover ? 0.22f : 0.12f), 3f * s);
+        dl.addRect(mn.x, mn.y, mx.x, mx.y, hover ? ThemeManager.teleportColor() : ThemeManager.teleportTintColor(0.55f), 3f * s, 0, 1f);
+        float ty = mn.y + (h - ImGui.getFontSize()) * 0.5f;
+        dl.addText(mn.x + pad, ty, ThemeManager.teleportColor(), label);
         TooltipUtil.onHover(headerColTooltip(COL_TELEPORT));
-        if (!row.isTeleportEnabled()) return;
+        if (ImGui.isItemClicked(0)) {
+            syncTeleportInputs(row);
+            ImGui.openPopup(popupId);
+        }
+    }
 
-        teleportXInput.set(formatCoord(row.getTeleportX()));
-        teleportYInput.set(formatCoord(row.getTeleportY()));
-        teleportZInput.set(formatCoord(row.getTeleportZ()));
+    private void renderTeleportAddChip(InputRow row, int rowIndex, String popupId) {
+        float s = uiScale();
+        float h = ImGui.getFrameHeight();
+        float pad = 6f * s;
+        ImDrawList dl = ImGui.getWindowDrawList();
+        float textW = ImGui.calcTextSize(TELEPORT_ADD_LABEL).x;
+        float w = pad + textW + pad;
 
+        ImGui.invisibleButton("tpadd" + rowIndex, w, h);
+        ImVec2 mn = ImGui.getItemRectMin();
+        ImVec2 mx = ImGui.getItemRectMax();
+        boolean hover = ImGui.isItemHovered();
+        int tint = hover ? ThemeManager.teleportColor() : ThemeManager.textDimColor();
+        dl.addRect(mn.x, mn.y, mx.x, mx.y, tint, 3f * s, 0, 1f);
+        float ty = mn.y + (h - ImGui.getFontSize()) * 0.5f;
+        dl.addText(mn.x + (w - textW) * 0.5f, ty, tint, TELEPORT_ADD_LABEL);
+        TooltipUtil.onHover(TELEPORT_ADD_TOOLTIP);
+        if (ImGui.isItemClicked(0)) {
+            Vec3dCore seed = teleportSeedPosition(rowIndex);
+            row.setTeleportDestination(seed.x, seed.y, seed.z);
+            row.setTeleportEnabled(true);
+            syncTeleportInputs(row);
+            notifyChange(rowIndex);
+            ImGui.openPopup(popupId);
+        }
+    }
+
+    private void renderTeleportPopup(InputRow row, int rowIndex, String popupId) {
+        if (!ImGui.beginPopup(popupId)) return;
         float width = TELEPORT_FIELD_WIDTH * uiScale();
         boolean changed = false;
-        ImGui.sameLine();
-        changed |= teleportField(TELEPORT_X_LABEL, ID_TELEPORT_X, teleportXInput, width);
-        ImGui.sameLine();
-        changed |= teleportField(TELEPORT_Y_LABEL, ID_TELEPORT_Y, teleportYInput, width);
-        ImGui.sameLine();
-        changed |= teleportField(TELEPORT_Z_LABEL, ID_TELEPORT_Z, teleportZInput, width);
+        changed |= Controls.decimalField(TELEPORT_X_LABEL, teleportXInput, width);
+        changed |= Controls.decimalField(TELEPORT_Y_LABEL, teleportYInput, width);
+        changed |= Controls.decimalField(TELEPORT_Z_LABEL, teleportZInput, width);
         if (changed) {
             row.setTeleportDestination(
                     parseCoord(teleportXInput, row.getTeleportX()),
@@ -1446,24 +1491,38 @@ public final class InputOverlay {
                     parseCoord(teleportZInput, row.getTeleportZ()));
             notifyChange(rowIndex);
         }
-
-        if (mc != null && mc.isReady()) {
-            ImGui.sameLine();
-            if (Controls.secondaryButton(TELEPORT_SET_BTN)) {
-                Vec3dCore p = mc.getPlayerPosition();
-                row.setTeleportDestination(p.x, p.y, p.z);
-                notifyChange(rowIndex);
-            }
-            TooltipUtil.onHover(MENU_SET_TO_PLAYER);
+        ThemeManager.paddedSeparator();
+        if (mc != null && mc.isReady() && Controls.secondaryButton(MENU_SET_TO_PLAYER, ImGui.getContentRegionAvail().x)) {
+            Vec3dCore p = mc.getPlayerPosition();
+            row.setTeleportDestination(p.x, p.y, p.z);
+            syncTeleportInputs(row);
+            notifyChange(rowIndex);
         }
+        if (Controls.dangerButton(TELEPORT_REMOVE_BTN, ImGui.getContentRegionAvail().x)) {
+            row.setTeleportEnabled(false);
+            notifyChange(rowIndex);
+            ImGui.closeCurrentPopup();
+        }
+        ImGui.endPopup();
     }
 
-    private boolean teleportField(String label, String id, ImString buf, float width) {
-        ImGui.alignTextToFramePadding();
-        ImGui.text(label);
-        ImGui.sameLine(0f, 3f * uiScale());
-        ImGui.setNextItemWidth(width);
-        return ImGui.inputText(id, buf, ImGuiInputTextFlags.CharsDecimal);
+    private Vec3dCore teleportSeedPosition(int rowIndex) {
+        if (mc != null && mc.isReady()) return mc.getPlayerPosition();
+        if (boxController != null) {
+            TickState st = boxController.getState(rowIndex);
+            if (st != null && st.position != null) return st.position;
+        }
+        return Vec3dCore.ZERO;
+    }
+
+    private void syncTeleportInputs(InputRow row) {
+        teleportXInput.set(formatCoord(row.getTeleportX()));
+        teleportYInput.set(formatCoord(row.getTeleportY()));
+        teleportZInput.set(formatCoord(row.getTeleportZ()));
+    }
+
+    private static String fmtChip(double value) {
+        return String.format(Locale.ROOT, "%.2f", value);
     }
 
     private static String formatCoord(double value) {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputOverlay.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputOverlay.java
@@ -85,7 +85,6 @@ public final class InputOverlay {
     private static final String TELEPORT_Y_LABEL = "Y";
     private static final String TELEPORT_Z_LABEL = "Z";
     private static final String TELEPORT_ADD_LABEL = "+";
-    private static final String TELEPORT_ADD_TOOLTIP = "Add a teleport to this tick";
     private static final String TELEPORT_REMOVE_BTN = "Remove";
     private static final float TELEPORT_FIELD_WIDTH = 110;
     private static final float TELEPORT_COLUMN_WIDTH = 190;
@@ -108,6 +107,7 @@ public final class InputOverlay {
     private static final String YAW_FORMAT_DISPLAY = "% 12.6f";
 
     private static final String DRAG_DROP_TYPE = "INPUT_ROW";
+    private static final String TP_DRAG_TYPE = "TELEPORT_MOVE";
 
     private static final String PITCH_FORMAT_DISPLAY = "% 12.6f";
 
@@ -143,6 +143,11 @@ public final class InputOverlay {
     private Runnable onSaveSelectionAsTas;
 
     private int draggingRowIndex = -1;
+    private int draggingTeleportRow = -1;
+    private int pendingTeleportMoveFrom = -1;
+    private int pendingTeleportMoveTo = -1;
+    private float tpChipMinX;
+    private float tpChipMaxX;
     private int editingYawRow = -1;
     private int editingPitchRow = -1;
     private int pendingPitchFocusRow = -1;
@@ -529,6 +534,7 @@ public final class InputOverlay {
         }
         renderDropIndicator(ImGui.getWindowDrawList(), dragDrop);
         applyDragDrop(dragDrop);
+        applyPendingTeleportMove();
         if (solverActive) angleSolver.endRows();
         ImGui.endChild();
     }
@@ -916,6 +922,13 @@ public final class InputOverlay {
 
         if (solverActive) {
             angleSolver.drawStartLandingInset(index, rMinX, rMinY, rMaxX, rMaxY);
+        }
+
+        if (!solverActive && isTeleportColumnVisible() && row.isTeleportEnabled()) {
+            ImDrawList dl = ImGui.getWindowDrawList();
+            int scrim = ThemeManager.bgTintColor(0.5f);
+            if (tpChipMinX > rMinX) dl.addRectFilled(rMinX, rMinY, tpChipMinX, rMaxY, scrim);
+            if (tpChipMaxX < rMaxX) dl.addRectFilled(tpChipMaxX, rMinY, rMaxX, rMaxY, scrim);
         }
 
         ImGui.popID();
@@ -1437,16 +1450,40 @@ public final class InputOverlay {
         ImGui.invisibleButton("tpchip" + rowIndex, w, h);
         ImVec2 mn = ImGui.getItemRectMin();
         ImVec2 mx = ImGui.getItemRectMax();
+        tpChipMinX = mn.x;
+        tpChipMaxX = mx.x;
         boolean hover = ImGui.isItemHovered();
+        boolean dragging = teleportDragSource(rowIndex);
+        teleportDropTarget(rowIndex);
         dl.addRectFilled(mn.x, mn.y, mx.x, mx.y, ThemeManager.panelColor(), 3f * s);
         dl.addRectFilled(mn.x, mn.y, mx.x, mx.y, ThemeManager.teleportTintColor(hover ? 0.22f : 0.12f), 3f * s);
         dl.addRect(mn.x, mn.y, mx.x, mx.y, hover ? ThemeManager.teleportColor() : ThemeManager.teleportTintColor(0.55f), 3f * s, 0, 1f);
         float ty = mn.y + (h - ImGui.getFontSize()) * 0.5f;
         dl.addText(mn.x + pad, ty, ThemeManager.teleportColor(), label);
-        TooltipUtil.onHover(headerColTooltip(COL_TELEPORT));
-        if (ImGui.isItemClicked(0)) {
+        if (!dragging && ImGui.isItemClicked(0)) {
             syncTeleportInputs(row);
             ImGui.openPopup(popupId);
+        }
+    }
+
+    private boolean teleportDragSource(int rowIndex) {
+        if (ImGui.beginDragDropSource(ImGuiDragDropFlags.SourceNoPreviewTooltip)) {
+            draggingTeleportRow = rowIndex;
+            ImGui.setDragDropPayload(TP_DRAG_TYPE, Integer.valueOf(rowIndex));
+            ImGui.endDragDropSource();
+            return true;
+        }
+        return false;
+    }
+
+    private void teleportDropTarget(int rowIndex) {
+        if (ImGui.beginDragDropTarget()) {
+            if (ImGui.acceptDragDropPayload(TP_DRAG_TYPE) != null
+                    && draggingTeleportRow >= 0 && draggingTeleportRow != rowIndex) {
+                pendingTeleportMoveFrom = draggingTeleportRow;
+                pendingTeleportMoveTo = rowIndex;
+            }
+            ImGui.endDragDropTarget();
         }
     }
 
@@ -1462,11 +1499,11 @@ public final class InputOverlay {
         ImVec2 mn = ImGui.getItemRectMin();
         ImVec2 mx = ImGui.getItemRectMax();
         boolean hover = ImGui.isItemHovered();
+        teleportDropTarget(rowIndex);
         int tint = hover ? ThemeManager.teleportColor() : ThemeManager.textDimColor();
         dl.addRect(mn.x, mn.y, mx.x, mx.y, tint, 3f * s, 0, 1f);
         float ty = mn.y + (h - ImGui.getFontSize()) * 0.5f;
         dl.addText(mn.x + (w - textW) * 0.5f, ty, tint, TELEPORT_ADD_LABEL);
-        TooltipUtil.onHover(TELEPORT_ADD_TOOLTIP);
         if (ImGui.isItemClicked(0)) {
             Vec3dCore seed = teleportSeedPosition(rowIndex);
             row.setTeleportDestination(seed.x, seed.y, seed.z);
@@ -1513,6 +1550,22 @@ public final class InputOverlay {
             if (st != null && st.position != null) return st.position;
         }
         return Vec3dCore.ZERO;
+    }
+
+    private void applyPendingTeleportMove() {
+        if (pendingTeleportMoveFrom < 0) return;
+        int from = pendingTeleportMoveFrom;
+        int to = pendingTeleportMoveTo;
+        pendingTeleportMoveFrom = -1;
+        pendingTeleportMoveTo = -1;
+        if (from == to || from < 0 || from >= data.size() || to < 0 || to >= data.size()) return;
+        InputRow src = data.get(from);
+        if (!src.isTeleportEnabled()) return;
+        InputRow dst = data.get(to);
+        dst.setTeleportDestination(src.getTeleportX(), src.getTeleportY(), src.getTeleportZ());
+        dst.setTeleportEnabled(true);
+        src.setTeleportEnabled(false);
+        notifyChange(Math.min(from, to));
     }
 
     private void syncTeleportInputs(InputRow row) {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputOverlay.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputOverlay.java
@@ -5,6 +5,7 @@ import de.legoshi.parkourcalc.core.anglesolver.TickConstraints;
 import de.legoshi.parkourcalc.core.perf.Perf;
 import de.legoshi.parkourcalc.core.ports.MinecraftAccess;
 import de.legoshi.parkourcalc.core.sim.TickState;
+import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.anglesolver.AngleSolverTable;
 import de.legoshi.parkourcalc.core.ui.anglesolver.SolverWidgets;
 import de.legoshi.parkourcalc.core.ui.theme.Controls;
@@ -79,6 +80,12 @@ public final class InputOverlay {
 
     private static final String MENU_SET_TO_PLAYER = "Set to user position";
     private static final String MENU_TELEPORT_TO_TICK = "Teleport player to tick %d";
+    private static final String MENU_TELEPORT_DEST_ENABLE = "Teleport at this tick";
+    private static final String MENU_TELEPORT_DEST_TO_PLAYER = "Set destination to user position";
+    private static final String TELEPORT_X_LABEL = "X";
+    private static final String TELEPORT_Y_LABEL = "Y";
+    private static final String TELEPORT_Z_LABEL = "Z";
+    private static final float TELEPORT_COORD_INPUT_WIDTH = 200;
     private static final String LABEL_ROWS = "Rows:";
     private static final String MENU_ADD_AT_END = "Add %d row(s) at end";
     private static final String MENU_ADD_ABOVE = "Add %d row(s) above";
@@ -121,6 +128,9 @@ public final class InputOverlay {
     private final KeyDragSelect keyDragSelect = new KeyDragSelect();
     private final ImString yawInput = new ImString(32);
     private final ImString pitchInput = new ImString(32);
+    private final ImString teleportXInput = new ImString(32);
+    private final ImString teleportYInput = new ImString(32);
+    private final ImString teleportZInput = new ImString(32);
     private final ImInt rowsToAdd = new ImInt(1);
     private final ImInt ampBuf = new ImInt();
     private final ImInt hotbarBuf = new ImInt();
@@ -1368,6 +1378,7 @@ public final class InputOverlay {
         renderApplyPotionOptions();
         renderYawLockOption();
         renderPitchLockOption();
+        renderTeleportDestinationOption();
 
         // Segment 3: destructive action, kept at the very bottom.
         renderDeleteOption();
@@ -1383,6 +1394,62 @@ public final class InputOverlay {
         if (state == null) return;
         if (contextButton(String.format(MENU_TELEPORT_TO_TICK, row + 1))) {
             playback.teleportToTick(state.position, state.yaw, boxController.getPitch(row));
+        }
+    }
+
+    private void renderTeleportDestinationOption() {
+        int row = selection.singleSelectedRow();
+        if (row < 0 || row >= data.size()) return;
+        InputRow r = data.get(row);
+
+        ThemeManager.paddedSeparator();
+        boolean enabled = r.isTeleportEnabled();
+        if (Controls.checkbox(MENU_TELEPORT_DEST_ENABLE, enabled)) {
+            r.setTeleportEnabled(!enabled);
+            if (!enabled) syncTeleportInputs(r);
+            notifyChange(row);
+        }
+        if (!r.isTeleportEnabled()) return;
+
+        if (ImGui.isWindowAppearing()) syncTeleportInputs(r);
+
+        float width = TELEPORT_COORD_INPUT_WIDTH * uiScale();
+        boolean changed = false;
+        changed |= Controls.decimalField(TELEPORT_X_LABEL, teleportXInput, width);
+        changed |= Controls.decimalField(TELEPORT_Y_LABEL, teleportYInput, width);
+        changed |= Controls.decimalField(TELEPORT_Z_LABEL, teleportZInput, width);
+        if (changed) {
+            r.setTeleportDestination(
+                    parseCoord(teleportXInput, r.getTeleportX()),
+                    parseCoord(teleportYInput, r.getTeleportY()),
+                    parseCoord(teleportZInput, r.getTeleportZ()));
+            notifyChange(row);
+        }
+
+        if (mc != null && mc.isReady()
+                && Controls.secondaryButton(MENU_TELEPORT_DEST_TO_PLAYER, ImGui.getContentRegionAvail().x)) {
+            Vec3dCore p = mc.getPlayerPosition();
+            r.setTeleportDestination(p.x, p.y, p.z);
+            syncTeleportInputs(r);
+            notifyChange(row);
+        }
+    }
+
+    private void syncTeleportInputs(InputRow r) {
+        teleportXInput.set(formatCoord(r.getTeleportX()));
+        teleportYInput.set(formatCoord(r.getTeleportY()));
+        teleportZInput.set(formatCoord(r.getTeleportZ()));
+    }
+
+    private static String formatCoord(double value) {
+        return String.format(Locale.ROOT, "%.5f", value);
+    }
+
+    private static double parseCoord(ImString buf, double fallback) {
+        try {
+            return Double.parseDouble(buf.get().trim());
+        } catch (NumberFormatException e) {
+            return fallback;
         }
     }
 

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputOverlay.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputOverlay.java
@@ -107,7 +107,6 @@ public final class InputOverlay {
     private static final String YAW_FORMAT_DISPLAY = "% 12.6f";
 
     private static final String DRAG_DROP_TYPE = "INPUT_ROW";
-    private static final String TP_DRAG_TYPE = "TELEPORT_MOVE";
 
     private static final String PITCH_FORMAT_DISPLAY = "% 12.6f";
 
@@ -144,9 +143,8 @@ public final class InputOverlay {
 
     private int draggingRowIndex = -1;
     private int draggingTeleportRow = -1;
-    private int pendingTeleportMoveFrom = -1;
-    private int pendingTeleportMoveTo = -1;
-    private boolean tpChipDragged;
+    private int teleportDropRow = -1;
+    private int teleportPressRow = -1;
     private float tpCellMinX;
     private float tpCellMaxX;
     private int editingYawRow = -1;
@@ -483,6 +481,7 @@ public final class InputOverlay {
 
         keyDragSelect.clearRowBounds();
         hoveredRow = -1;
+        teleportDropRow = -1;
         if (solverActive) angleSolver.beginRows();
 
         handleAutoScroll();
@@ -535,7 +534,7 @@ public final class InputOverlay {
         }
         renderDropIndicator(ImGui.getWindowDrawList(), dragDrop);
         applyDragDrop(dragDrop);
-        applyPendingTeleportMove();
+        applyTeleportDrag();
         if (solverActive) angleSolver.endRows();
         ImGui.endChild();
     }
@@ -936,6 +935,15 @@ public final class InputOverlay {
             float gapHi = Math.max(rMinX, Math.min(tpCellMaxX, rMaxX));
             if (gapLo > rMinX) dl.addRectFilled(rMinX, rMinY, gapLo, rMaxY, scrim);
             if (gapHi < rMaxX) dl.addRectFilled(gapHi, rMinY, rMaxX, rMaxY, scrim);
+        }
+
+        if (draggingTeleportRow >= 0 && draggingTeleportRow != index && isTeleportColumnVisible()) {
+            ImVec2 m = ImGui.getMousePos();
+            if (m.y >= rMinY && m.y < rMaxY && m.x >= rMinX && m.x <= rMaxX) {
+                teleportDropRow = index;
+                ImGui.getWindowDrawList().addRect(tpCellMinX, rMinY, tpCellMaxX, rMaxY,
+                        ThemeManager.teleportColor(), 3f * uiScale(), 0, 2f);
+            }
         }
 
         ImGui.popID();
@@ -1460,41 +1468,22 @@ public final class InputOverlay {
         ImVec2 mn = ImGui.getItemRectMin();
         ImVec2 mx = ImGui.getItemRectMax();
         boolean hover = ImGui.isItemHovered();
-        if (teleportDragSource(rowIndex)) tpChipDragged = true;
-        teleportDropTarget(rowIndex);
+        if (hover && ImGui.isMouseClicked(0)) {
+            teleportPressRow = rowIndex;
+        }
+        if (teleportPressRow == rowIndex && draggingTeleportRow < 0 && ImGui.isMouseDragging(0)) {
+            draggingTeleportRow = rowIndex;
+        }
+        boolean dragSource = draggingTeleportRow == rowIndex;
         dl.addRectFilled(mn.x, mn.y, mx.x, mx.y, ThemeManager.panelColor(), 3f * s);
-        dl.addRectFilled(mn.x, mn.y, mx.x, mx.y, ThemeManager.teleportTintColor(hover ? 0.22f : 0.12f), 3f * s);
-        dl.addRect(mn.x, mn.y, mx.x, mx.y, hover ? ThemeManager.teleportColor() : ThemeManager.teleportTintColor(0.55f), 3f * s, 0, 1f);
+        dl.addRectFilled(mn.x, mn.y, mx.x, mx.y, ThemeManager.teleportTintColor(hover || dragSource ? 0.22f : 0.12f), 3f * s);
+        dl.addRect(mn.x, mn.y, mx.x, mx.y, hover || dragSource ? ThemeManager.teleportColor() : ThemeManager.teleportTintColor(0.55f), 3f * s, 0, 1f);
         float ty = mn.y + (h - ImGui.getFontSize()) * 0.5f;
         dl.addText(mn.x + pad, ty, ThemeManager.teleportColor(), label);
-        if (ImGui.isItemDeactivated()) {
-            if (tpChipDragged) {
-                tpChipDragged = false;
-            } else {
-                syncTeleportInputs(row);
-                ImGui.openPopup(popupId);
-            }
-        }
-    }
-
-    private boolean teleportDragSource(int rowIndex) {
-        if (ImGui.beginDragDropSource(ImGuiDragDropFlags.SourceNoPreviewTooltip)) {
-            draggingTeleportRow = rowIndex;
-            ImGui.setDragDropPayload(TP_DRAG_TYPE, Integer.valueOf(rowIndex));
-            ImGui.endDragDropSource();
-            return true;
-        }
-        return false;
-    }
-
-    private void teleportDropTarget(int rowIndex) {
-        if (ImGui.beginDragDropTarget()) {
-            if (ImGui.acceptDragDropPayload(TP_DRAG_TYPE) != null
-                    && draggingTeleportRow >= 0 && draggingTeleportRow != rowIndex) {
-                pendingTeleportMoveFrom = draggingTeleportRow;
-                pendingTeleportMoveTo = rowIndex;
-            }
-            ImGui.endDragDropTarget();
+        if (teleportPressRow == rowIndex && draggingTeleportRow < 0 && hover && ImGui.isMouseReleased(0)) {
+            teleportPressRow = -1;
+            syncTeleportInputs(row);
+            ImGui.openPopup(popupId);
         }
     }
 
@@ -1510,7 +1499,6 @@ public final class InputOverlay {
         ImVec2 mn = ImGui.getItemRectMin();
         ImVec2 mx = ImGui.getItemRectMax();
         boolean hover = ImGui.isItemHovered();
-        teleportDropTarget(rowIndex);
         int tint = hover ? ThemeManager.teleportColor() : ThemeManager.textDimColor();
         dl.addRect(mn.x, mn.y, mx.x, mx.y, tint, 3f * s, 0, 1f);
         float ty = mn.y + (h - ImGui.getFontSize()) * 0.5f;
@@ -1563,12 +1551,24 @@ public final class InputOverlay {
         return Vec3dCore.ZERO;
     }
 
-    private void applyPendingTeleportMove() {
-        if (pendingTeleportMoveFrom < 0) return;
-        int from = pendingTeleportMoveFrom;
-        int to = pendingTeleportMoveTo;
-        pendingTeleportMoveFrom = -1;
-        pendingTeleportMoveTo = -1;
+    private void applyTeleportDrag() {
+        if (draggingTeleportRow >= 0 && draggingTeleportRow < data.size()) {
+            InputRow src = data.get(draggingTeleportRow);
+            String label = "TP " + fmtChip(src.getTeleportX()) + ", " + fmtChip(src.getTeleportY()) + ", " + fmtChip(src.getTeleportZ());
+            ImVec2 m = ImGui.getMousePos();
+            ImGui.getForegroundDrawList().addText(m.x + 14f * uiScale(), m.y, ThemeManager.teleportColor(), label);
+        }
+        if (!ImGui.isMouseDown(0)) {
+            if (draggingTeleportRow >= 0 && ImGui.isMouseReleased(0)) {
+                moveTeleport(draggingTeleportRow, teleportDropRow);
+            }
+            draggingTeleportRow = -1;
+            teleportDropRow = -1;
+            teleportPressRow = -1;
+        }
+    }
+
+    private void moveTeleport(int from, int to) {
         if (from == to || from < 0 || from >= data.size() || to < 0 || to >= data.size()) return;
         InputRow src = data.get(from);
         if (!src.isTeleportEnabled()) return;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputOverlay.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputOverlay.java
@@ -596,9 +596,6 @@ public final class InputOverlay {
         if (isHotbarColumnVisible()) {
             ImGui.tableSetupColumn(COL_HOTBAR, ImGuiTableColumnFlags.WidthFixed, ThemeManager.tableColumnWidth(COL_HOTBAR, HOTBAR_COLUMN_WIDTH * scale));
         }
-        if (isTeleportColumnVisible()) {
-            ImGui.tableSetupColumn(COL_TELEPORT, ImGuiTableColumnFlags.WidthStretch, 1.0f);
-        }
         if (isYawColumnVisible()) {
             ImGui.tableSetupColumn(COL_YAW, ImGuiTableColumnFlags.WidthFixed, ThemeManager.tableColumnWidth(COL_YAW, yawColumnWidth()));
         }
@@ -620,6 +617,9 @@ public final class InputOverlay {
             ImGui.tableSetupColumn(angleSolver.constraintsColumnHeaderLabel(), ImGuiTableColumnFlags.WidthStretch, 1.0f);
             ImGui.tableSetupColumn(angleSolver.stateColumnHeaderLabel(), ImGuiTableColumnFlags.WidthStretch, 0.8f);
         }
+        if (isTeleportColumnVisible()) {
+            ImGui.tableSetupColumn(COL_TELEPORT, ImGuiTableColumnFlags.WidthStretch, 1.0f);
+        }
         if (scrollFreeze) ImGui.tableSetupScrollFreeze(1, 1);
         if (renderHeaders) renderColumnHeadersWithTooltips(solverActive);
     }
@@ -639,11 +639,6 @@ public final class InputOverlay {
             ImGui.tableSetColumnIndex(col++);
             ThemeManager.tableHeaderCentered(COL_HOTBAR);
             TooltipUtil.onHover(headerColTooltip(COL_HOTBAR));
-        }
-        if (isTeleportColumnVisible()) {
-            ImGui.tableSetColumnIndex(col++);
-            ThemeManager.tableHeaderCentered(COL_TELEPORT);
-            TooltipUtil.onHover(headerColTooltip(COL_TELEPORT));
         }
         if (isYawColumnVisible()) {
             ImGui.tableSetColumnIndex(col++);
@@ -670,6 +665,11 @@ public final class InputOverlay {
             ThemeManager.tableHeaderCentered(angleSolver.constraintsColumnHeaderLabel());
             ImGui.tableSetColumnIndex(col++);
             ThemeManager.tableHeaderCentered(angleSolver.stateColumnHeaderLabel());
+        }
+        if (isTeleportColumnVisible()) {
+            ImGui.tableSetColumnIndex(col++);
+            ThemeManager.tableHeaderCentered(COL_TELEPORT);
+            TooltipUtil.onHover(headerColTooltip(COL_TELEPORT));
         }
         ThemeManager.tableRightmostCellTrailingPad();
     }
@@ -908,7 +908,6 @@ public final class InputOverlay {
 
         renderKeyColumns(row, index, rowH);
         if (isHotbarColumnVisible()) renderHotbarColumn(row, index);
-        if (isTeleportColumnVisible()) renderTeleportColumn(row, index);
         if (isYawColumnVisible()) renderYawColumn(row, index, centerY);
         if (isPitchColumnVisible()) renderPitchColumn(row, index, centerY);
         renderPotionColumns(row, index);
@@ -918,24 +917,20 @@ public final class InputOverlay {
             ImGui.tableNextColumn();
             angleSolver.renderStateCell(index, rowH);
         }
+        if (isTeleportColumnVisible()) renderTeleportColumn(row, index);
         ThemeManager.tableRightmostCellTrailingPad();
 
         if (solverActive) {
             angleSolver.drawStartLandingInset(index, rMinX, rMinY, rMaxX, rMaxY);
         }
 
-        if (!solverActive && isTeleportColumnVisible() && row.isTeleportEnabled()) {
-            ImDrawList dl = ImGui.getWindowDrawList();
-            int scrim = ThemeManager.bgTintColor(0.5f);
-            float gapLo = Math.max(rMinX, Math.min(tpCellMinX, rMaxX));
-            float gapHi = Math.max(rMinX, Math.min(tpCellMaxX, rMaxX));
-            if (gapLo > rMinX) dl.addRectFilled(rMinX, rMinY, gapLo, rMaxY, scrim);
-            if (gapHi < rMaxX) dl.addRectFilled(gapHi, rMinY, rMaxX, rMaxY, scrim);
+        if (isTeleportColumnVisible() && row.isTeleportEnabled() && tpCellMinX > rMinX) {
+            ImGui.getWindowDrawList().addRectFilled(rMinX, rMinY, tpCellMinX, rMaxY, ThemeManager.bgTintColor(0.5f));
         }
 
         if (draggingTeleportRow >= 0 && draggingTeleportRow != index && isTeleportColumnVisible()) {
-            ImVec2 m = ImGui.getMousePos();
-            if (m.y >= rMinY && m.y < rMaxY && m.x >= rMinX && m.x <= rMaxX) {
+            float my = ImGui.getMousePos().y;
+            if (my >= rMinY && my < rMaxY) {
                 teleportDropRow = index;
                 ImGui.getWindowDrawList().addRect(tpCellMinX, rMinY, tpCellMaxX, rMaxY,
                         ThemeManager.teleportColor(), 3f * uiScale(), 0, 2f);

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputOverlay.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputOverlay.java
@@ -925,7 +925,10 @@ public final class InputOverlay {
         }
 
         if (isTeleportColumnVisible() && row.isTeleportEnabled() && tpCellMinX > rMinX) {
-            ImGui.getWindowDrawList().addRectFilled(rMinX, rMinY, tpCellMinX, rMaxY, ThemeManager.bgTintColor(0.5f));
+            ImDrawList dl = ImGui.getWindowDrawList();
+            dl.pushClipRect(rMinX, rMinY, tpCellMinX, rMaxY, false);
+            dl.addRectFilled(rMinX, rMinY, tpCellMinX, rMaxY, ThemeManager.bgTintColor(0.66f));
+            dl.popClipRect();
         }
 
         if (draggingTeleportRow >= 0 && draggingTeleportRow != index && isTeleportColumnVisible()) {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputOverlay.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputOverlay.java
@@ -146,8 +146,9 @@ public final class InputOverlay {
     private int draggingTeleportRow = -1;
     private int pendingTeleportMoveFrom = -1;
     private int pendingTeleportMoveTo = -1;
-    private float tpChipMinX;
-    private float tpChipMaxX;
+    private boolean tpChipDragged;
+    private float tpCellMinX;
+    private float tpCellMaxX;
     private int editingYawRow = -1;
     private int editingPitchRow = -1;
     private int pendingPitchFocusRow = -1;
@@ -597,7 +598,11 @@ public final class InputOverlay {
             ImGui.tableSetupColumn(COL_HOTBAR, ImGuiTableColumnFlags.WidthFixed, ThemeManager.tableColumnWidth(COL_HOTBAR, HOTBAR_COLUMN_WIDTH * scale));
         }
         if (isTeleportColumnVisible()) {
-            ImGui.tableSetupColumn(COL_TELEPORT, ImGuiTableColumnFlags.WidthFixed, ThemeManager.tableColumnWidth(COL_TELEPORT, TELEPORT_COLUMN_WIDTH * scale));
+            if (solverActive) {
+                ImGui.tableSetupColumn(COL_TELEPORT, ImGuiTableColumnFlags.WidthFixed, ThemeManager.tableColumnWidth(COL_TELEPORT, TELEPORT_COLUMN_WIDTH * scale));
+            } else {
+                ImGui.tableSetupColumn(COL_TELEPORT, ImGuiTableColumnFlags.WidthStretch, 1.0f);
+            }
         }
         if (isYawColumnVisible()) {
             ImGui.tableSetupColumn(COL_YAW, ImGuiTableColumnFlags.WidthFixed, ThemeManager.tableColumnWidth(COL_YAW, yawColumnWidth()));
@@ -927,8 +932,10 @@ public final class InputOverlay {
         if (!solverActive && isTeleportColumnVisible() && row.isTeleportEnabled()) {
             ImDrawList dl = ImGui.getWindowDrawList();
             int scrim = ThemeManager.bgTintColor(0.5f);
-            if (tpChipMinX > rMinX) dl.addRectFilled(rMinX, rMinY, tpChipMinX, rMaxY, scrim);
-            if (tpChipMaxX < rMaxX) dl.addRectFilled(tpChipMaxX, rMinY, rMaxX, rMaxY, scrim);
+            float gapLo = Math.max(rMinX, Math.min(tpCellMinX, rMaxX));
+            float gapHi = Math.max(rMinX, Math.min(tpCellMaxX, rMaxX));
+            if (gapLo > rMinX) dl.addRectFilled(rMinX, rMinY, gapLo, rMaxY, scrim);
+            if (gapHi < rMaxX) dl.addRectFilled(gapHi, rMinY, rMaxX, rMaxY, scrim);
         }
 
         ImGui.popID();
@@ -1430,6 +1437,8 @@ public final class InputOverlay {
 
     private void renderTeleportColumn(InputRow row, int rowIndex) {
         ImGui.tableNextColumn();
+        tpCellMinX = ImGui.getCursorScreenPos().x;
+        tpCellMaxX = tpCellMinX + ImGui.getContentRegionAvail().x;
         String popupId = "tpedit" + rowIndex;
         if (row.isTeleportEnabled()) {
             renderTeleportChip(row, rowIndex, popupId);
@@ -1450,19 +1459,21 @@ public final class InputOverlay {
         ImGui.invisibleButton("tpchip" + rowIndex, w, h);
         ImVec2 mn = ImGui.getItemRectMin();
         ImVec2 mx = ImGui.getItemRectMax();
-        tpChipMinX = mn.x;
-        tpChipMaxX = mx.x;
         boolean hover = ImGui.isItemHovered();
-        boolean dragging = teleportDragSource(rowIndex);
+        if (teleportDragSource(rowIndex)) tpChipDragged = true;
         teleportDropTarget(rowIndex);
         dl.addRectFilled(mn.x, mn.y, mx.x, mx.y, ThemeManager.panelColor(), 3f * s);
         dl.addRectFilled(mn.x, mn.y, mx.x, mx.y, ThemeManager.teleportTintColor(hover ? 0.22f : 0.12f), 3f * s);
         dl.addRect(mn.x, mn.y, mx.x, mx.y, hover ? ThemeManager.teleportColor() : ThemeManager.teleportTintColor(0.55f), 3f * s, 0, 1f);
         float ty = mn.y + (h - ImGui.getFontSize()) * 0.5f;
         dl.addText(mn.x + pad, ty, ThemeManager.teleportColor(), label);
-        if (!dragging && ImGui.isItemClicked(0)) {
-            syncTeleportInputs(row);
-            ImGui.openPopup(popupId);
+        if (ImGui.isItemDeactivated()) {
+            if (tpChipDragged) {
+                tpChipDragged = false;
+            } else {
+                syncTeleportInputs(row);
+                ImGui.openPopup(popupId);
+            }
         }
     }
 

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputRow.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputRow.java
@@ -21,6 +21,10 @@ public class InputRow {
     private int speedAmplifier;
     private int jumpBoostAmplifier;
     private int hotbarSlot;
+    private boolean teleportEnabled;
+    private double teleportX;
+    private double teleportY;
+    private double teleportZ;
     private int modCount;
 
     // LEFT_CLICK / RIGHT_CLICK appended last to keep existing ordinals stable for old saves.
@@ -122,6 +126,34 @@ public class InputRow {
         this.hotbarSlot = clamped;
     }
 
+    public boolean isTeleportEnabled() {
+        return teleportEnabled;
+    }
+
+    public void setTeleportEnabled(boolean enabled) {
+        if (this.teleportEnabled != enabled) modCount++;
+        this.teleportEnabled = enabled;
+    }
+
+    public double getTeleportX() {
+        return teleportX;
+    }
+
+    public double getTeleportY() {
+        return teleportY;
+    }
+
+    public double getTeleportZ() {
+        return teleportZ;
+    }
+
+    public void setTeleportDestination(double x, double y, double z) {
+        if (this.teleportX != x || this.teleportY != y || this.teleportZ != z) modCount++;
+        this.teleportX = x;
+        this.teleportY = y;
+        this.teleportZ = z;
+    }
+
     private static int clampAmplifier(int amplifier) {
         if (amplifier < 0) return 0;
         if (amplifier > MAX_AMPLIFIER) return MAX_AMPLIFIER;
@@ -144,6 +176,10 @@ public class InputRow {
         copy.speedAmplifier = this.speedAmplifier;
         copy.jumpBoostAmplifier = this.jumpBoostAmplifier;
         copy.hotbarSlot = this.hotbarSlot;
+        copy.teleportEnabled = this.teleportEnabled;
+        copy.teleportX = this.teleportX;
+        copy.teleportY = this.teleportY;
+        copy.teleportZ = this.teleportZ;
         return copy;
     }
 }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/Settings.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/Settings.java
@@ -70,6 +70,7 @@ public final class Settings {
     private static final boolean DEFAULT_SHOW_COL_PITCH = false;
     private static final boolean DEFAULT_SHOW_COL_LEFT_CLICK = false;
     private static final boolean DEFAULT_SHOW_COL_RIGHT_CLICK = false;
+    private static final boolean DEFAULT_SHOW_COL_TELEPORT = false;
 
     private static final boolean DEFAULT_VIEW_TICK_INFO = true;
     private static final boolean DEFAULT_VIEW_SERVER_EVENTS = true;
@@ -178,6 +179,7 @@ public final class Settings {
     public boolean showColPitch = DEFAULT_SHOW_COL_PITCH;
     public boolean showColLeftClick = DEFAULT_SHOW_COL_LEFT_CLICK;
     public boolean showColRightClick = DEFAULT_SHOW_COL_RIGHT_CLICK;
+    public boolean showColTeleport = DEFAULT_SHOW_COL_TELEPORT;
 
     public float yawFlickSpeed = DEFAULT_YAW_FLICK_SPEED;
 
@@ -290,6 +292,7 @@ public final class Settings {
         showColPitch = DEFAULT_SHOW_COL_PITCH;
         showColLeftClick = DEFAULT_SHOW_COL_LEFT_CLICK;
         showColRightClick = DEFAULT_SHOW_COL_RIGHT_CLICK;
+        showColTeleport = DEFAULT_SHOW_COL_TELEPORT;
         yawFlickSpeed = DEFAULT_YAW_FLICK_SPEED;
         pathRenderDistance = DEFAULT_PATH_RENDER_DISTANCE;
         unlimitedPathRender = DEFAULT_UNLIMITED_PATH_RENDER;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/SettingsModal.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/SettingsModal.java
@@ -36,6 +36,7 @@ public final class SettingsModal {
     private static final String TT_COL_SPEED_AMP = "Adds a per-tick Speed potion amplifier column to the input table.";
     private static final String TT_COL_JUMP_BOOST_AMP = "Adds a per-tick Jump Boost potion amplifier column to the input table.";
     private static final String TT_COL_HOTBAR = "Adds a per-tick hotbar slot column (1-9). During playback the held slot switches on ticks that set one; empty keeps the previous slot.";
+    private static final String TT_COL_TELEPORT = "Adds a per-tick teleport column. When enabled on a tick, the player teleports to the given X/Y/Z at the start of that tick, before its inputs, in both the simulation and the replay.";
     private static final String TT_CONSTRAINTS = "Draws Angle Solver position constraints (X/Z) as translucent plates at the tick they apply to. The front plate sits on the constraint; the back fades out toward the open/free direction. Only visible while the Angle Solver is open.";
     private static final String TT_C_EXPAND = "Grow each plate outward by the player hitbox half-width (0.3) so the plate covers your hitbox: your hitbox fits inside the plate exactly when the tick is valid.";
     private static final String TT_C_DIM = "Size in blocks. Width is across the constraint, height is vertical, length is along the plate (front depth from the boundary / back reach behind it).";
@@ -472,6 +473,7 @@ public final class SettingsModal {
             checkboxRow("Speed", "##show_speed", settings.showColSpeed, TT_COL_SPEED_AMP, v -> settings.showColSpeed = v);
             checkboxRow("Jump Boost", "##show_jump_boost", settings.showColJumpBoost, TT_COL_JUMP_BOOST_AMP, v -> settings.showColJumpBoost = v);
             checkboxRow("Hotbar slot", "##show_hotbar", settings.showColHotbar, TT_COL_HOTBAR, v -> settings.showColHotbar = v);
+            checkboxRow("Teleport", "##show_teleport", settings.showColTeleport, TT_COL_TELEPORT, v -> settings.showColTeleport = v);
             ThemeManager.endStandardFormTable();
         }
 

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverWindow.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverWindow.java
@@ -54,7 +54,7 @@ public final class AngleSolverWindow implements RenderInterface {
     private static final String WINDOW_ID = "###angle_solver";
     private static final String TITLE = "Angle Solver";
     private static final String TELEPORT_SOLVE_BLOCKED =
-            "Can't solve: the start or goal tick sits on a teleport, which overrides that tick's position.";
+            "Can't solve: the solve range crosses a tick with a teleport, which overrides that tick's movement.";
 
     private static final String[] AXES = {"X", "Z"};
     private static final String[] GOALS = {"MAX", "MIN"};
@@ -893,7 +893,7 @@ public final class AngleSolverWindow implements RenderInterface {
             ImGui.setTooltip("Capture each tick's surface state (ground + medium) from the simulation into the overrides, for the solve range (H).");
         }
         ImGui.sameLine();
-        boolean teleportBlocked = teleportAtRow.test(state.getStartTick()) || teleportAtRow.test(state.getLandingTick());
+        boolean teleportBlocked = solveRangeCrossesTeleport();
         if (teleportBlocked) {
             Controls.disabledButton("Solve");
             ThemeManager.pushTextColor(ThemeManager.warningColor());
@@ -902,6 +902,15 @@ public final class AngleSolverWindow implements RenderInterface {
         } else if (Controls.secondaryButton("Solve")) {
             runTicks.start();
         }
+    }
+
+    private boolean solveRangeCrossesTeleport() {
+        int lo = Math.min(state.getStartTick(), state.getLandingTick());
+        int hi = Math.max(state.getStartTick(), state.getLandingTick());
+        for (int t = lo; t <= hi; t++) {
+            if (teleportAtRow.test(t)) return true;
+        }
+        return false;
     }
 
     private void renderSolvingIndicator() {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverWindow.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverWindow.java
@@ -53,6 +53,8 @@ public final class AngleSolverWindow implements RenderInterface {
 
     private static final String WINDOW_ID = "###angle_solver";
     private static final String TITLE = "Angle Solver";
+    private static final String TELEPORT_SOLVE_BLOCKED =
+            "Can't solve: the start or goal tick sits on a teleport, which overrides that tick's position.";
 
     private static final String[] AXES = {"X", "Z"};
     private static final String[] GOALS = {"MAX", "MIN"};
@@ -124,9 +126,14 @@ public final class AngleSolverWindow implements RenderInterface {
     private int doseToRemove;
     private RunTicksControls runTicks = RunTicksControls.NONE;
     private java.util.function.DoubleSupplier playerYawSupplier = () -> 0.0;
+    private java.util.function.IntPredicate teleportAtRow = t -> false;
 
     public void setPlayerYawSupplier(java.util.function.DoubleSupplier supplier) {
         this.playerYawSupplier = supplier != null ? supplier : () -> 0.0;
+    }
+
+    public void setTeleportAtRow(java.util.function.IntPredicate predicate) {
+        this.teleportAtRow = predicate != null ? predicate : t -> false;
     }
 
     public void setRunTicksControls(RunTicksControls controls) {
@@ -886,7 +893,15 @@ public final class AngleSolverWindow implements RenderInterface {
             ImGui.setTooltip("Capture each tick's surface state (ground + medium) from the simulation into the overrides, for the solve range (H).");
         }
         ImGui.sameLine();
-        if (Controls.secondaryButton("Solve")) runTicks.start();
+        boolean teleportBlocked = teleportAtRow.test(state.getStartTick()) || teleportAtRow.test(state.getLandingTick());
+        if (teleportBlocked) {
+            Controls.disabledButton("Solve");
+            ThemeManager.pushTextColor(ThemeManager.warningColor());
+            ImGui.textWrapped(TELEPORT_SOLVE_BLOCKED);
+            ThemeManager.popTextColor();
+        } else if (Controls.secondaryButton("Solve")) {
+            runTicks.start();
+        }
     }
 
     private void renderSolvingIndicator() {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/theme/Controls.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/theme/Controls.java
@@ -51,6 +51,15 @@ public final class Controls {
         return changed;
     }
 
+    public static boolean decimalField(String label, ImString holder, float width) {
+        pushInputFrameHeight();
+        beginLabeled(label, width <= 0 ? DEFAULT_NUM_WIDTH : width);
+        boolean changed = ImGui.inputText(idFor(label), holder, ImGuiInputTextFlags.CharsDecimal);
+        popInputFrameHeight();
+        drawFocusRingIfActive();
+        return changed;
+    }
+
     // ---- sliders ---------------------------------------------------------------
 
     public static boolean sliderFloat(String label, float[] ref, float lo, float hi, String fmt) {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/theme/MacroBadgeStyle.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/theme/MacroBadgeStyle.java
@@ -6,4 +6,13 @@ public final class MacroBadgeStyle {
     public static final String LABEL = "MACRO";
     public static final int COLOR_ARGB = 0x4DFF6060;
 
+    public static final String TELEPORT_LABEL = "Teleported";
+    private static final int TELEPORT_COLOR_RGB = 0x00FF6060;
+
+    public static int teleportColorArgb(float alpha) {
+        float a = alpha < 0f ? 0f : (alpha > 1f ? 1f : alpha);
+        int ai = Math.round(a * 255f);
+        return (ai << 24) | TELEPORT_COLOR_RGB;
+    }
+
 }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/theme/ThemeManager.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/theme/ThemeManager.java
@@ -34,6 +34,7 @@ public final class ThemeManager {
     private static final float[] DANGER       = rgb(0xf3, 0x8b, 0xa8, 1.00f);
     private static final float[] OK           = rgb(0xa6, 0xe3, 0xa1, 1.00f);
     private static final float[] FOCUS        = rgb(0xb4, 0xbe, 0xfe, 1.00f);
+    private static final float[] TELEPORT     = rgb(0x94, 0xe2, 0xd5, 1.00f);
     private static final float[] STATUS_BG    = rgb(0x18, 0x18, 0x25, 1.00f);
 
     // Button state fills, lifted byte-exact from kit.css .btn--primary / .btn--danger swatches.
@@ -670,6 +671,10 @@ public final class ThemeManager {
         return u32(PEACH);
     }
 
+    public static int teleportColor() {
+        return u32(TELEPORT);
+    }
+
     public static int panelColor() {
         return u32(PANEL);
     }
@@ -708,6 +713,10 @@ public final class ThemeManager {
 
     public static int peachTintColor(float alpha) {
         return ImGui.colorConvertFloat4ToU32(PEACH[0], PEACH[1], PEACH[2], alpha);
+    }
+
+    public static int teleportTintColor(float alpha) {
+        return ImGui.colorConvertFloat4ToU32(TELEPORT[0], TELEPORT[1], TELEPORT[2], alpha);
     }
 
     public static int bgTintColor(float alpha) {

--- a/core/src/test/java/de/legoshi/parkourcalc/core/FakePlaybackBridge.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/FakePlaybackBridge.java
@@ -18,6 +18,10 @@ public class FakePlaybackBridge implements PlaybackBridge {
     public Vec3dCore teleportVel;
     public float teleportYaw;
     public Checkpoint teleportCarry;
+    public int teleportInPlaceCalls;
+    public Vec3dCore teleportInPlacePos;
+    public Vec3dCore teleportInPlaceVel;
+    public float teleportInPlaceYaw;
     public float pitch;
     public final Map<InputRow.Key, Boolean> keys = new EnumMap<InputRow.Key, Boolean>(InputRow.Key.class);
 
@@ -31,6 +35,14 @@ public class FakePlaybackBridge implements PlaybackBridge {
         teleportYaw = yaw;
         teleportCarry = carry;
         teleportCalls++;
+    }
+
+    @Override
+    public void teleportInPlace(Vec3dCore pos, Vec3dCore vel, float yaw) {
+        teleportInPlacePos = pos;
+        teleportInPlaceVel = vel;
+        teleportInPlaceYaw = yaw;
+        teleportInPlaceCalls++;
     }
 
     @Override public void setKey(InputRow.Key key, boolean pressed) { keys.put(key, pressed); }

--- a/core/src/test/java/de/legoshi/parkourcalc/core/InputRowSaveRoundTripTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/InputRowSaveRoundTripTest.java
@@ -105,6 +105,46 @@ public class InputRowSaveRoundTripTest {
     }
 
     @Test
+    public void teleportDestinationRoundTrips() throws Exception {
+        FileSystemSaveStore store = store(Files.createTempDirectory("pkc-rt-teleport"));
+
+        InputData in = new InputData();
+        InputRow r0 = new InputRow();
+        r0.setTeleportEnabled(true);
+        r0.setTeleportDestination(12.5, 65.0, -3.25);
+        in.getRows().add(r0);
+
+        InputRow r1 = new InputRow();
+        in.getRows().add(r1);
+
+        InputData out = saveAndReload(store, in);
+        assertEquals(2, out.size());
+
+        InputRow o0 = out.get(0);
+        assertTrue("teleport flag must survive a round-trip", o0.isTeleportEnabled());
+        assertEquals(12.5, o0.getTeleportX(), 0.0);
+        assertEquals(65.0, o0.getTeleportY(), 0.0);
+        assertEquals(-3.25, o0.getTeleportZ(), 0.0);
+
+        assertFalse("an untouched teleport stays disabled", out.get(1).isTeleportEnabled());
+    }
+
+    @Test
+    public void oldFormatRowWithoutTeleportLoadsDisabled() {
+        String json = "{\n" +
+                "  \"version\": 1,\n" +
+                "  \"start\": { \"pos\": [0.0, 0.0, 0.0], \"vel\": [0.0, 0.0, 0.0], \"yaw\": 0.0 },\n" +
+                "  \"rows\": [ { \"keys\": [\"W\"], \"yaw\": 0.0 } ]\n" +
+                "}";
+        SaveFile file = SaveIO.parseSafe(json);
+        assertNotNull(file);
+        InputData out = new InputData();
+        SaveIO.applyRowsTo(file, out);
+        assertEquals(1, out.size());
+        assertFalse("missing teleport field must load as disabled", out.get(0).isTeleportEnabled());
+    }
+
+    @Test
     public void oldFormatRowWithoutPitchOrMouseLoadsWithDefaults() {
         String json = "{\n" +
                 "  \"version\": 1,\n" +

--- a/core/src/test/java/de/legoshi/parkourcalc/core/MediumWorldFakeSimulator.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/MediumWorldFakeSimulator.java
@@ -381,6 +381,15 @@ public class MediumWorldFakeSimulator extends LazyEntitySimulator<MediumWorldFak
 
     @Override protected void setInput(FakeEntity e, InputRow row) { e.row = row; }
 
+    @Override protected void teleportEntity(FakeEntity e, Vec3dCore pos, Vec3dCore velocity) {
+        e.x = pos.x;
+        e.y = pos.y;
+        e.z = pos.z;
+        e.vx = velocity.x;
+        e.vy = velocity.y;
+        e.vz = velocity.z;
+    }
+
     @Override protected void applyYaw(FakeEntity e, float yaw) { e.yaw = e.yaw + yaw; }
 
     @Override protected void setYawAbsolute(FakeEntity e, float yaw) { e.yaw = yaw; }

--- a/core/src/test/java/de/legoshi/parkourcalc/core/PlaybackRangeTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/PlaybackRangeTest.java
@@ -117,6 +117,27 @@ public class PlaybackRangeTest {
     }
 
     @Test
+    public void perTickTeleportDuringReplayUsesInPlaceTeleportNotRestartHop() {
+        InputData data = rows(7);
+        InputRow tp = data.get(5);
+        tp.setTeleportEnabled(true);
+        tp.setTeleportDestination(5, 6, 7);
+        FakePlaybackBridge bridge = new FakePlaybackBridge();
+        PlaybackController pc = controller(bridge, new SimulationRunner(new FakeSimulator()), data);
+
+        pc.start(4, data.size(), new Vec3dCore(0, 64, 0), Vec3dCore.ZERO, 0f);
+        int restartHopTeleports = bridge.teleportCalls;
+
+        for (int i = 0; i < 8 && bridge.teleportInPlaceCalls == 0; i++) pc.tick();
+
+        assertEquals("per-tick teleport routes through the in-place path", 1, bridge.teleportInPlaceCalls);
+        assertEquals(new Vec3dCore(5, 6, 7), bridge.teleportInPlacePos);
+        assertEquals(Vec3dCore.GROUND_REST_VELOCITY, bridge.teleportInPlaceVel);
+        assertEquals("restart-hop teleport is never used mid-replay for a per-tick teleport",
+                restartHopTeleports, bridge.teleportCalls);
+    }
+
+    @Test
     public void statusHintDescribesTheRangeButNotAFullFromTopReplay() {
         InputData data = rows(10);
         FakePlaybackBridge bridge = new FakePlaybackBridge();

--- a/core/src/test/java/de/legoshi/parkourcalc/core/TeleportTickSimTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/TeleportTickSimTest.java
@@ -22,7 +22,7 @@ public class TeleportTickSimTest {
     }
 
     @Test
-    public void teleportPlacesEntityAndZeroesHorizontalVelocity() {
+    public void teleportTickIsNoOpAndIgnoresItsOwnInputs() {
         MediumWorldFakeSimulator sim = new MediumWorldFakeSimulator(new MediumWorldFakeSimulator.World());
         SimulationRunner runner = new SimulationRunner(sim);
         runner.setStartPosition(new Vec3dCore(0.0, 100.0, 0.0));
@@ -32,7 +32,8 @@ public class TeleportTickSimTest {
         InputData data = new InputData();
         data.getRows().add(moving());
         data.getRows().add(moving());
-        InputRow teleportRow = new InputRow();
+        InputRow teleportRow = moving();
+        teleportRow.setKeyActive(InputRow.Key.JUMP, true);
         teleportRow.setTeleportEnabled(true);
         teleportRow.setTeleportDestination(50.0, 80.0, 50.0);
         data.getRows().add(teleportRow);
@@ -41,11 +42,11 @@ public class TeleportTickSimTest {
         List<TickState> path = runner.simulate(data);
 
         TickState afterTeleport = path.get(3);
-        assertEquals("teleport pins X (horizontal velocity zeroed, no strafe on the teleport tick)",
+        assertEquals("teleport pins X: the teleport tick's own inputs are ignored",
                 50.0, afterTeleport.position.x, 1.0e-9);
-        assertEquals("teleport pins Z (horizontal velocity zeroed, no strafe on the teleport tick)",
+        assertEquals("teleport pins Z: the teleport tick's own inputs are ignored",
                 50.0, afterTeleport.position.z, 1.0e-9);
-        assertEquals("Y falls by exactly the default rest velocity from the destination",
+        assertEquals("Y falls by exactly the default rest velocity from the destination (no jump)",
                 80.0 + Vec3dCore.GROUND_REST_VELOCITY.y, afterTeleport.position.y, 1.0e-9);
     }
 
@@ -60,7 +61,7 @@ public class TeleportTickSimTest {
         InputData data = new InputData();
         data.getRows().add(moving());
         data.getRows().add(moving());
-        InputRow teleportRow = new InputRow();
+        InputRow teleportRow = moving();
         data.getRows().add(teleportRow);
         data.getRows().add(new InputRow());
 

--- a/core/src/test/java/de/legoshi/parkourcalc/core/TeleportTickSimTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/TeleportTickSimTest.java
@@ -1,0 +1,79 @@
+package de.legoshi.parkourcalc.core;
+
+import de.legoshi.parkourcalc.core.sim.SimulationRunner;
+import de.legoshi.parkourcalc.core.sim.TickState;
+import de.legoshi.parkourcalc.core.sim.Vec3dCore;
+import de.legoshi.parkourcalc.core.ui.InputData;
+import de.legoshi.parkourcalc.core.ui.InputRow;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class TeleportTickSimTest {
+
+    private static InputRow moving() {
+        InputRow r = new InputRow();
+        r.setKeyActive(InputRow.Key.W, true);
+        r.setKeyActive(InputRow.Key.SPRINT, true);
+        return r;
+    }
+
+    @Test
+    public void teleportPlacesEntityAndZeroesHorizontalVelocity() {
+        MediumWorldFakeSimulator sim = new MediumWorldFakeSimulator(new MediumWorldFakeSimulator.World());
+        SimulationRunner runner = new SimulationRunner(sim);
+        runner.setStartPosition(new Vec3dCore(0.0, 100.0, 0.0));
+        runner.setStartVelocity(Vec3dCore.GROUND_REST_VELOCITY);
+        runner.setStartYaw(0.0f);
+
+        InputData data = new InputData();
+        data.getRows().add(moving());
+        data.getRows().add(moving());
+        InputRow teleportRow = new InputRow();
+        teleportRow.setTeleportEnabled(true);
+        teleportRow.setTeleportDestination(50.0, 80.0, 50.0);
+        data.getRows().add(teleportRow);
+        data.getRows().add(new InputRow());
+
+        List<TickState> path = runner.simulate(data);
+
+        TickState afterTeleport = path.get(3);
+        assertEquals("teleport pins X (horizontal velocity zeroed, no strafe on the teleport tick)",
+                50.0, afterTeleport.position.x, 1.0e-9);
+        assertEquals("teleport pins Z (horizontal velocity zeroed, no strafe on the teleport tick)",
+                50.0, afterTeleport.position.z, 1.0e-9);
+        assertEquals("Y falls by exactly the default rest velocity from the destination",
+                80.0 + Vec3dCore.GROUND_REST_VELOCITY.y, afterTeleport.position.y, 1.0e-9);
+    }
+
+    @Test
+    public void teleportRerunsIncrementallyFromTheTeleportTick() {
+        MediumWorldFakeSimulator sim = new MediumWorldFakeSimulator(new MediumWorldFakeSimulator.World());
+        SimulationRunner runner = new SimulationRunner(sim);
+        runner.setStartPosition(new Vec3dCore(0.0, 100.0, 0.0));
+        runner.setStartVelocity(Vec3dCore.GROUND_REST_VELOCITY);
+        runner.setStartYaw(0.0f);
+
+        InputData data = new InputData();
+        data.getRows().add(moving());
+        data.getRows().add(moving());
+        InputRow teleportRow = new InputRow();
+        data.getRows().add(teleportRow);
+        data.getRows().add(new InputRow());
+
+        runner.simulate(data);
+
+        teleportRow.setTeleportEnabled(true);
+        teleportRow.setTeleportDestination(50.0, 80.0, 50.0);
+        assertTrue(runner.canResumeFrom(2));
+        List<TickState> path = runner.simulateFrom(2, data);
+
+        TickState afterTeleport = path.get(3);
+        assertEquals(50.0, afterTeleport.position.x, 1.0e-9);
+        assertEquals(50.0, afterTeleport.position.z, 1.0e-9);
+        assertEquals(80.0 + Vec3dCore.GROUND_REST_VELOCITY.y, afterTeleport.position.y, 1.0e-9);
+    }
+}

--- a/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/FabricParkourCalculator.java
+++ b/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/FabricParkourCalculator.java
@@ -470,7 +470,7 @@ public class FabricParkourCalculator implements ClientModInitializer {
     public static void onHudRender(GuiGraphics context) {
         if (!application.isReady()) return;
         if (application.isPlaybackRunning()) {
-            hudRenderer.render(context);
+            hudRenderer.render(context, application.getPlayback().teleportNoticeAlpha());
         }
     }
 

--- a/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/FabricPlaybackBridge.java
+++ b/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/FabricPlaybackBridge.java
@@ -291,6 +291,9 @@ public final class FabricPlaybackBridge implements PlaybackBridge {
                 new PositionMoveRotation(new Vec3(pos.x, pos.y, pos.z), startVel, yaw, sp.getXRot()),
                 Collections.emptySet()
             );
+            sp.setOnGround(true);
+            sp.setSprinting(false);
+            sp.fallDistance = 0;
         });
     }
 

--- a/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/FabricPlaybackBridge.java
+++ b/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/FabricPlaybackBridge.java
@@ -272,6 +272,29 @@ public final class FabricPlaybackBridge implements PlaybackBridge {
     }
 
     @Override
+    public void teleportInPlace(Vec3dCore pos, Vec3dCore vel, float yaw) {
+        if (!isSingleplayer()) {
+            teleport(pos, vel, yaw, null);
+            return;
+        }
+        Minecraft mc = Minecraft.getInstance();
+        LocalPlayer client = mc.player;
+        if (client == null) return;
+        IntegratedServer server = mc.getSingleplayerServer();
+        if (server == null) return;
+        UUID uuid = client.getUUID();
+        Vec3 startVel = new Vec3(vel.x, vel.y, vel.z);
+        server.execute(() -> {
+            ServerPlayer sp = server.getPlayerList().getPlayer(uuid);
+            if (sp == null) return;
+            sp.connection.teleport(
+                new PositionMoveRotation(new Vec3(pos.x, pos.y, pos.z), startVel, yaw, sp.getXRot()),
+                Collections.emptySet()
+            );
+        });
+    }
+
+    @Override
     public void setKey(InputRow.Key key, boolean pressed) {
         currentRow.setKeyActive(key, pressed);
         if (ghostMode) return;

--- a/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/render/FabricHudOverlayRenderer.java
+++ b/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/render/FabricHudOverlayRenderer.java
@@ -7,11 +7,17 @@ import net.minecraft.client.gui.GuiGraphics;
 
 public final class FabricHudOverlayRenderer {
 
-    public void render(GuiGraphics context) {
+    public void render(GuiGraphics context, float teleportAlpha) {
         Minecraft client = Minecraft.getInstance();
         Font tr = client.font;
         String label = MacroBadgeStyle.LABEL;
         int x = context.guiWidth() - tr.width(label) - 4;
         context.drawString(tr, label, x, 4, MacroBadgeStyle.COLOR_ARGB, true);
+
+        int noticeColor = MacroBadgeStyle.teleportColorArgb(teleportAlpha);
+        if ((noticeColor >>> 24) < 4) return;
+        String notice = MacroBadgeStyle.TELEPORT_LABEL;
+        int nx = context.guiWidth() - tr.width(notice) - 4;
+        context.drawString(tr, notice, nx, 4 + tr.lineHeight + 2, noticeColor, true);
     }
 }

--- a/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/sim/FabricSimulator.java
+++ b/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/sim/FabricSimulator.java
@@ -183,6 +183,11 @@ public final class FabricSimulator extends LazyEntitySimulator<SimulatorEntity> 
         e.input.setData(row);
     }
 
+    @Override protected void teleportEntity(SimulatorEntity e, Vec3dCore pos, Vec3dCore velocity) {
+        e.setPos(pos.x, pos.y, pos.z);
+        e.setDeltaMovement(velocity.x, velocity.y, velocity.z);
+    }
+
     @Override protected void applyYaw(SimulatorEntity e, float yaw) {
         e.setYRot(e.getYRot() + yaw);
     }

--- a/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/sim/FabricSimulator.java
+++ b/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/sim/FabricSimulator.java
@@ -184,8 +184,7 @@ public final class FabricSimulator extends LazyEntitySimulator<SimulatorEntity> 
     }
 
     @Override protected void teleportEntity(SimulatorEntity e, Vec3dCore pos, Vec3dCore velocity) {
-        e.setPos(pos.x, pos.y, pos.z);
-        e.setDeltaMovement(velocity.x, velocity.y, velocity.z);
+        e.teleportRest(pos.x, pos.y, pos.z, velocity.x, velocity.y, velocity.z);
     }
 
     @Override protected void applyYaw(SimulatorEntity e, float yaw) {

--- a/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/sim/SimulatorEntity.java
+++ b/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/sim/SimulatorEntity.java
@@ -466,6 +466,25 @@ public class SimulatorEntity extends Player {
         this.fallDistance = c.fallDistance;
     }
 
+    public void teleportRest(double x, double y, double z, double vx, double vy, double vz) {
+        float keepYaw = this.getYRot();
+        this.setPos(x, y, z);
+        this.setDeltaMovement(vx, vy, vz);
+        this.setYRot(keepYaw);
+        this.setOnGround(true);
+        this.horizontalCollision = false;
+        this.minorHorizontalCollision = false;
+        this.setSprinting(false);
+        this.sprintTriggerTime = 0;
+        this.input.seedKeyPresses(new Input(false, false, false, false, false, false, false));
+        this.noJumpDelay = 0;
+        this.stuckSpeedMultiplier = Vec3.ZERO;
+        this.fallDistance = 0;
+        this.crouching = false;
+        this.setPose(Pose.STANDING);
+        this.refreshDimensions();
+    }
+
     public static void applyCheckpoint(net.minecraft.client.player.LocalPlayer p, de.legoshi.parkourcalc.core.sim.Checkpoint state) {
         Checkpoint c = de.legoshi.parkourcalc.fabric.sim.paired.PairedCheckpoint.clientPart(state);
         if (c == null) return;

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricParkourCalculator.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricParkourCalculator.java
@@ -540,7 +540,7 @@ public class FabricParkourCalculator implements ClientModInitializer {
     public static void onHudRender(GuiGraphicsExtractor context) {
         if (!application.isReady()) return;
         if (application.isPlaybackRunning()) {
-            hudRenderer.render(context);
+            hudRenderer.render(context, application.getPlayback().teleportNoticeAlpha());
         }
     }
 

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricPlaybackBridge.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricPlaybackBridge.java
@@ -407,6 +407,9 @@ public final class FabricPlaybackBridge implements PlaybackBridge {
                 new PositionMoveRotation(new Vec3(pos.x, pos.y, pos.z), startVel, yaw, sp.getXRot()),
                 Collections.emptySet()
             );
+            sp.setOnGround(true);
+            sp.setSprinting(false);
+            sp.fallDistance = 0;
         });
     }
 

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricPlaybackBridge.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricPlaybackBridge.java
@@ -388,6 +388,29 @@ public final class FabricPlaybackBridge implements PlaybackBridge {
     }
 
     @Override
+    public void teleportInPlace(Vec3dCore pos, Vec3dCore vel, float yaw) {
+        if (!isSingleplayer()) {
+            teleport(pos, vel, yaw, null);
+            return;
+        }
+        Minecraft mc = Minecraft.getInstance();
+        LocalPlayer client = mc.player;
+        if (client == null) return;
+        IntegratedServer server = mc.getSingleplayerServer();
+        if (server == null) return;
+        UUID uuid = client.getUUID();
+        Vec3 startVel = new Vec3(vel.x, vel.y, vel.z);
+        server.execute(() -> {
+            ServerPlayer sp = server.getPlayerList().getPlayer(uuid);
+            if (sp == null) return;
+            sp.connection.teleport(
+                new PositionMoveRotation(new Vec3(pos.x, pos.y, pos.z), startVel, yaw, sp.getXRot()),
+                Collections.emptySet()
+            );
+        });
+    }
+
+    @Override
     public void setKey(InputRow.Key key, boolean pressed) {
         currentRow.setKeyActive(key, pressed);
         if (ghostMode) return;

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/render/FabricHudOverlayRenderer.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/render/FabricHudOverlayRenderer.java
@@ -8,11 +8,17 @@ import net.minecraft.client.gui.GuiGraphicsExtractor;
 /** Top-right MACRO badge shown while playback drives the real player. */
 public final class FabricHudOverlayRenderer {
 
-    public void render(GuiGraphicsExtractor context) {
+    public void render(GuiGraphicsExtractor context, float teleportAlpha) {
         Minecraft client = Minecraft.getInstance();
         Font tr = client.font;
         String label = MacroBadgeStyle.LABEL;
         int x = context.guiWidth() - tr.width(label) - 4;
         context.text(tr, label, x, 4, MacroBadgeStyle.COLOR_ARGB, true);
+
+        int noticeColor = MacroBadgeStyle.teleportColorArgb(teleportAlpha);
+        if ((noticeColor >>> 24) < 4) return;
+        String notice = MacroBadgeStyle.TELEPORT_LABEL;
+        int nx = context.guiWidth() - tr.width(notice) - 4;
+        context.text(tr, notice, nx, 4 + tr.lineHeight + 2, noticeColor, true);
     }
 }

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/sim/FabricSimulator.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/sim/FabricSimulator.java
@@ -183,6 +183,11 @@ public final class FabricSimulator extends LazyEntitySimulator<SimulatorEntity> 
         e.input.setData(row);
     }
 
+    @Override protected void teleportEntity(SimulatorEntity e, Vec3dCore pos, Vec3dCore velocity) {
+        e.setPos(pos.x, pos.y, pos.z);
+        e.setDeltaMovement(velocity.x, velocity.y, velocity.z);
+    }
+
     @Override protected void applyYaw(SimulatorEntity e, float yaw) {
         e.setYRot(e.getYRot() + yaw);
     }

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/sim/FabricSimulator.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/sim/FabricSimulator.java
@@ -184,8 +184,7 @@ public final class FabricSimulator extends LazyEntitySimulator<SimulatorEntity> 
     }
 
     @Override protected void teleportEntity(SimulatorEntity e, Vec3dCore pos, Vec3dCore velocity) {
-        e.setPos(pos.x, pos.y, pos.z);
-        e.setDeltaMovement(velocity.x, velocity.y, velocity.z);
+        e.teleportRest(pos.x, pos.y, pos.z, velocity.x, velocity.y, velocity.z);
     }
 
     @Override protected void applyYaw(SimulatorEntity e, float yaw) {

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/sim/SimulatorEntity.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/sim/SimulatorEntity.java
@@ -489,6 +489,25 @@ public class SimulatorEntity extends Player {
         this.fallDistance = c.fallDistance;
     }
 
+    public void teleportRest(double x, double y, double z, double vx, double vy, double vz) {
+        float keepYaw = this.getYRot();
+        this.setPos(x, y, z);
+        this.setDeltaMovement(vx, vy, vz);
+        this.setYRot(keepYaw);
+        this.setOnGround(true);
+        this.horizontalCollision = false;
+        this.minorHorizontalCollision = false;
+        this.setSprinting(false);
+        this.sprintTriggerTime = 0;
+        this.input.seedKeyPresses(new Input(false, false, false, false, false, false, false));
+        this.noJumpDelay = 0;
+        this.stuckSpeedMultiplier = Vec3.ZERO;
+        this.fallDistance = 0;
+        this.crouching = false;
+        this.setPose(Pose.STANDING);
+        this.refreshDimensions();
+    }
+
     public static void applyCheckpoint(net.minecraft.client.player.LocalPlayer p, de.legoshi.parkourcalc.core.sim.Checkpoint state) {
         Checkpoint c = de.legoshi.parkourcalc.fabric.sim.paired.PairedCheckpoint.clientPart(state);
         if (c == null) return;

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12ParkourCalculator.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12ParkourCalculator.java
@@ -272,7 +272,7 @@ public class Forge12ParkourCalculator {
     public void onHudRender(RenderGameOverlayEvent.Post event) {
         if (event.getType() != RenderGameOverlayEvent.ElementType.TEXT) return;
         if (application.isPlaybackRunning()) {
-            hudRenderer.render();
+            hudRenderer.render(application.getPlayback().teleportNoticeAlpha());
         }
     }
 

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/render/Forge12HudOverlayRenderer.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/render/Forge12HudOverlayRenderer.java
@@ -20,8 +20,13 @@ public final class Forge12HudOverlayRenderer {
         int noticeColor = MacroBadgeStyle.teleportColorArgb(teleportAlpha);
         if ((noticeColor >>> 24) >= 4) {
             String notice = MacroBadgeStyle.TELEPORT_LABEL;
-            int nx = sr.getScaledWidth() - fr.getStringWidth(notice) - 4;
-            fr.drawStringWithShadow(notice, nx, 4 + fr.FONT_HEIGHT + 2, noticeColor);
+            float sc = 0.25f;
+            float nx = sr.getScaledWidth() - fr.getStringWidth(notice) * sc - 4;
+            float ny = 4 + fr.FONT_HEIGHT + 2;
+            net.minecraft.client.renderer.GlStateManager.pushMatrix();
+            net.minecraft.client.renderer.GlStateManager.scale(sc, sc, 1f);
+            fr.drawStringWithShadow(notice, nx / sc, ny / sc, noticeColor);
+            net.minecraft.client.renderer.GlStateManager.popMatrix();
         }
     }
 }

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/render/Forge12HudOverlayRenderer.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/render/Forge12HudOverlayRenderer.java
@@ -20,7 +20,7 @@ public final class Forge12HudOverlayRenderer {
         int noticeColor = MacroBadgeStyle.teleportColorArgb(teleportAlpha);
         if ((noticeColor >>> 24) >= 4) {
             String notice = MacroBadgeStyle.TELEPORT_LABEL;
-            float sc = 0.25f;
+            float sc = 0.5f;
             float nx = sr.getScaledWidth() - fr.getStringWidth(notice) * sc - 4;
             float ny = 4 + fr.FONT_HEIGHT + 2;
             net.minecraft.client.renderer.GlStateManager.pushMatrix();

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/render/Forge12HudOverlayRenderer.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/render/Forge12HudOverlayRenderer.java
@@ -9,7 +9,7 @@ import net.minecraft.client.gui.ScaledResolution;
 @SuppressWarnings("DuplicatedCode")
 public final class Forge12HudOverlayRenderer {
 
-    public void render() {
+    public void render(float teleportAlpha) {
         Minecraft mc = Minecraft.getMinecraft();
         FontRenderer fr = mc.fontRenderer;
         if (fr == null) return;
@@ -17,5 +17,11 @@ public final class Forge12HudOverlayRenderer {
         String label = MacroBadgeStyle.LABEL;
         int x = sr.getScaledWidth() - fr.getStringWidth(label) - 4;
         fr.drawStringWithShadow(label, x, 4, MacroBadgeStyle.COLOR_ARGB);
+        int noticeColor = MacroBadgeStyle.teleportColorArgb(teleportAlpha);
+        if ((noticeColor >>> 24) >= 4) {
+            String notice = MacroBadgeStyle.TELEPORT_LABEL;
+            int nx = sr.getScaledWidth() - fr.getStringWidth(notice) - 4;
+            fr.drawStringWithShadow(notice, nx, 4 + fr.FONT_HEIGHT + 2, noticeColor);
+        }
     }
 }

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/sim/Forge12Simulator.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/sim/Forge12Simulator.java
@@ -214,6 +214,12 @@ public final class Forge12Simulator extends LazyEntitySimulator<SimulatorEntity>
         lastRow = row;
         e.setInput(row);
     }
+    @Override protected void teleportEntity(SimulatorEntity e, Vec3dCore pos, Vec3dCore velocity) {
+        e.setPosition(pos.x, pos.y, pos.z);
+        e.motionX = velocity.x;
+        e.motionY = velocity.y;
+        e.motionZ = velocity.z;
+    }
     @Override protected void applyYaw(SimulatorEntity e, float yaw) { e.rotationYaw += yaw; }
     @Override protected void setYawAbsolute(SimulatorEntity e, float yaw) { e.rotationYaw = yaw; }
 

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/sim/Forge12Simulator.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/sim/Forge12Simulator.java
@@ -215,10 +215,7 @@ public final class Forge12Simulator extends LazyEntitySimulator<SimulatorEntity>
         e.setInput(row);
     }
     @Override protected void teleportEntity(SimulatorEntity e, Vec3dCore pos, Vec3dCore velocity) {
-        e.setPosition(pos.x, pos.y, pos.z);
-        e.motionX = velocity.x;
-        e.motionY = velocity.y;
-        e.motionZ = velocity.z;
+        e.teleportRest(pos.x, pos.y, pos.z, velocity.x, velocity.y, velocity.z);
     }
     @Override protected void applyYaw(SimulatorEntity e, float yaw) { e.rotationYaw += yaw; }
     @Override protected void setYawAbsolute(SimulatorEntity e, float yaw) { e.rotationYaw = yaw; }

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/sim/SimulatorEntity.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/sim/SimulatorEntity.java
@@ -368,6 +368,21 @@ public class SimulatorEntity extends EntityPlayer {
         this.setPosition(c.posX, c.posY, c.posZ);
     }
 
+    public void teleportRest(double x, double y, double z, double vx, double vy, double vz) {
+        this.setPosition(x, y, z);
+        this.motionX = vx;
+        this.motionY = vy;
+        this.motionZ = vz;
+        this.onGround = true;
+        this.collidedHorizontally = false;
+        this.setSprinting(false);
+        this.setSneaking(false);
+        this.sprintState = PlayerSprintMachine.State.initial();
+        this.jumpTicks = 0;
+        this.isInWeb = false;
+        this.fallDistance = 0;
+    }
+
     public static void applyCheckpoint(EntityLivingBase p, de.legoshi.parkourcalc.core.sim.Checkpoint state) {
         Checkpoint c = de.legoshi.parkourcalc.forge12.sim.paired.PairedCheckpoint.clientPart(state);
         if (c == null) return;

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8ParkourCalculator.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8ParkourCalculator.java
@@ -277,7 +277,7 @@ public class Forge8ParkourCalculator {
     public void onHudRender(RenderGameOverlayEvent.Post event) {
         if (event.type != RenderGameOverlayEvent.ElementType.TEXT) return;
         if (application.isPlaybackRunning()) {
-            hudRenderer.render();
+            hudRenderer.render(application.getPlayback().teleportNoticeAlpha());
         }
     }
 

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/render/Forge8HudOverlayRenderer.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/render/Forge8HudOverlayRenderer.java
@@ -10,7 +10,7 @@ import net.minecraft.client.renderer.GlStateManager;
 @SuppressWarnings("DuplicatedCode")
 public final class Forge8HudOverlayRenderer {
 
-    public void render() {
+    public void render(float teleportAlpha) {
         Minecraft mc = Minecraft.getMinecraft();
         FontRenderer fr = mc.fontRendererObj;
         if (fr == null) return;
@@ -18,6 +18,12 @@ public final class Forge8HudOverlayRenderer {
         String label = MacroBadgeStyle.LABEL;
         int x = sr.getScaledWidth() - fr.getStringWidth(label) - 4;
         fr.drawStringWithShadow(label, x, 4, MacroBadgeStyle.COLOR_ARGB);
+        int noticeColor = MacroBadgeStyle.teleportColorArgb(teleportAlpha);
+        if ((noticeColor >>> 24) >= 4) {
+            String notice = MacroBadgeStyle.TELEPORT_LABEL;
+            int nx = sr.getScaledWidth() - fr.getStringWidth(notice) - 4;
+            fr.drawStringWithShadow(notice, nx, 4 + fr.FONT_HEIGHT + 2, noticeColor);
+        }
         GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
     }
 }

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/render/Forge8HudOverlayRenderer.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/render/Forge8HudOverlayRenderer.java
@@ -21,8 +21,13 @@ public final class Forge8HudOverlayRenderer {
         int noticeColor = MacroBadgeStyle.teleportColorArgb(teleportAlpha);
         if ((noticeColor >>> 24) >= 4) {
             String notice = MacroBadgeStyle.TELEPORT_LABEL;
-            int nx = sr.getScaledWidth() - fr.getStringWidth(notice) - 4;
-            fr.drawStringWithShadow(notice, nx, 4 + fr.FONT_HEIGHT + 2, noticeColor);
+            float sc = 0.25f;
+            float nx = sr.getScaledWidth() - fr.getStringWidth(notice) * sc - 4;
+            float ny = 4 + fr.FONT_HEIGHT + 2;
+            GlStateManager.pushMatrix();
+            GlStateManager.scale(sc, sc, 1f);
+            fr.drawStringWithShadow(notice, nx / sc, ny / sc, noticeColor);
+            GlStateManager.popMatrix();
         }
         GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
     }

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/render/Forge8HudOverlayRenderer.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/render/Forge8HudOverlayRenderer.java
@@ -21,7 +21,7 @@ public final class Forge8HudOverlayRenderer {
         int noticeColor = MacroBadgeStyle.teleportColorArgb(teleportAlpha);
         if ((noticeColor >>> 24) >= 4) {
             String notice = MacroBadgeStyle.TELEPORT_LABEL;
-            float sc = 0.25f;
+            float sc = 0.5f;
             float nx = sr.getScaledWidth() - fr.getStringWidth(notice) * sc - 4;
             float ny = 4 + fr.FONT_HEIGHT + 2;
             GlStateManager.pushMatrix();

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/sim/Forge8Simulator.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/sim/Forge8Simulator.java
@@ -213,6 +213,13 @@ public final class Forge8Simulator extends LazyEntitySimulator<SimulatorEntity> 
         e.setInput(row);
     }
 
+    @Override protected void teleportEntity(SimulatorEntity e, Vec3dCore pos, Vec3dCore velocity) {
+        e.setPosition(pos.x, pos.y, pos.z);
+        e.motionX = velocity.x;
+        e.motionY = velocity.y;
+        e.motionZ = velocity.z;
+    }
+
     @Override protected void applyYaw(SimulatorEntity e, float yaw) {
         e.rotationYaw += yaw;
     }

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/sim/Forge8Simulator.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/sim/Forge8Simulator.java
@@ -214,10 +214,7 @@ public final class Forge8Simulator extends LazyEntitySimulator<SimulatorEntity> 
     }
 
     @Override protected void teleportEntity(SimulatorEntity e, Vec3dCore pos, Vec3dCore velocity) {
-        e.setPosition(pos.x, pos.y, pos.z);
-        e.motionX = velocity.x;
-        e.motionY = velocity.y;
-        e.motionZ = velocity.z;
+        e.teleportRest(pos.x, pos.y, pos.z, velocity.x, velocity.y, velocity.z);
     }
 
     @Override protected void applyYaw(SimulatorEntity e, float yaw) {

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/sim/SimulatorEntity.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/sim/SimulatorEntity.java
@@ -356,6 +356,21 @@ public class SimulatorEntity extends EntityPlayer {
         this.setPosition(c.posX, c.posY, c.posZ);
     }
 
+    public void teleportRest(double x, double y, double z, double vx, double vy, double vz) {
+        this.setPosition(x, y, z);
+        this.motionX = vx;
+        this.motionY = vy;
+        this.motionZ = vz;
+        this.onGround = true;
+        this.isCollidedHorizontally = false;
+        this.setSprinting(false);
+        this.setSneaking(false);
+        this.sprintState = PlayerSprintMachine.State.initial();
+        this.jumpTicks = 0;
+        this.isInWeb = false;
+        this.fallDistance = 0;
+    }
+
     public static void applyCheckpoint(EntityLivingBase p, de.legoshi.parkourcalc.core.sim.Checkpoint state) {
         Checkpoint c = de.legoshi.parkourcalc.forge8.sim.paired.PairedCheckpoint.clientPart(state);
         if (c == null) return;


### PR DESCRIPTION
Onejump courses teleport the player between single-jump pads. Ticks can now carry a teleport destination that both the simulation and the replay honor: at a marked tick the player is forced to the given X/Y/Z, X and Z velocity are cleared, and Y velocity resets to `GROUND_REST_VELOCITY`.

- New per-tick teleport destination on `InputRow`, distinct from the existing "Teleport player to tick" navigation feature (they share no state). Edited in the per-tick context menu with an enable toggle, X/Y/Z inputs, and a button that reads the player's current position through the `MinecraftAccess` port.
- Applied in both the sim (`SimulationRunner`) and the replay (`PlaybackController`) before that tick's inputs, so the boxes and the replay agree; reuses the existing `PlaybackBridge.teleport`.
- Round-trips through the save schema (old saves load as no teleport). A transient "Teleported" HUD notice fades under the MACRO badge, in all four loaders.
- Core stays Minecraft-free.

Testing: `:core:build`, `:core:test -PslowTests` (plus new `TeleportTickSimTest` and save round-trip), and all four loaders compile.

QA needed: confirm the mid-replay teleport does not trip the lockstep "moved wrongly" guard, and that the HUD notice appears and fades.

Closes #438
