### PR TITLE
feat: remove the slow polish stage from the run-ticks fast solve

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/RunTicksController.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/RunTicksController.java
@@ -7,6 +7,8 @@ import de.legoshi.parkourcalc.core.anglesolver.Slipperiness;
 import de.legoshi.parkourcalc.core.anglesolver.SolveResult;
 import de.legoshi.parkourcalc.core.anglesolver.StateOverride;
 import de.legoshi.parkourcalc.core.anglesolver.TickConstraints;
+import de.legoshi.parkourcalc.core.anglesolver.graph.BuiltinGraphs;
+import de.legoshi.parkourcalc.core.anglesolver.graph.SolverGraph;
 import de.legoshi.parkourcalc.core.anglesolver.runticks.RunTicksControls;
 import de.legoshi.parkourcalc.core.anglesolver.runticks.RunTicksFilter;
 import de.legoshi.parkourcalc.core.anglesolver.runticks.RunTicksRows;
@@ -31,6 +33,8 @@ public final class RunTicksController implements RunTicksControls {
     private static final InputRow.Key[] INHERITED_KEYS = {
             InputRow.Key.W, InputRow.Key.A, InputRow.Key.S, InputRow.Key.D, InputRow.Key.SPRINT
     };
+
+    private static final SolverGraph FAST_GRAPH = BuiltinGraphs.fastRunTicks();
 
     private enum Phase { IDLE, STEP, FINAL }
 
@@ -214,7 +218,7 @@ public final class RunTicksController implements RunTicksControls {
         applyStep(node);
         runSimulation.run();
         stepStartMs = now();
-        engine.solve(AngleSolverState.Effort.FAST, false);
+        engine.solve(AngleSolverState.Effort.FAST, false, FAST_GRAPH);
         phase = Phase.STEP;
     }
 
@@ -233,7 +237,7 @@ public final class RunTicksController implements RunTicksControls {
             }
             stepTimeoutMs = Math.max(settings().getTimeoutMs(), timeouts.forDepth(search.jumpCount()));
             stepStartMs = now();
-            engine.solve(AngleSolverState.Effort.FAST);
+            engine.solve(AngleSolverState.Effort.FAST, true, FAST_GRAPH);
             phase = Phase.FINAL;
             return;
         }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/AngleSolverEngine.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/AngleSolverEngine.java
@@ -349,6 +349,10 @@ public final class AngleSolverEngine {
      *  {@link #solve()} and exposed (via {@link #debugBuildSpec()}) so tests can obtain the exact compiled
      *  spec without spawning the worker / triggering the slow fallback. */
     private Job buildJob(AngleSolverState.Effort effort) {
+        return buildJob(effort, null);
+    }
+
+    private Job buildJob(AngleSolverState.Effort effort, SolverGraph graphOverride) {
         int startTick = state.getStartTick();
         int landingTick = state.getLandingTick();
         int total = segmentConstraintCount(startTick, landingTick);
@@ -408,7 +412,7 @@ public final class AngleSolverEngine {
                 ph.force45Mask, uiCons,
                 deadlineNanosFor(state, effort), longRunConfigFor(state, effort), useWindowSolverFor(state, effort),
                 stopOnFeasibleFor(state, effort), ilsExhaustiveFor(state, effort), legalGoal,
-                GraphFactory.forState(state, effort));
+                graphOverride != null ? graphOverride : GraphFactory.forState(state, effort));
     }
 
     public String legalGoalWallLabel() {
@@ -477,9 +481,13 @@ public final class AngleSolverEngine {
     }
 
     public void solve(AngleSolverState.Effort effort, boolean smoothFinal) {
+        solve(effort, smoothFinal, null);
+    }
+
+    public void solve(AngleSolverState.Effort effort, boolean smoothFinal, SolverGraph graphOverride) {
         if (solving) return;
         this.smoothFinalResult = smoothFinal;
-        Job job = buildJob(effort);
+        Job job = buildJob(effort, graphOverride);
         if (job == null) return; // invalid range: buildJob already published the failure result
 
         long t0 = System.nanoTime();

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/BuiltinGraphs.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/BuiltinGraphs.java
@@ -15,19 +15,23 @@ public final class BuiltinGraphs {
     }
 
     public static SolverGraph fast() {
-        return build(FAST_PRESET, 10, 3, 0);
+        return build(FAST_PRESET, 10, 3, 0, true);
+    }
+
+    public static SolverGraph fastRunTicks() {
+        return build("Fast (run ticks)", 10, 3, 0, false);
     }
 
     public static SolverGraph optimize(int optimizeSeconds) {
-        return build(OPTIMIZE_PRESET, 10, 3, optimizeSeconds > 0 ? optimizeSeconds : 120);
+        return build(OPTIMIZE_PRESET, 10, 3, optimizeSeconds > 0 ? optimizeSeconds : 120, true);
     }
 
     public static SolverGraph fromBudget(boolean stopOnFeasible, boolean ilsExhaustive,
                                          boolean useWindowSolver, int window, int commit, int timeBudgetSeconds) {
-        return build("Custom", window, commit, timeBudgetSeconds);
+        return build("Custom", window, commit, timeBudgetSeconds, true);
     }
 
-    private static SolverGraph build(String name, int window, int commit, int t) {
+    private static SolverGraph build(String name, int window, int commit, int t, boolean leafSnap) {
         boolean fastTier = t <= 0;
         int tp = fastTier ? 120 : t;
         long reserveNanos = fastTier ? 0L : GraphRunner.wrapReserveNanos(t * 1_000_000_000L);
@@ -85,8 +89,10 @@ public final class BuiltinGraphs {
                 .set("wrap", "budgetSec", fastTier ? 0 : tp)
                 .set("wrap", "minRemainingSec", 1);
         g.add("translate", "translatedStart");
-        g.add("snap", "leafSnap")
-                .set("snap", "pairPass", fastTier ? 0 : 1);
+        if (leafSnap) {
+            g.add("snap", "leafSnap")
+                    .set("snap", "pairPass", fastTier ? 0 : 1);
+        }
         g.add("emit", "emit");
 
         chain(g, "entry", "horizon");
@@ -104,8 +110,12 @@ public final class BuiltinGraphs {
         chain(g, "ils", "cap2");
         chain(g, "cap2", "wrap");
         chain(g, "wrap", "translate");
-        chain(g, "translate", "snap");
-        chain(g, "snap", "emit");
+        if (leafSnap) {
+            chain(g, "translate", "snap");
+            chain(g, "snap", "emit");
+        } else {
+            chain(g, "translate", "emit");
+        }
         return g.build();
     }
 

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/BuiltinGraphs.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/graph/BuiltinGraphs.java
@@ -15,23 +15,24 @@ public final class BuiltinGraphs {
     }
 
     public static SolverGraph fast() {
-        return build(FAST_PRESET, 10, 3, 0, true);
+        return build(FAST_PRESET, 10, 3, 0, false);
     }
 
     public static SolverGraph fastRunTicks() {
-        return build("Fast (run ticks)", 10, 3, 0, false);
+        return build("Fast (run ticks)", 10, 3, 0, true);
     }
 
     public static SolverGraph optimize(int optimizeSeconds) {
-        return build(OPTIMIZE_PRESET, 10, 3, optimizeSeconds > 0 ? optimizeSeconds : 120, true);
+        return build(OPTIMIZE_PRESET, 10, 3, optimizeSeconds > 0 ? optimizeSeconds : 120, false);
     }
 
     public static SolverGraph fromBudget(boolean stopOnFeasible, boolean ilsExhaustive,
                                          boolean useWindowSolver, int window, int commit, int timeBudgetSeconds) {
-        return build("Custom", window, commit, timeBudgetSeconds, true);
+        return build("Custom", window, commit, timeBudgetSeconds, false);
     }
 
-    private static SolverGraph build(String name, int window, int commit, int t, boolean leafSnap) {
+    private static SolverGraph build(String name, int window, int commit, int t, boolean runTicks) {
+        boolean leafSnap = !runTicks;
         boolean fastTier = t <= 0;
         int tp = fastTier ? 120 : t;
         long reserveNanos = fastTier ? 0L : GraphRunner.wrapReserveNanos(t * 1_000_000_000L);
@@ -95,10 +96,17 @@ public final class BuiltinGraphs {
         }
         g.add("emit", "emit");
 
-        chain(g, "entry", "horizon");
-        chain(g, "horizon", "wrap0");
-        chain(g, "wrap0", "seed");
-        chain(g, "seed", "cap1");
+        if (runTicks) {
+            chain(g, "entry", "seed");
+            chain(g, "seed", "horizon");
+            chain(g, "horizon", "wrap0");
+            chain(g, "wrap0", "cap1");
+        } else {
+            chain(g, "entry", "horizon");
+            chain(g, "horizon", "wrap0");
+            chain(g, "wrap0", "seed");
+            chain(g, "seed", "cap1");
+        }
         chain(g, "cap1", "freeRescue");
         chain(g, "freeRescue", "peel");
         chain(g, "peel", "freeImprove");


### PR DESCRIPTION
## What

The run-ticks bruteforcer now solves each candidate with a lean, reordered Fast graph: the deterministic seed runs first and the expensive stages are deferred or dropped.

Closes #439.

## Why

Run ticks only needs *any* facing sequence that satisfies the constraints, as fast as possible. On the release baseline (1.10.0) the 6-tick `runticks-test.json` solve finished with a 150ms step timeout. On dev it needed 500-750ms per step: a real regression.

Two causes, both measured on that exact save (5-jump `MAX Z`, 1.8.9):

1. **`recedingHorizon` runs first.** dev made the receding-horizon window solver the primary multi-jump seed. On this path it grinds **~600ms**, while the deterministic `dualChain` seed (closed form) solves the *same* path feasibly in **~7ms**. 1.10.0 used `dualChain` as the multi-jump seed; dev put `recedingHorizon` ahead of it.
2. **`leafSnap` polish.** Once a feasible facing exists, the leaf-snap stage kept snapping to the sine lattice / nudging the objective, eating the rest of the step budget (~100ms here, seconds on larger paths).

Per-node timing on the full 63-tick path:

```
fast (dev)   : recedingHorizon 884ms + leafSnap 91ms   = 1026ms
run-ticks    : dualChain seed 7ms (closed form)        =   10ms
```

## How

`BuiltinGraphs.build(...)` gained a `runTicks` flag; `BuiltinGraphs.fastRunTicks()` passes it. `fast()`/`optimize()`/`fromBudget()` pass `false`, so those graphs are byte-identical to before.

For the run-ticks graph:
- **Seed first.** Chain head is `entry -> seed -> horizon -> wrap0 -> cap1` (vs `entry -> horizon -> wrap0 -> seed`). `recedingHorizon` stays as a **fallback**: it returns NONE when a candidate already exists, so it only runs when the seed misses. `dualChain` returns feasible-or-null (never infeasible best-effort), so it never wrongly preempts the horizon.
- **No leaf snap** (`leafSnap = !runTicks`).
- Every rescue finder (`freeRescue`/`peel`/`freeImprove`/`fold`/`ladder`/`cert`/`bnb`) is retained; they self-skip on the feasible seed candidate. Dropping them regressed `df-chain-free-start` in an earlier attempt, so they stay.

`AngleSolverEngine.solve(effort, smoothFinal, graphOverride)` lets `RunTicksController` supply this graph for both the per-step and final solves.

## Measured

- `runticks-test.json` full path: **582ms -> 10ms** (under the 100ms goal, below the 1.10.0 150ms baseline).
- 16-capture parity sweep, `fast()` vs `fastRunTicks()`: **0 feasibility regressions** (incl. `df-chain-free-start`).

## Modules

- [x] core

## QA

- `:core:test -PslowTests -PverySlowTests` green (incl. `PipelineShapeTest`, `CertifiedBnbEngineTest`; `fast`/`optimize` graphs unchanged).
- In-game run-ticks QA on a touched loader still recommended before merge, since the applied result is now the pre-snap feasible facing.