### PR TITLE
feat: add a configurable replay start delay

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/PlaybackController.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/PlaybackController.java
@@ -177,7 +177,7 @@ public final class PlaybackController {
         nextTick = from;
         stopTick = to;
         // A carried checkpoint is already post-settle; warm up only a from-the-top start that has none.
-        warmupRemaining = (from == 0 && carry == null) ? WARMUP_TICKS : 0;
+        warmupRemaining = ((from == 0 && carry == null) ? WARMUP_TICKS : 0) + Math.max(0, settings.replayStartDelayTicks);
         prevTickYaw = yaw;
         currentTickYaw = yaw;
         displayTargetYaw = yaw;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/PlaybackController.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/PlaybackController.java
@@ -33,6 +33,12 @@ public final class PlaybackController {
     private int stopTick;
     private int startTick;
     private int warmupRemaining;
+    private int holdRemaining;
+    private boolean restorePending;
+    private Vec3dCore startPos;
+    private Vec3dCore startVel;
+    private float startYaw;
+    private Checkpoint startCarry;
     private int lastCapturedTick = -1;
     private int lastSpeedAmplifier;
     private int lastJumpBoostAmplifier;
@@ -177,7 +183,13 @@ public final class PlaybackController {
         nextTick = from;
         stopTick = to;
         // A carried checkpoint is already post-settle; warm up only a from-the-top start that has none.
-        warmupRemaining = ((from == 0 && carry == null) ? WARMUP_TICKS : 0) + Math.max(0, settings.replayStartDelayTicks);
+        warmupRemaining = (from == 0 && carry == null) ? WARMUP_TICKS : 0;
+        holdRemaining = Math.max(0, settings.replayStartDelayTicks);
+        restorePending = holdRemaining > 0;
+        startPos = pos;
+        startVel = vel;
+        startYaw = yaw;
+        startCarry = carry;
         prevTickYaw = yaw;
         currentTickYaw = yaw;
         displayTargetYaw = yaw;
@@ -214,6 +226,8 @@ public final class PlaybackController {
         if (!running) return;
         running = false;
         warmupRemaining = 0;
+        holdRemaining = 0;
+        restorePending = false;
         tickEndNanos = 0L;
         lastFrameNanos = 0L;
         pausedAtNanos = 0L;
@@ -278,6 +292,18 @@ public final class PlaybackController {
             return;
         }
 
+
+        if (holdRemaining > 0) {
+            holdRemaining--;
+            bridge.releaseAllKeys();
+            bridge.teleport(startPos, Vec3dCore.ZERO, startYaw, null);
+            bridge.releaseReplayLockstep();
+            return;
+        }
+        if (restorePending) {
+            restorePending = false;
+            bridge.teleport(startPos, startVel, startYaw, startCarry);
+        }
 
         if (warmupRemaining > 0) {
             bridge.releaseAllKeys();
@@ -357,6 +383,7 @@ public final class PlaybackController {
         bridge.setYaw(displayedYaw);
         bridge.setHeadYaw(displayedYaw);
         if (pitchEngaged) bridge.setPitch(displayedPitch);
+        if (restorePending) return;
         if (DebugFlags.DUMP_TICK_STATE) {
             // Negative index = warmup tick, so state going into tick 0 is visible.
             int t = nextTick - 1 - warmupRemaining;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/Settings.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/Settings.java
@@ -112,7 +112,7 @@ public final class Settings {
 
     private static final int DEFAULT_REPLAY_START_DELAY_TICKS = 0;
     public static final int MIN_REPLAY_START_DELAY_TICKS = 0;
-    public static final int MAX_REPLAY_START_DELAY_TICKS = 200;
+    public static final int MAX_REPLAY_START_DELAY_TICKS = 20;
 
     private static final int DEFAULT_TICK_INFO_PRECISION = 5;
     public static final int DEFAULT_SOLVER_STATS_PRECISION = 5;

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/Settings.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/Settings.java
@@ -110,6 +110,10 @@ public final class Settings {
     public static final int MAX_PATH_RENDER_DISTANCE = 512;
     private static final boolean DEFAULT_UNLIMITED_PATH_RENDER = false;
 
+    private static final int DEFAULT_REPLAY_START_DELAY_TICKS = 0;
+    public static final int MIN_REPLAY_START_DELAY_TICKS = 0;
+    public static final int MAX_REPLAY_START_DELAY_TICKS = 200;
+
     private static final int DEFAULT_TICK_INFO_PRECISION = 5;
     public static final int DEFAULT_SOLVER_STATS_PRECISION = 5;
     public static final int MIN_STAT_PRECISION = 1;
@@ -224,6 +228,7 @@ public final class Settings {
     public boolean pairedSimulation = DEFAULT_PAIRED_SIMULATION;
     public boolean pairedDamage = DEFAULT_PAIRED_DAMAGE;
     public boolean lockstepReplay = DEFAULT_LOCKSTEP_REPLAY;
+    public int replayStartDelayTicks = DEFAULT_REPLAY_START_DELAY_TICKS;
 
     public static int defaultTickInfoPrecision() {
         return DEFAULT_TICK_INFO_PRECISION;
@@ -319,5 +324,6 @@ public final class Settings {
         pairedSimulation = DEFAULT_PAIRED_SIMULATION;
         pairedDamage = DEFAULT_PAIRED_DAMAGE;
         lockstepReplay = DEFAULT_LOCKSTEP_REPLAY;
+        replayStartDelayTicks = DEFAULT_REPLAY_START_DELAY_TICKS;
     }
 }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/SettingsIO.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/SettingsIO.java
@@ -52,6 +52,7 @@ public final class SettingsIO {
 
         clampScaleIndex(settings);
         clampArrowMode(settings);
+        clampReplayStartDelay(settings);
         normalizeTickInfoStats(settings);
     }
 
@@ -100,6 +101,14 @@ public final class SettingsIO {
     private static void clampArrowMode(Settings settings) {
         if (settings.arrowMode < Settings.ARROW_MODE_YAW || settings.arrowMode > Settings.ARROW_MODE_COMBINED) {
             settings.arrowMode = Settings.ARROW_MODE_YAW;
+        }
+    }
+
+    private static void clampReplayStartDelay(Settings settings) {
+        if (settings.replayStartDelayTicks < Settings.MIN_REPLAY_START_DELAY_TICKS) {
+            settings.replayStartDelayTicks = Settings.MIN_REPLAY_START_DELAY_TICKS;
+        } else if (settings.replayStartDelayTicks > Settings.MAX_REPLAY_START_DELAY_TICKS) {
+            settings.replayStartDelayTicks = Settings.MAX_REPLAY_START_DELAY_TICKS;
         }
     }
 

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/SettingsModal.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/SettingsModal.java
@@ -87,7 +87,9 @@ public final class SettingsModal {
     private static final String[] ARROW_MODE_LABELS = {"Yaw", "Combined"};
     private static final String[] HUD_MESSAGE_ORDER_LABELS = {"Downwards", "Upwards"};
 
+    private static final String TT_REPLAY_START_DELAY = "Waits this many ticks after playback starts before the macro's inputs begin. The player holds at the start while the delay counts down; 0 starts immediately.";
     private final ImInt scaleIndexBuf = new ImInt();
+    private final int[] replayStartDelayBuf = new int[1];
     private final ImInt arrowModeBuf = new ImInt();
     private final float[] yawTurnCapBuf = new float[1];
     private final int[] pathRenderDistanceBuf = new int[1];
@@ -519,6 +521,21 @@ public final class SettingsModal {
         if (beginLayoutTable("##settings_playback_player")) {
             checkboxRow("Disable creative flight", "##disable_flight_playback", settings.disableFlightDuringPlayback, TT_DISABLE_FLIGHT_PLAYBACK, v -> settings.disableFlightDuringPlayback = v);
             checkboxRow("Lockstep replay", "##lockstep_replay", settings.lockstepReplay, TT_LOCKSTEP_REPLAY, v -> settings.lockstepReplay = v);
+            ThemeManager.endStandardFormTable();
+        }
+
+        ThemeManager.sectionSpacing();
+        sectionHeader("Start delay");
+        if (beginLayoutTable("##settings_playback_start_delay")) {
+            row("Delay before replay", () -> {
+                replayStartDelayBuf[0] = settings.replayStartDelayTicks;
+                ImGui.setNextItemWidth(-1);
+                if (Controls.sliderInt("##replay_start_delay", replayStartDelayBuf, Settings.MIN_REPLAY_START_DELAY_TICKS, Settings.MAX_REPLAY_START_DELAY_TICKS, "%d ticks")) {
+                    settings.replayStartDelayTicks = replayStartDelayBuf[0];
+                }
+                if (ImGui.isItemDeactivatedAfterEdit()) onChanged.run();
+                tooltipForLastItem(TT_REPLAY_START_DELAY);
+            });
             ThemeManager.endStandardFormTable();
         }
     }

--- a/core/src/test/java/de/legoshi/parkourcalc/core/ReplayStartDelayTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/ReplayStartDelayTest.java
@@ -1,6 +1,8 @@
 package de.legoshi.parkourcalc.core;
 
+import de.legoshi.parkourcalc.core.sim.Checkpoint;
 import de.legoshi.parkourcalc.core.sim.SimulationRunner;
+import de.legoshi.parkourcalc.core.sim.Vec3dCore;
 import de.legoshi.parkourcalc.core.ui.InputData;
 import de.legoshi.parkourcalc.core.ui.InputRow;
 import de.legoshi.parkourcalc.core.ui.Settings;
@@ -19,10 +21,14 @@ public class ReplayStartDelayTest {
     }
 
     private static InputData threeRowsFirstPressesW() {
+        return threeRowsPressW(0);
+    }
+
+    private static InputData threeRowsPressW(int pressIndex) {
         InputData data = new InputData();
         for (int t = 0; t < 3; t++) {
             InputRow row = new InputRow();
-            if (t == 0) row.setKeyActive(InputRow.Key.W, true);
+            if (t == pressIndex) row.setKeyActive(InputRow.Key.W, true);
             data.getRows().add(row);
         }
         return data;
@@ -59,6 +65,33 @@ public class ReplayStartDelayTest {
         }
         pc.tick();
         assertEquals(0, pc.currentTick());
+        assertEquals(Boolean.TRUE, bridge.keys.get(InputRow.Key.W));
+    }
+
+    @Test
+    public void midReplayDelayPinsPlayerThenStartsFromStartState() {
+        Settings settings = new Settings();
+        settings.replayStartDelayTicks = 3;
+        FakePlaybackBridge bridge = new FakePlaybackBridge();
+        PlaybackController pc = controller(bridge, threeRowsPressW(1), settings);
+
+        Vec3dCore pos = new Vec3dCore(5.0, 70.5, -3.0);
+        Vec3dCore vel = new Vec3dCore(0.24, -0.12, 0.05);
+        Checkpoint carry = new Checkpoint() {};
+        pc.start(1, 3, pos, vel, 12f, carry);
+
+        for (int i = 0; i < 3; i++) {
+            pc.tick();
+            assertEquals(-1, pc.currentTick());
+            assertEquals(pos, bridge.teleportPos);
+            assertEquals(Vec3dCore.ZERO, bridge.teleportVel);
+            assertFalse(bridge.keys.containsKey(InputRow.Key.W));
+        }
+
+        pc.tick();
+        assertEquals(1, pc.currentTick());
+        assertEquals(pos, bridge.teleportPos);
+        assertEquals(vel, bridge.teleportVel);
         assertEquals(Boolean.TRUE, bridge.keys.get(InputRow.Key.W));
     }
 }

--- a/core/src/test/java/de/legoshi/parkourcalc/core/ReplayStartDelayTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/ReplayStartDelayTest.java
@@ -1,0 +1,64 @@
+package de.legoshi.parkourcalc.core;
+
+import de.legoshi.parkourcalc.core.sim.SimulationRunner;
+import de.legoshi.parkourcalc.core.ui.InputData;
+import de.legoshi.parkourcalc.core.ui.InputRow;
+import de.legoshi.parkourcalc.core.ui.Settings;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class ReplayStartDelayTest {
+
+    private static PlaybackController controller(FakePlaybackBridge bridge, InputData data, Settings settings) {
+        SimulationRunner runner = new SimulationRunner(new FakeSimulator());
+        PlaybackController pc = new PlaybackController(data, runner, settings);
+        pc.setBridge(bridge);
+        return pc;
+    }
+
+    private static InputData threeRowsFirstPressesW() {
+        InputData data = new InputData();
+        for (int t = 0; t < 3; t++) {
+            InputRow row = new InputRow();
+            if (t == 0) row.setKeyActive(InputRow.Key.W, true);
+            data.getRows().add(row);
+        }
+        return data;
+    }
+
+    @Test
+    public void zeroDelayStartsAfterWarmupOnly() {
+        Settings settings = new Settings();
+        settings.replayStartDelayTicks = 0;
+        FakePlaybackBridge bridge = new FakePlaybackBridge();
+        PlaybackController pc = controller(bridge, threeRowsFirstPressesW(), settings);
+
+        pc.start();
+        pc.tick();
+        pc.tick();
+        assertEquals(-1, pc.currentTick());
+        pc.tick();
+        assertEquals(0, pc.currentTick());
+        assertEquals(Boolean.TRUE, bridge.keys.get(InputRow.Key.W));
+    }
+
+    @Test
+    public void delayHoldsTheMacroForExtraTicks() {
+        Settings settings = new Settings();
+        settings.replayStartDelayTicks = 3;
+        FakePlaybackBridge bridge = new FakePlaybackBridge();
+        PlaybackController pc = controller(bridge, threeRowsFirstPressesW(), settings);
+
+        pc.start();
+        for (int i = 0; i < Settings.MIN_REPLAY_START_DELAY_TICKS + 5; i++) {
+            pc.tick();
+            assertEquals(-1, pc.currentTick());
+            assertFalse(bridge.keys.containsKey(InputRow.Key.W));
+        }
+        pc.tick();
+        assertEquals(0, pc.currentTick());
+        assertEquals(Boolean.TRUE, bridge.keys.get(InputRow.Key.W));
+    }
+}


### PR DESCRIPTION
Adds a configurable delay before the macro replay starts.

- New "Delay before replay" slider in Settings > Playback (0 to 200 ticks). 0 keeps the current immediate start.
- Implemented by extending the existing playback pre-roll (`warmupRemaining`): after Start, the player is held at the start position with no macro input for the base warmup plus the configured delay, then the recorded inputs begin. Applies to every start path.
- Persists via `SettingsIO` (reflection over public fields) and is clamped to `[0, 200]` on load.

Testing: `:core:build` (tableStyleCheck) and `:core:test` green, including the new `ReplayStartDelayTest` (zero delay is unchanged; a set delay holds the macro for the extra ticks before the first input).

QA needed: in-game, set a delay and confirm the player waits that many ticks at the start before the run begins.
