### PR TITLE
fix: use 1.12.2 folded deg-to-rad in ExactJumpModel moveFlying

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/ExactJumpModel.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/solver/ExactJumpModel.java
@@ -52,16 +52,23 @@ public final class ExactJumpModel implements ForwardModel {
     private final boolean modern;
     /** 26.x Mth.sin/cos: double-indexed lookup into the regenerated table (see McSineTable.sinStep262). */
     private final boolean sine262;
+    private final boolean foldedInputRad;
 
     public ExactJumpModel(double inertiaThreshold, boolean perAxisInertia, boolean modern) {
         this(inertiaThreshold, perAxisInertia, modern, false);
     }
 
     public ExactJumpModel(double inertiaThreshold, boolean perAxisInertia, boolean modern, boolean sine262) {
+        this(inertiaThreshold, perAxisInertia, modern, sine262, false);
+    }
+
+    public ExactJumpModel(double inertiaThreshold, boolean perAxisInertia, boolean modern, boolean sine262,
+                          boolean foldedInputRad) {
         this.inertiaThreshold = inertiaThreshold;
         this.perAxisInertia = perAxisInertia;
         this.modern = modern;
         this.sine262 = sine262;
+        this.foldedInputRad = foldedInputRad;
     }
 
     private float tableSin(float rad) {
@@ -108,7 +115,7 @@ public final class ExactJumpModel implements ForwardModel {
      *  additionally runs the rewritten double-indexed sine lookup. */
     public static ExactJumpModel forMcVersion(String mcVersion) {
         if (mcVersion != null && mcVersion.startsWith("1.8")) return new ExactJumpModel(0.005, true, false);
-        if (mcVersion != null && mcVersion.startsWith("1.12")) return new ExactJumpModel(0.003, true, false);
+        if (mcVersion != null && mcVersion.startsWith("1.12")) return new ExactJumpModel(0.003, true, false, false, true);
         if (mcVersion != null && mcVersion.startsWith("1.21.3")) return new ExactJumpModel(0.003, true, true, false);
         boolean sine262 = mcVersion != null && !mcVersion.startsWith("1.");
         return new ExactJumpModel(0.003, false, true, sine262);
@@ -264,7 +271,7 @@ public final class ExactJumpModel implements ForwardModel {
                     fm = accelSpeed / fm;
                     strafe *= fm;
                     forward *= fm;
-                    float rad = yawF * (float) Math.PI / 180.0F;
+                    float rad = foldedInputRad ? yawF * (float) (Math.PI / 180.0) : yawF * (float) Math.PI / 180.0F;
                     float sinD = tableSin(rad);
                     float cosD = tableCos(rad);
                     vx += (double) (strafe * cosD - forward * sinD);


### PR DESCRIPTION
## Problem

On 1.12.2, applying an angle solve reported "Sim left the solved path at T…" on turns, and re-solving never cleared it. The resim (real `SimulatorEntity`) diverged from the collision-free `ExactJumpModel` by ~2e-6 in **X** starting at a single turn tick; the downstream wall clamp was a symptom, not the cause.

## Root cause

`ExactJumpModel`'s legacy `moveFlying` step computed yaw→rad as `yawF * (float)Math.PI / 180.0F`, i.e. `(yaw*PI)/180` (multiply then divide) — the pre-1.9 form. MC 1.12.2 `Entity.moveRelative` uses the folded constant `rotationYaw * 0.017453292F`. Float multiply is not associative, so the two differ by one ULP in `rad`; at yaws that land on a sine-table bucket boundary (e.g. −21.708984°) the LUT index flips (61584 vs 61585), so `sin(yaw)` comes out ~8.9e-5 off and X drifts ~2.3e-6. X uses `sin` and Z uses `cos`, so only X diverged. Present since the original angle optimizer (#122); it only bites on bucket-boundary yaws, hence rarely observed.

## Fix

Add a `foldedInputRad` flag on `ExactJumpModel`; legacy `moveFlying` uses `yawF * (float)(Math.PI/180.0)` (folded, `== 0.017453292F`) when set, else the pre-1.9 `(yaw*PI)/180F`. `forMcVersion` sets it for the `1.12` branch only. Defaults `false`, so 1.8.9, modern, and every existing construction stay byte-identical.

## Testing

- Verified against the reporting 1.12.2 capture: the model now matches the recorded resim byte-exact (`ddx=ddz=0`) through the turn; the deviation is gone (was diverging at the turn tick).
- `./gradlew :core:test -PslowTests` green.

## Scope notes

- Confirmed against decompiled sources that the `jump()` sprint-boost cast is **already correct** for both eras: 1.8.9 (`EntityLivingBase.jump` line 1139) and 1.12.2 both use the folded `0.017453292F`, and the model's jump branch already uses the folded form. `moveFlying`/`moveRelative` is the only version-dependent spot. (1.8.9 is internally inconsistent — jump folded, walk unfolded — and the model reproduces that.)
- No regression test yet — CI's `:core:test` never diffs the model against a real 1.12.2 turn trace, so this class slips through. Worth pinning with a `PlanRealizationRegressionTest`-style test seeded from the capture.
