### PR TITLE
feat: show the in-game yaw in tick info

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/TickInfoPanel.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/TickInfoPanel.java
@@ -61,6 +61,13 @@ public final class TickInfoPanel implements RenderInterface {
         return p;
     }
 
+    private static float wrapDegrees(float value) {
+        float f = value % 360.0f;
+        if (f >= 180.0f) f -= 360.0f;
+        if (f < -180.0f) f += 360.0f;
+        return f;
+    }
+
     private static int clampPrecision(int p) {
         return Math.min(Math.max(p, Settings.MIN_STAT_PRECISION), Settings.MAX_STAT_PRECISION);
     }
@@ -185,6 +192,9 @@ public final class TickInfoPanel implements RenderInterface {
                 break;
             case YAW:
                 rowNum(stat.label(), appliedYaw, decimals, tip);
+                break;
+            case IN_GAME_YAW:
+                rowNum(stat.label(), wrapDegrees(appliedYaw), decimals, tip);
                 break;
             case PITCH:
                 rowNum(stat.label(), appliedPitch, decimals, tip);

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/TickInfoStat.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/TickInfoStat.java
@@ -6,6 +6,8 @@ public enum TickInfoStat {
             "Tick number (1-based), matching the input table's Tick column."),
     YAW("yaw", "Yaw", Kind.NUM,
             "Facing applied during this tick (drives this tick's movement). MC convention: 0 = +Z, increases CW looking down."),
+    IN_GAME_YAW("inGameYaw", "In-game yaw", Kind.NUM,
+            "Same facing as Yaw, wrapped to [-180, 180) as shown on the F3 debug screen. Drops the accumulated full turns."),
     PITCH("pitch", "Pitch", Kind.NUM,
             "Camera pitch held during this tick (-90 up, 90 down). Defaults to 40; each row adds a relative turn unless locked to an absolute value. Display only; pitch does not affect movement."),
     SPEED_XZ("speedXZ", "Speed (XZ)", Kind.NUM,


### PR DESCRIPTION
## What

Adds an **In-game yaw** row to the Tick Info panel. It shows the applied yaw wrapped to `[-180, 180)`, matching what the F3 debug screen displays, so long TASes no longer show accumulated multi-turn values (e.g. `3874`) when you only want the actual facing.

## Why

Closes #451. On long TASes the raw yaw can climb into the thousands of degrees, which isn't useful for reading the in-game facing at a glance.

## How

- New `IN_GAME_YAW` stat in `TickInfoStat` (right after `Yaw`), so it's auto-added to the stats config and reorderable/toggleable like every other row.
- `TickInfoPanel` renders it via a `wrapDegrees` helper that mirrors MC's `MathHelper.wrapDegrees` exactly (`[-180, 180)`).

Existing configs pick it up automatically through `TickInfoConfig.normalize` (appended, enabled).

## Modules

- [x] core

## QA

- `:core:test` (TickInfoConfigTest) green; `tableStyleCheck` clean.