### PR TITLE
feat: list Fast and Optimize as built-in graph presets in Custom

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/AngleSolverState.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/AngleSolverState.java
@@ -136,7 +136,7 @@ public final class AngleSolverState {
     private double customAngleDeg = 0.0;
     private CustomAngleType customAngleType = CustomAngleType.POSITION;
     private Effort effort = Effort.FAST;
-    private boolean stopOnFeasible;
+    private boolean stopOnFeasible = true;
     private boolean legalMode;
     private int optimizeSeconds = DEFAULT_OPTIMIZE_SECONDS;
     public static final double TASER_SMOOTH_LAMBDA = 1.0e-2;
@@ -729,7 +729,7 @@ public final class AngleSolverState {
         customAngleDeg = 0.0;
         customAngleType = CustomAngleType.POSITION;
         effort = Effort.FAST;
-        stopOnFeasible = false;
+        stopOnFeasible = true;
         legalMode = false;
         optimizeSeconds = DEFAULT_OPTIMIZE_SECONDS;
         solveBudget.resetToDefaults();

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/BuiltinGraphs.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/BuiltinGraphs.java
@@ -4,15 +4,22 @@ public final class BuiltinGraphs {
 
     public static final int IMPROVE_TICK_CAP = 256;
 
+    public static final String FAST_PRESET = "Fast";
+    public static final String OPTIMIZE_PRESET = "Optimize";
+
     private BuiltinGraphs() {
     }
 
+    public static boolean isBuiltinPreset(String name) {
+        return FAST_PRESET.equals(name) || OPTIMIZE_PRESET.equals(name);
+    }
+
     public static SolverGraph fast() {
-        return build("Fast", 10, 3, 0);
+        return build(FAST_PRESET, 10, 3, 0);
     }
 
     public static SolverGraph optimize(int optimizeSeconds) {
-        return build("Optimize", 10, 3, optimizeSeconds > 0 ? optimizeSeconds : 120);
+        return build(OPTIMIZE_PRESET, 10, 3, optimizeSeconds > 0 ? optimizeSeconds : 120);
     }
 
     public static SolverGraph fromBudget(boolean stopOnFeasible, boolean ilsExhaustive,

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/GraphFactory.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/GraphFactory.java
@@ -16,6 +16,9 @@ public final class GraphFactory {
             case THOROUGH:
                 return BuiltinGraphs.optimize(state.getOptimizeSeconds());
             case CUSTOM: {
+                String preset = state.getGraphPresetName();
+                if (BuiltinGraphs.FAST_PRESET.equals(preset)) return BuiltinGraphs.fast();
+                if (BuiltinGraphs.OPTIMIZE_PRESET.equals(preset)) return BuiltinGraphs.optimize(state.getOptimizeSeconds());
                 SolverGraph user = state.getCustomGraph();
                 return user != null ? user : legacyCustom(state);
             }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverWindow.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverWindow.java
@@ -7,6 +7,7 @@ import de.legoshi.parkourcalc.core.anglesolver.Potion;
 import de.legoshi.parkourcalc.core.anglesolver.PotionDose;
 import de.legoshi.parkourcalc.core.anglesolver.Slipperiness;
 import de.legoshi.parkourcalc.core.anglesolver.SolveResult;
+import de.legoshi.parkourcalc.core.anglesolver.graph.BuiltinGraphs;
 import de.legoshi.parkourcalc.core.anglesolver.graph.GraphFactory;
 import de.legoshi.parkourcalc.core.anglesolver.graph.GraphPresetFile;
 import de.legoshi.parkourcalc.core.anglesolver.graph.GraphPresetIO;
@@ -65,6 +66,9 @@ public final class AngleSolverWindow implements RenderInterface {
                     + "make a solvable segment report no solution until the route is re-recorded."};
     private static final String[] EFFORTS = {"Fast", "Optimize", "Custom"};
     private static final String LEGACY_PRESET_ITEM = "Legacy budget";
+    private static final String FAST_PRESET_ITEM = BuiltinGraphs.FAST_PRESET;
+    private static final String OPTIMIZE_PRESET_ITEM = BuiltinGraphs.OPTIMIZE_PRESET;
+    private static final int BUILTIN_PRESET_COUNT = 2;
 
     private static final String[] FORM_LABELS =
             {"Start tick", "Goal tick", "Axis", "Goal", "Target angle", "Inputs", "Sprint", "Slipperiness", "Potion",
@@ -720,13 +724,25 @@ public final class AngleSolverWindow implements RenderInterface {
         if (presetNames == null) refreshPresets();
 
         String current = state.getGraphPresetName();
-        int currentIdx = indexOfPreset(current);
-        boolean missing = current != null && currentIdx < 0;
-        String[] items = new String[presetNames.length + (missing ? 2 : 1)];
-        items[0] = LEGACY_PRESET_ITEM;
-        System.arraycopy(presetNames, 0, items, 1, presetNames.length);
-        if (missing) items[items.length - 1] = current + " (missing)";
-        int selected = current == null ? 0 : (missing ? items.length - 1 : currentIdx + 1);
+        int diskIdx = indexOfPreset(current);
+        boolean builtinFast = FAST_PRESET_ITEM.equals(current);
+        boolean builtinOptimize = OPTIMIZE_PRESET_ITEM.equals(current);
+        boolean missing = current != null && !builtinFast && !builtinOptimize && diskIdx < 0;
+
+        int legacyIdx = BUILTIN_PRESET_COUNT + presetNames.length;
+        String[] items = new String[legacyIdx + 1 + (missing ? 1 : 0)];
+        items[0] = FAST_PRESET_ITEM;
+        items[1] = OPTIMIZE_PRESET_ITEM;
+        System.arraycopy(presetNames, 0, items, BUILTIN_PRESET_COUNT, presetNames.length);
+        items[legacyIdx] = LEGACY_PRESET_ITEM;
+        if (missing) items[legacyIdx + 1] = current + " (missing)";
+
+        int selected;
+        if (current == null) selected = legacyIdx;
+        else if (builtinFast) selected = 0;
+        else if (builtinOptimize) selected = 1;
+        else if (diskIdx >= 0) selected = BUILTIN_PRESET_COUNT + diskIdx;
+        else selected = legacyIdx + 1;
 
         Controls.pushInputFrameHeight();
         ImGui.beginGroup();
@@ -735,13 +751,10 @@ public final class AngleSolverWindow implements RenderInterface {
         ImGui.setNextItemWidth(ImGui.getContentRegionAvail().x);
         if (Controls.combo("##graphPreset", presetBuf, items)) {
             int pick = presetBuf.get();
-            if (pick == 0) {
-                state.setGraphPresetName(null);
-                state.setCustomGraph(null);
-                presetError = null;
-            } else if (pick <= presetNames.length) {
-                selectPreset(presetNames[pick - 1]);
-            }
+            if (pick == 0) selectBuiltinPreset(FAST_PRESET_ITEM);
+            else if (pick == 1) selectBuiltinPreset(OPTIMIZE_PRESET_ITEM);
+            else if (pick < legacyIdx) selectPreset(presetNames[pick - BUILTIN_PRESET_COUNT]);
+            else if (pick == legacyIdx) selectLegacyBudget();
         }
         ImGui.endGroup();
         Controls.popInputFrameHeight();
@@ -785,17 +798,33 @@ public final class AngleSolverWindow implements RenderInterface {
     }
 
     private static final String PRESET_TIP =
-            "Which solver graph a Custom solve runs. Legacy budget rebuilds the graph from this save's"
-            + " Custom knobs, matching the pre-preset behavior byte for byte. Presets are JSON files under"
-            + " parkourcalculator/graphs/ in the game folder: save the current graph, hand-edit the file,"
-            + " then Reload to pick up the changes. The selected preset name travels with the save file.";
+            "Which solver graph a Custom solve runs. Fast and Optimize are the built-in graphs the effort tiers"
+            + " use; they cannot be overwritten, but Duplicate copies one into an editable preset. Legacy budget"
+            + " rebuilds the graph from this save's Custom knobs, matching the pre-preset behavior byte for byte."
+            + " User presets are JSON files under parkourcalculator/graphs/ in the game folder: save the current"
+            + " graph, hand-edit the file, then Reload to pick up the changes. The selected preset name travels"
+            + " with the save file.";
 
     private void refreshPresets() {
         List<SaveInfo> infos = graphStore.list();
-        String[] names = new String[infos.size()];
-        for (int i = 0; i < infos.size(); i++) names[i] = infos.get(i).name;
-        Arrays.sort(names);
-        presetNames = names;
+        List<String> names = new ArrayList<>();
+        for (SaveInfo info : infos) {
+            if (!BuiltinGraphs.isBuiltinPreset(info.name)) names.add(info.name);
+        }
+        Collections.sort(names);
+        presetNames = names.toArray(new String[0]);
+    }
+
+    private void selectBuiltinPreset(String name) {
+        state.setGraphPresetName(name);
+        state.setCustomGraph(null);
+        presetError = null;
+    }
+
+    private void selectLegacyBudget() {
+        state.setGraphPresetName(null);
+        state.setCustomGraph(null);
+        presetError = null;
     }
 
     private int indexOfPreset(String name) {
@@ -818,8 +847,7 @@ public final class AngleSolverWindow implements RenderInterface {
     }
 
     private SolverGraph currentCustomGraph() {
-        SolverGraph graph = state.getCustomGraph();
-        return graph != null ? graph : GraphFactory.legacyCustom(state);
+        return GraphFactory.forState(state, AngleSolverState.Effort.CUSTOM);
     }
 
     private void savePresetAs() {
@@ -842,6 +870,10 @@ public final class AngleSolverWindow implements RenderInterface {
     }
 
     boolean writePreset(String name, SolverGraph graph) {
+        if (BuiltinGraphs.isBuiltinPreset(name)) {
+            presetError = "\"" + name + "\" is a built-in preset. Choose another name.";
+            return false;
+        }
         GraphPresetFile file = GraphPresetIO.fromGraph(graph);
         file.name = name;
         file.createdAt = SaveIO.nowIso8601();

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverWindow.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverWindow.java
@@ -65,7 +65,6 @@ public final class AngleSolverWindow implements RenderInterface {
                     + "sprint from that tick on, and the solve inherits it, so a broken path can\n"
                     + "make a solvable segment report no solution until the route is re-recorded."};
     private static final String[] EFFORTS = {"Fast", "Optimize", "Custom"};
-    private static final String LEGACY_PRESET_ITEM = "Legacy budget";
     private static final String FAST_PRESET_ITEM = BuiltinGraphs.FAST_PRESET;
     private static final String OPTIMIZE_PRESET_ITEM = BuiltinGraphs.OPTIMIZE_PRESET;
     private static final int BUILTIN_PRESET_COUNT = 2;
@@ -725,24 +724,21 @@ public final class AngleSolverWindow implements RenderInterface {
 
         String current = state.getGraphPresetName();
         int diskIdx = indexOfPreset(current);
-        boolean builtinFast = FAST_PRESET_ITEM.equals(current);
         boolean builtinOptimize = OPTIMIZE_PRESET_ITEM.equals(current);
-        boolean missing = current != null && !builtinFast && !builtinOptimize && diskIdx < 0;
+        boolean missing = current != null && !FAST_PRESET_ITEM.equals(current) && !builtinOptimize && diskIdx < 0;
 
-        int legacyIdx = BUILTIN_PRESET_COUNT + presetNames.length;
-        String[] items = new String[legacyIdx + 1 + (missing ? 1 : 0)];
+        String[] items = new String[BUILTIN_PRESET_COUNT + presetNames.length + (missing ? 1 : 0)];
         items[0] = FAST_PRESET_ITEM;
         items[1] = OPTIMIZE_PRESET_ITEM;
         System.arraycopy(presetNames, 0, items, BUILTIN_PRESET_COUNT, presetNames.length);
-        items[legacyIdx] = LEGACY_PRESET_ITEM;
-        if (missing) items[legacyIdx + 1] = current + " (missing)";
+        int missingIdx = items.length - 1;
+        if (missing) items[missingIdx] = current + " (missing)";
 
         int selected;
-        if (current == null) selected = legacyIdx;
-        else if (builtinFast) selected = 0;
-        else if (builtinOptimize) selected = 1;
+        if (builtinOptimize) selected = 1;
         else if (diskIdx >= 0) selected = BUILTIN_PRESET_COUNT + diskIdx;
-        else selected = legacyIdx + 1;
+        else if (missing) selected = missingIdx;
+        else selected = 0;
 
         Controls.pushInputFrameHeight();
         ImGui.beginGroup();
@@ -753,8 +749,7 @@ public final class AngleSolverWindow implements RenderInterface {
             int pick = presetBuf.get();
             if (pick == 0) selectBuiltinPreset(FAST_PRESET_ITEM);
             else if (pick == 1) selectBuiltinPreset(OPTIMIZE_PRESET_ITEM);
-            else if (pick < legacyIdx) selectPreset(presetNames[pick - BUILTIN_PRESET_COUNT]);
-            else if (pick == legacyIdx) selectLegacyBudget();
+            else if (pick < BUILTIN_PRESET_COUNT + presetNames.length) selectPreset(presetNames[pick - BUILTIN_PRESET_COUNT]);
         }
         ImGui.endGroup();
         Controls.popInputFrameHeight();
@@ -784,7 +779,7 @@ public final class AngleSolverWindow implements RenderInterface {
                 graphEditor.open(currentCustomGraph(),
                         state.getCustomGraph() != null ? state.getGraphPresetName() : null);
             }
-            TooltipUtil.onHover("Edit the selected graph on a node canvas. Legacy budget opens as an"
+            TooltipUtil.onHover("Edit the selected graph on a node canvas. A built-in opens as an"
                     + " unsaved draft; save it under a name to keep changes.");
         } else {
             Controls.disabledButton("Open editor");
@@ -799,11 +794,10 @@ public final class AngleSolverWindow implements RenderInterface {
 
     private static final String PRESET_TIP =
             "Which solver graph a Custom solve runs. Fast and Optimize are the built-in graphs the effort tiers"
-            + " use; they cannot be overwritten, but Duplicate copies one into an editable preset. Legacy budget"
-            + " rebuilds the graph from this save's Custom knobs, matching the pre-preset behavior byte for byte."
-            + " User presets are JSON files under parkourcalculator/graphs/ in the game folder: save the current"
-            + " graph, hand-edit the file, then Reload to pick up the changes. The selected preset name travels"
-            + " with the save file.";
+            + " use; they cannot be overwritten, but Duplicate copies one into an editable preset. User presets"
+            + " are JSON files under parkourcalculator/graphs/ in the game folder: save the current graph,"
+            + " hand-edit the file, then Reload to pick up the changes. The selected preset name travels with"
+            + " the save file.";
 
     private void refreshPresets() {
         List<SaveInfo> infos = graphStore.list();
@@ -817,12 +811,6 @@ public final class AngleSolverWindow implements RenderInterface {
 
     private void selectBuiltinPreset(String name) {
         state.setGraphPresetName(name);
-        state.setCustomGraph(null);
-        presetError = null;
-    }
-
-    private void selectLegacyBudget() {
-        state.setGraphPresetName(null);
         state.setCustomGraph(null);
         presetError = null;
     }

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/graph/BuiltinPresetSelectionTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/graph/BuiltinPresetSelectionTest.java
@@ -1,0 +1,67 @@
+package de.legoshi.parkourcalc.anglesolver.graph;
+
+import de.legoshi.parkourcalc.core.anglesolver.AngleSolverState;
+import de.legoshi.parkourcalc.core.anglesolver.graph.BuiltinGraphs;
+import de.legoshi.parkourcalc.core.anglesolver.graph.GraphFactory;
+import de.legoshi.parkourcalc.core.anglesolver.graph.GraphPresetFile;
+import de.legoshi.parkourcalc.core.anglesolver.graph.GraphPresetIO;
+import de.legoshi.parkourcalc.core.anglesolver.graph.SolverGraph;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class BuiltinPresetSelectionTest {
+
+    private static String json(SolverGraph g) {
+        return GraphPresetIO.toJson(GraphPresetIO.fromGraph(g));
+    }
+
+    private static String shape(SolverGraph g) {
+        GraphPresetFile f = GraphPresetIO.fromGraph(g);
+        f.name = "";
+        return GraphPresetIO.toJson(f);
+    }
+
+    @Test
+    public void freshCustomStopsOnFeasibleByDefault() {
+        assertTrue("fresh Custom must match Fast's stop-on-feasible", new AngleSolverState().isStopOnFeasible());
+    }
+
+    @Test
+    public void freshCustomBuildsTheFastGraphShape() {
+        AngleSolverState s = new AngleSolverState();
+        s.setEffort(AngleSolverState.Effort.CUSTOM);
+        assertEquals(shape(BuiltinGraphs.fast()), shape(GraphFactory.forState(s)));
+    }
+
+    @Test
+    public void selectingTheFastBuiltinBuildsFast() {
+        AngleSolverState s = new AngleSolverState();
+        s.setEffort(AngleSolverState.Effort.CUSTOM);
+        s.setGraphPresetName(BuiltinGraphs.FAST_PRESET);
+        assertEquals(json(BuiltinGraphs.fast()), json(GraphFactory.forState(s)));
+    }
+
+    @Test
+    public void selectingTheOptimizeBuiltinBuildsOptimizeWithTheStateSeconds() {
+        AngleSolverState s = new AngleSolverState();
+        s.setEffort(AngleSolverState.Effort.CUSTOM);
+        s.setGraphPresetName(BuiltinGraphs.OPTIMIZE_PRESET);
+        s.setOptimizeSeconds(45);
+        assertEquals(json(BuiltinGraphs.optimize(45)), json(GraphFactory.forState(s)));
+        s.setOptimizeSeconds(120);
+        assertEquals(json(BuiltinGraphs.optimize(120)), json(GraphFactory.forState(s)));
+    }
+
+    @Test
+    public void recordedNonDefaultBudgetKeepsItsLegacyGraph() {
+        AngleSolverState s = new AngleSolverState();
+        s.setEffort(AngleSolverState.Effort.CUSTOM);
+        s.getSolveBudget().setWindow(12);
+        s.getSolveBudget().setCommit(4);
+        s.getSolveBudget().setTimeBudgetSeconds(60);
+        assertEquals(json(BuiltinGraphs.fromBudget(true, false, true, 12, 4, 60)),
+                json(GraphFactory.forState(s)));
+    }
+}


### PR DESCRIPTION
The Custom effort's Preset combo now lists the built-in Fast and Optimize graphs ahead of the user disk presets; selecting one runs that exact built-in graph, resolved by name in `GraphFactory` so it survives save and load.

- Built-ins cannot be overwritten: saving under a built-in name is rejected, disk files shadowing a built-in name are hidden, and Duplicate copies the built-in into a new editable disk preset.
- A fresh Custom state now equals Fast exactly. Note: the graph a fresh Custom built was already structurally identical to `fast()` (the ticket's parameter table was stale, since `fromBudget`'s stop-on-feasible / ILS / window args are ignored by `BuiltinGraphs.build`); the only real gap was the engine's `stopOnFeasible` flag for Custom, which now defaults on.
- Back-compat: a save carrying a recorded `customBudget` has a null preset name and resolves through the unchanged legacy mapping to the same graph it built before, and stop-on-feasible for loaded saves comes from the save, not the new default.

Testing: `:core:build`, `:core:test -PslowTests`, and `:core:test -PverySlowTests` (PipelineShapeTest one-solve-path guard + CertifiedBnbEngineTest) all green, confirming the named Fast/Optimize tiers are byte-unchanged. New `BuiltinPresetSelectionTest`.

Closes #336
