### PR TITLE
feat: copy a tick as a teleport command

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
@@ -427,7 +427,8 @@ public final class Application {
             copyStartTeleportCommand();
             return;
         }
-        ImGui.setClipboardText(TeleportCommand.format(state.position, state.yaw, boxController.getPitch(row)));
+        ImGui.setClipboardText(TeleportCommand.format(state.position,
+                boxController.getAppliedYaw(row), boxController.getAppliedPitch(row)));
         pushHudMessage("Copied teleport for tick " + (row + 1));
     }
 

--- a/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
@@ -38,6 +38,7 @@ import de.legoshi.parkourcalc.core.ui.ServerEventLogPanel;
 import de.legoshi.parkourcalc.core.ui.TickInfoPanel;
 import de.legoshi.parkourcalc.core.ui.YawGizmoController;
 import de.legoshi.parkourcalc.core.ui.theme.HudMessageStyle;
+import de.legoshi.parkourcalc.core.ui.util.TeleportCommand;
 import de.legoshi.parkourcalc.core.anglesolver.AngleSolverEngine;
 import de.legoshi.parkourcalc.core.anglesolver.AngleSolverState;
 import de.legoshi.parkourcalc.core.anglesolver.BlockSelection;
@@ -55,6 +56,7 @@ import de.legoshi.parkourcalc.core.anglesolver.graph.GraphPresetIO;
 import de.legoshi.parkourcalc.core.anglesolver.graph.SolveRunLog;
 import de.legoshi.parkourcalc.core.anglesolver.solver.ExactJumpModel;
 import de.legoshi.parkourcalc.core.undo.UndoController;
+import imgui.ImGui;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -190,7 +192,7 @@ public final class Application {
         saveController.setDebugSource(boxController, settings);
         AngleSolverTable angleSolverTable = new AngleSolverTable(angleSolverState, settings, selection, constraintSelection, inputData::size);
         inputOverlay.setAngleSolver(angleSolverTable);
-        StartStateTable startStateTable = new StartStateTable(runner, () -> onUserChange(-1));
+        StartStateTable startStateTable = new StartStateTable(runner, () -> onUserChange(-1), this::copyStartTeleportCommand);
         inputOverlay.setStartState(startStateTable);
         FileSystemSaveStore graphStore = saveStore == null ? null : new FileSystemSaveStore(
                 saveStore.getSaveDir().resolve("graphs"), saveStore.getModVersion(), saveStore.getMcVersion(),
@@ -416,6 +418,23 @@ public final class Application {
         runner.setStartPosition(mc.getPlayerPosition());
         runner.setStartYaw(mc.getPlayerYaw());
         onUserChange(-1);
+    }
+
+    public void copyTeleportCommand() {
+        int row = firstSelectedRow();
+        TickState state = row >= 0 ? boxController.getState(row) : null;
+        if (state == null) {
+            copyStartTeleportCommand();
+            return;
+        }
+        ImGui.setClipboardText(TeleportCommand.format(state.position, state.yaw, boxController.getPitch(row)));
+        pushHudMessage("Copied teleport for tick " + (row + 1));
+    }
+
+    public void copyStartTeleportCommand() {
+        ImGui.setClipboardText(TeleportCommand.format(
+                runner.getStartPosition(), runner.getStartYaw(), runner.getStartPitch()));
+        pushHudMessage("Copied teleport for start");
     }
 
     private WorldPick pickWorld(Vec3dCore rayOrigin, Vec3dCore rayDirection) {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
@@ -176,7 +176,7 @@ public final class Application {
 
     public void setupUi() {
         inputOverlay = new InputOverlay(inputData, settings, selection, this::onUserChange,
-                this::setStartToPlayer, playback, mc, boxController
+                this::setStartToPlayer, playback, mc, boxController, this::pushHudMessage
         );
 
         angleSolverState = new AngleSolverState();

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/BoxController.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/BoxController.java
@@ -166,6 +166,16 @@ public final class BoxController {
         return states.get(index).yaw;
     }
 
+    public float getAppliedYaw(int index) {
+        if (index < 0 || index >= states.size()) return 0f;
+        return states.get(index + 1 < states.size() ? index + 1 : index).yaw;
+    }
+
+    public float getAppliedPitch(int index) {
+        if (index < 0) return 0f;
+        return getPitch(index + 1 < pitches.length ? index + 1 : index);
+    }
+
     /** Unmodifiable view of recorded per-tick states; index aligned with positions. */
     public List<TickState> getStates() {
         return Collections.unmodifiableList(states);

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputOverlay.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputOverlay.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.function.IntConsumer;
 import java.util.function.Supplier;
 
@@ -77,6 +78,7 @@ public final class InputOverlay {
 
     private static final String MENU_SET_TO_PLAYER = "Set to user position";
     private static final String MENU_TELEPORT_TO_TICK = "Teleport player to tick %d";
+    private static final String MENU_COPY_TELEPORT = "Copy teleport command";
     private static final String COL_TELEPORT = "Teleport";
     private static final String TELEPORT_X_LABEL = "X";
     private static final String TELEPORT_Y_LABEL = "Y";
@@ -122,6 +124,7 @@ public final class InputOverlay {
     private final PlaybackController playback;
     private final MinecraftAccess mc;
     private final BoxController boxController;
+    private final Consumer<String> hudMessage;
 
     private final SelectionManager selection;
     private final KeyDragSelect keyDragSelect = new KeyDragSelect();
@@ -216,7 +219,7 @@ public final class InputOverlay {
 
     public InputOverlay(InputData data, Settings settings, SelectionManager selection, IntConsumer onDataChangedAt,
                         Runnable onSetPlayerPosition, PlaybackController playback,
-                        MinecraftAccess mc, BoxController boxController
+                        MinecraftAccess mc, BoxController boxController, Consumer<String> hudMessage
     ) {
         this.data = data;
         this.settings = settings;
@@ -226,6 +229,7 @@ public final class InputOverlay {
         this.playback = playback;
         this.mc = mc;
         this.boxController = boxController;
+        this.hudMessage = hudMessage;
     }
 
     private AngleSolverTable angleSolver;
@@ -1415,6 +1419,7 @@ public final class InputOverlay {
             notifyFullResim();
         }
         renderTeleportToTickOption();
+        renderCopyAsTeleportOption();
         renderApplyPotionOptions();
         renderYawLockOption();
         renderPitchLockOption();
@@ -1434,6 +1439,31 @@ public final class InputOverlay {
         if (contextButton(String.format(MENU_TELEPORT_TO_TICK, row + 1))) {
             playback.teleportToTick(state.position, state.yaw, boxController.getPitch(row));
         }
+    }
+
+    private void renderCopyAsTeleportOption() {
+        if (boxController == null) return;
+        int row = selection.singleSelectedRow();
+        if (row < 0) return;
+        TickState state = boxController.getState(row);
+        if (state == null) return;
+        if (contextButton(MENU_COPY_TELEPORT)) {
+            Vec3dCore p = state.position;
+            float yaw = wrapDegrees(state.yaw);
+            float pitch = boxController.getPitch(row);
+            String command = "/tp @p " + p.x + " " + p.y + " " + p.z + " " + yaw + " " + pitch;
+            ImGui.setClipboardText(command);
+            if (hudMessage != null) {
+                hudMessage.accept("Copied teleport for tick " + (row + 1));
+            }
+        }
+    }
+
+    private static float wrapDegrees(float value) {
+        float f = value % 360.0f;
+        if (f >= 180.0f) f -= 360.0f;
+        if (f < -180.0f) f += 360.0f;
+        return f;
     }
 
     private void renderTeleportColumn(InputRow row, int rowIndex) {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputOverlay.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputOverlay.java
@@ -10,6 +10,7 @@ import de.legoshi.parkourcalc.core.ui.anglesolver.AngleSolverTable;
 import de.legoshi.parkourcalc.core.ui.anglesolver.SolverWidgets;
 import de.legoshi.parkourcalc.core.ui.theme.Controls;
 import de.legoshi.parkourcalc.core.ui.theme.ThemeManager;
+import de.legoshi.parkourcalc.core.ui.util.TeleportCommand;
 import de.legoshi.parkourcalc.core.ui.util.TooltipUtil;
 import imgui.ImDrawList;
 import imgui.ImGui;
@@ -1448,22 +1449,11 @@ public final class InputOverlay {
         TickState state = boxController.getState(row);
         if (state == null) return;
         if (contextButton(MENU_COPY_TELEPORT)) {
-            Vec3dCore p = state.position;
-            float yaw = wrapDegrees(state.yaw);
-            float pitch = boxController.getPitch(row);
-            String command = "/tp " + p.x + " " + p.y + " " + p.z + " " + yaw + " " + pitch;
-            ImGui.setClipboardText(command);
+            ImGui.setClipboardText(TeleportCommand.format(state.position, state.yaw, boxController.getPitch(row)));
             if (hudMessage != null) {
                 hudMessage.accept("Copied teleport for tick " + (row + 1));
             }
         }
-    }
-
-    private static float wrapDegrees(float value) {
-        float f = value % 360.0f;
-        if (f >= 180.0f) f -= 360.0f;
-        if (f < -180.0f) f += 360.0f;
-        return f;
     }
 
     private void renderTeleportColumn(InputRow row, int rowIndex) {

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputOverlay.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputOverlay.java
@@ -1438,7 +1438,7 @@ public final class InputOverlay {
         TickState state = boxController.getState(row);
         if (state == null) return;
         if (contextButton(String.format(MENU_TELEPORT_TO_TICK, row + 1))) {
-            playback.teleportToTick(state.position, state.yaw, boxController.getPitch(row));
+            playback.teleportToTick(state.position, boxController.getAppliedYaw(row), boxController.getAppliedPitch(row));
         }
     }
 
@@ -1449,7 +1449,8 @@ public final class InputOverlay {
         TickState state = boxController.getState(row);
         if (state == null) return;
         if (contextButton(MENU_COPY_TELEPORT)) {
-            ImGui.setClipboardText(TeleportCommand.format(state.position, state.yaw, boxController.getPitch(row)));
+            ImGui.setClipboardText(TeleportCommand.format(state.position,
+                    boxController.getAppliedYaw(row), boxController.getAppliedPitch(row)));
             if (hudMessage != null) {
                 hudMessage.accept("Copied teleport for tick " + (row + 1));
             }

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputOverlay.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/InputOverlay.java
@@ -1451,7 +1451,7 @@ public final class InputOverlay {
             Vec3dCore p = state.position;
             float yaw = wrapDegrees(state.yaw);
             float pitch = boxController.getPitch(row);
-            String command = "/tp @p " + p.x + " " + p.y + " " + p.z + " " + yaw + " " + pitch;
+            String command = "/tp " + p.x + " " + p.y + " " + p.z + " " + yaw + " " + pitch;
             ImGui.setClipboardText(command);
             if (hudMessage != null) {
                 hudMessage.accept("Copied teleport for tick " + (row + 1));

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/StartStateTable.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/StartStateTable.java
@@ -22,9 +22,11 @@ import java.util.function.DoubleConsumer;
 public final class StartStateTable {
 
     private static final int PRECISION = 5;
+    private static final String COPY_TELEPORT_LABEL = "Copy teleport command";
 
     private final SimulationRunner runner;
     private final Runnable reSimulate;
+    private final Runnable copyTeleport;
 
     private boolean expanded;
     private float measuredContentH = -1f;
@@ -34,9 +36,10 @@ public final class StartStateTable {
     private String activeField;
     private ImDrawList drawerDrawList;
 
-    public StartStateTable(SimulationRunner runner, Runnable reSimulate) {
+    public StartStateTable(SimulationRunner runner, Runnable reSimulate, Runnable copyTeleport) {
         this.runner = runner;
         this.reSimulate = reSimulate;
+        this.copyTeleport = copyTeleport;
     }
 
     public boolean isExpanded() {
@@ -66,6 +69,7 @@ public final class StartStateTable {
                 + sectionHead + 3f * inputRow
                 + sectionHead + 3f * inputRow
                 + sectionHead + 2f * inputRow
+                + spacing + inputRow
                 + sectionHead + 9f * inputRow
                 + fhs;
     }
@@ -101,6 +105,11 @@ public final class StartStateTable {
         ThemeManager.sectionSpacing();
         sectionHeader("Rotation");
         rotationEditor(runner.getStartYaw(), runner.getStartPitch());
+
+        ThemeManager.sectionSpacing();
+        if (Controls.secondaryButton(COPY_TELEPORT_LABEL, ImGui.getContentRegionAvail().x) && copyTeleport != null) {
+            copyTeleport.run();
+        }
 
         ThemeManager.sectionSpacing();
         sectionHeader("Resume state");

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/util/TeleportCommand.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/util/TeleportCommand.java
@@ -1,0 +1,21 @@
+package de.legoshi.parkourcalc.core.ui.util;
+
+import de.legoshi.parkourcalc.core.sim.Vec3dCore;
+
+public final class TeleportCommand {
+
+    private TeleportCommand() {
+    }
+
+    public static String format(Vec3dCore position, float yaw, float pitch) {
+        return "/tp " + position.x + " " + position.y + " " + position.z
+                + " " + wrapDegrees(yaw) + " " + pitch;
+    }
+
+    private static float wrapDegrees(float value) {
+        float f = value % 360.0f;
+        if (f >= 180.0f) f -= 360.0f;
+        if (f < -180.0f) f += 360.0f;
+        return f;
+    }
+}

--- a/core/src/test/java/de/legoshi/parkourcalc/core/ui/AppliedFacingTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/ui/AppliedFacingTest.java
@@ -1,0 +1,43 @@
+package de.legoshi.parkourcalc.core.ui;
+
+import de.legoshi.parkourcalc.core.sim.TickState;
+import de.legoshi.parkourcalc.core.sim.Vec3dCore;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class AppliedFacingTest {
+
+    private static BoxController controllerWithYaws(float... yaws) {
+        BoxController c = new BoxController();
+        for (float yaw : yaws) {
+            c.add(new TickState(new Vec3dCore(0.0, 0.0, 0.0), true, false, false, yaw,
+                    null, Vec3dCore.ZERO, false, Double.NaN));
+        }
+        return c;
+    }
+
+    @Test
+    public void appliedYawIsTheTicksOwnTurnNotThePriorOne() {
+        BoxController c = controllerWithYaws(0f, 45f, 90f);
+        assertEquals(0f, c.getYaw(0), 0f);
+        assertEquals(45f, c.getAppliedYaw(0), 0f);
+        assertEquals(90f, c.getAppliedYaw(1), 0f);
+    }
+
+    @Test
+    public void appliedYawFallsBackOnTheLastState() {
+        BoxController c = controllerWithYaws(0f, 45f, 90f);
+        assertEquals(90f, c.getAppliedYaw(2), 0f);
+    }
+
+    @Test
+    public void appliedPitchIsFoldedOneRowFurtherThanPreTickPitch() {
+        BoxController c = controllerWithYaws(0f, 0f, 0f);
+        c.setPitches(new float[]{0f, -20f, -35f});
+        assertEquals(0f, c.getPitch(0), 0f);
+        assertEquals(-20f, c.getAppliedPitch(0), 0f);
+        assertEquals(-35f, c.getAppliedPitch(1), 0f);
+        assertEquals(-35f, c.getAppliedPitch(2), 0f);
+    }
+}

--- a/core/src/test/java/de/legoshi/parkourcalc/core/ui/CopyPasteTicksTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/ui/CopyPasteTicksTest.java
@@ -25,7 +25,7 @@ public class CopyPasteTicksTest {
     }
 
     private static InputOverlay overlay(InputData data, SelectionManager sel, int[] dirtySink) {
-        return new InputOverlay(data, new Settings(), sel, t -> dirtySink[0] = t, null, null, null, null);
+        return new InputOverlay(data, new Settings(), sel, t -> dirtySink[0] = t, null, null, null, null, null);
     }
 
     @Test

--- a/core/src/test/java/de/legoshi/parkourcalc/core/ui/TeleportCommandTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/core/ui/TeleportCommandTest.java
@@ -1,0 +1,30 @@
+package de.legoshi.parkourcalc.core.ui;
+
+import de.legoshi.parkourcalc.core.sim.Vec3dCore;
+import de.legoshi.parkourcalc.core.ui.util.TeleportCommand;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TeleportCommandTest {
+
+    @Test
+    public void keepsFullPrecisionCoordinates() {
+        String cmd = TeleportCommand.format(new Vec3dCore(1.5, 64.0, -2.25), 0f, 0f);
+        assertEquals("/tp 1.5 64.0 -2.25 0.0 0.0", cmd);
+    }
+
+    @Test
+    public void wrapsYawIntoF3Range() {
+        Vec3dCore p = new Vec3dCore(0.0, 0.0, 0.0);
+        assertEquals("/tp 0.0 0.0 0.0 -90.0 0.0", TeleportCommand.format(p, 270f, 0f));
+        assertEquals("/tp 0.0 0.0 0.0 -180.0 0.0", TeleportCommand.format(p, 180f, 0f));
+        assertEquals("/tp 0.0 0.0 0.0 45.0 0.0", TeleportCommand.format(p, 765f, 0f));
+        assertEquals("/tp 0.0 0.0 0.0 -45.0 0.0", TeleportCommand.format(p, -765f, 0f));
+    }
+
+    @Test
+    public void keepsPitchUnwrapped() {
+        assertEquals("/tp 0.0 0.0 0.0 0.0 -37.5", TeleportCommand.format(new Vec3dCore(0.0, 0.0, 0.0), 0f, -37.5f));
+    }
+}

--- a/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/FabricParkourCalculator.java
+++ b/loader-fabric-1.21.3/src/main/java/de/legoshi/parkourcalc/fabric/FabricParkourCalculator.java
@@ -45,6 +45,7 @@ public class FabricParkourCalculator implements ClientModInitializer {
     private static KeyMapping solverStartTickKeyBinding;
     private static KeyMapping solverEndTickKeyBinding;
     private static KeyMapping rerunSimulationKeyBinding;
+    private static KeyMapping copyTeleportKeyBinding;
     private static KeyMapping captureMomentumBlockKeyBinding;
     private static KeyMapping captureCollisionBlockKeyBinding;
     private static KeyMapping captureLandBlockKeyBinding;
@@ -89,6 +90,7 @@ public class FabricParkourCalculator implements ClientModInitializer {
         solverStartTickKeyBinding = key("key.parkourcalculator.set_solver_start", GLFW.GLFW_KEY_I);
         solverEndTickKeyBinding = key("key.parkourcalculator.set_solver_end", GLFW.GLFW_KEY_O);
         rerunSimulationKeyBinding = key("key.parkourcalculator.rerun_simulation", GLFW.GLFW_KEY_J);
+        copyTeleportKeyBinding = key("key.parkourcalculator.copy_teleport", GLFW.GLFW_KEY_K);
         if (blockCaptureEnabled) {
             captureMomentumBlockKeyBinding = key("key.parkourcalculator.capture_momentum_block", GLFW.GLFW_KEY_M);
             captureCollisionBlockKeyBinding = key("key.parkourcalculator.capture_collision_block", GLFW.GLFW_KEY_N);
@@ -286,6 +288,10 @@ public class FabricParkourCalculator implements ClientModInitializer {
         while (rerunSimulationKeyBinding.consumeClick()) {
             rerunSimulationPressed = true;
         }
+        boolean copyTeleportPressed = false;
+        while (copyTeleportKeyBinding.consumeClick()) {
+            copyTeleportPressed = true;
+        }
         boolean captureMomentum = false;
         boolean captureCollision = false;
         boolean captureLand = false;
@@ -345,6 +351,9 @@ public class FabricParkourCalculator implements ClientModInitializer {
         }
         if (rerunSimulationPressed && canDispatch) {
             application.runSimulation();
+        }
+        if (copyTeleportPressed && canDispatch) {
+            application.copyTeleportCommand();
         }
         if (captureMomentum && canDispatch) {
             application.captureAngleSolverBlock(BlockSelection.Kind.MOMENTUM);
@@ -415,6 +424,10 @@ public class FabricParkourCalculator implements ClientModInitializer {
         }
         if (glfwKey == boundKey(rerunSimulationKeyBinding)) {
             application.runSimulation();
+            return true;
+        }
+        if (glfwKey == boundKey(copyTeleportKeyBinding)) {
+            application.copyTeleportCommand();
             return true;
         }
         return false;

--- a/loader-fabric-1.21.3/src/main/resources/assets/parkourcalculator/lang/en_us.json
+++ b/loader-fabric-1.21.3/src/main/resources/assets/parkourcalculator/lang/en_us.json
@@ -10,6 +10,7 @@
     "key.parkourcalculator.set_solver_start": "Set solver start tick",
     "key.parkourcalculator.set_solver_end": "Set solver goal tick",
     "key.parkourcalculator.rerun_simulation": "Rerun simulation",
+    "key.parkourcalculator.copy_teleport": "Copy teleport command",
     "key.parkourcalculator.capture_momentum_block": "Capture Momentum block",
     "key.parkourcalculator.capture_collision_block": "Capture Collision block",
     "key.parkourcalculator.capture_land_block": "Capture Land block",

--- a/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricParkourCalculator.java
+++ b/loader-fabric/src/client/java/de/legoshi/parkourcalc/fabric/FabricParkourCalculator.java
@@ -44,6 +44,7 @@ public class FabricParkourCalculator implements ClientModInitializer {
     private static KeyMapping solverStartTickKeyBinding;
     private static KeyMapping solverEndTickKeyBinding;
     private static KeyMapping rerunSimulationKeyBinding;
+    private static KeyMapping copyTeleportKeyBinding;
     private static KeyMapping captureMomentumBlockKeyBinding;
     private static KeyMapping captureCollisionBlockKeyBinding;
     private static KeyMapping captureLandBlockKeyBinding;
@@ -132,6 +133,12 @@ public class FabricParkourCalculator implements ClientModInitializer {
                 "key.parkourcalculator.rerun_simulation",
                 InputConstants.Type.KEYSYM,
                 GLFW.GLFW_KEY_J,
+                category
+        ));
+        copyTeleportKeyBinding = KeyMappingHelper.registerKeyMapping(new KeyMapping(
+                "key.parkourcalculator.copy_teleport",
+                InputConstants.Type.KEYSYM,
+                GLFW.GLFW_KEY_K,
                 category
         ));
 
@@ -333,6 +340,10 @@ public class FabricParkourCalculator implements ClientModInitializer {
         while (rerunSimulationKeyBinding.consumeClick()) {
             rerunSimulationPressed = true;
         }
+        boolean copyTeleportPressed = false;
+        while (copyTeleportKeyBinding.consumeClick()) {
+            copyTeleportPressed = true;
+        }
         boolean captureMomentum = false;
         boolean captureCollision = false;
         boolean captureLand = false;
@@ -393,6 +404,9 @@ public class FabricParkourCalculator implements ClientModInitializer {
         }
         if (rerunSimulationPressed && chordFree) {
             application.runSimulation();
+        }
+        if (copyTeleportPressed && chordFree) {
+            application.copyTeleportCommand();
         }
         if (captureMomentum && chordFree) {
             application.captureAngleSolverBlock(BlockSelection.Kind.MOMENTUM);
@@ -460,6 +474,10 @@ public class FabricParkourCalculator implements ClientModInitializer {
         }
         if (glfwKey == boundKey(solverEndTickKeyBinding)) {
             application.setSolverLandingTickFromSelection();
+            return true;
+        }
+        if (glfwKey == boundKey(copyTeleportKeyBinding)) {
+            application.copyTeleportCommand();
             return true;
         }
         return false;

--- a/loader-fabric/src/client/resources/assets/parkourcalculator/lang/en_us.json
+++ b/loader-fabric/src/client/resources/assets/parkourcalculator/lang/en_us.json
@@ -10,6 +10,7 @@
     "key.parkourcalculator.set_solver_start": "Set solver start tick",
     "key.parkourcalculator.set_solver_end": "Set solver goal tick",
     "key.parkourcalculator.rerun_simulation": "Rerun simulation",
+    "key.parkourcalculator.copy_teleport": "Copy teleport command",
     "key.parkourcalculator.capture_momentum_block": "Capture Momentum block",
     "key.parkourcalculator.capture_collision_block": "Capture Collision block",
     "key.parkourcalculator.capture_land_block": "Capture Land block",

--- a/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12ParkourCalculator.java
+++ b/loader-forge-1.12.2/src/main/java/de/legoshi/parkourcalc/forge12/Forge12ParkourCalculator.java
@@ -84,6 +84,7 @@ public class Forge12ParkourCalculator {
     private KeyBinding solverStartTickKeyBinding;
     private KeyBinding solverEndTickKeyBinding;
     private KeyBinding rerunSimulationKeyBinding;
+    private KeyBinding copyTeleportKeyBinding;
     private KeyBinding captureMomentumBlockKeyBinding;
     private KeyBinding captureCollisionBlockKeyBinding;
     private KeyBinding captureLandBlockKeyBinding;
@@ -144,6 +145,8 @@ public class Forge12ParkourCalculator {
         ClientRegistry.registerKeyBinding(solverEndTickKeyBinding);
         rerunSimulationKeyBinding = new KeyBinding("key.parkourcalculator.rerun_simulation", Keyboard.KEY_J, "key.categories.parkourcalculator");
         ClientRegistry.registerKeyBinding(rerunSimulationKeyBinding);
+        copyTeleportKeyBinding = new KeyBinding("key.parkourcalculator.copy_teleport", Keyboard.KEY_K, "key.categories.parkourcalculator");
+        ClientRegistry.registerKeyBinding(copyTeleportKeyBinding);
         if (blockCaptureEnabled) {
             captureMomentumBlockKeyBinding = new KeyBinding("key.parkourcalculator.capture_momentum_block", Keyboard.KEY_M, "key.categories.parkourcalculator");
             ClientRegistry.registerKeyBinding(captureMomentumBlockKeyBinding);
@@ -331,6 +334,10 @@ public class Forge12ParkourCalculator {
         while (rerunSimulationKeyBinding.isPressed()) {
             rerunSimulationPressed = true;
         }
+        boolean copyTeleportPressed = false;
+        while (copyTeleportKeyBinding.isPressed()) {
+            copyTeleportPressed = true;
+        }
         boolean captureMomentum = false;
         boolean captureCollision = false;
         boolean captureLand = false;
@@ -385,6 +392,9 @@ public class Forge12ParkourCalculator {
             }
             if (rerunSimulationPressed && chordFree) {
                 application.runSimulation();
+            }
+            if (copyTeleportPressed && chordFree) {
+                application.copyTeleportCommand();
             }
             if (captureMomentum && chordFree) {
                 application.captureAngleSolverBlock(BlockSelection.Kind.MOMENTUM);
@@ -457,6 +467,10 @@ public class Forge12ParkourCalculator {
         }
         if (keyCode == rerunSimulationKeyBinding.getKeyCode()) {
             application.runSimulation();
+            return true;
+        }
+        if (keyCode == copyTeleportKeyBinding.getKeyCode()) {
+            application.copyTeleportCommand();
             return true;
         }
         return false;

--- a/loader-forge-1.12.2/src/main/resources/assets/parkourcalculator/lang/en_us.lang
+++ b/loader-forge-1.12.2/src/main/resources/assets/parkourcalculator/lang/en_us.lang
@@ -9,6 +9,7 @@ key.parkourcalculator.solve=Solve and apply (Angle Solver)
 key.parkourcalculator.set_solver_start=Set solver start tick
 key.parkourcalculator.set_solver_end=Set solver goal tick
 key.parkourcalculator.rerun_simulation=Rerun simulation
+key.parkourcalculator.copy_teleport=Copy teleport command
 key.parkourcalculator.capture_momentum_block=Capture Momentum block
 key.parkourcalculator.capture_collision_block=Capture Collision block
 key.parkourcalculator.capture_land_block=Capture Land block

--- a/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8ParkourCalculator.java
+++ b/loader-forge-1.8.9/src/main/java/de/legoshi/parkourcalc/forge8/Forge8ParkourCalculator.java
@@ -89,6 +89,7 @@ public class Forge8ParkourCalculator {
     private KeyBinding solverStartTickKeyBinding;
     private KeyBinding solverEndTickKeyBinding;
     private KeyBinding rerunSimulationKeyBinding;
+    private KeyBinding copyTeleportKeyBinding;
     private KeyBinding captureMomentumBlockKeyBinding;
     private KeyBinding captureCollisionBlockKeyBinding;
     private KeyBinding captureLandBlockKeyBinding;
@@ -149,6 +150,8 @@ public class Forge8ParkourCalculator {
         ClientRegistry.registerKeyBinding(solverEndTickKeyBinding);
         rerunSimulationKeyBinding = new KeyBinding("key.parkourcalculator.rerun_simulation", Keyboard.KEY_J, "key.categories.parkourcalculator");
         ClientRegistry.registerKeyBinding(rerunSimulationKeyBinding);
+        copyTeleportKeyBinding = new KeyBinding("key.parkourcalculator.copy_teleport", Keyboard.KEY_K, "key.categories.parkourcalculator");
+        ClientRegistry.registerKeyBinding(copyTeleportKeyBinding);
         if (blockCaptureEnabled) {
             captureMomentumBlockKeyBinding = new KeyBinding("key.parkourcalculator.capture_momentum_block", Keyboard.KEY_M, "key.categories.parkourcalculator");
             ClientRegistry.registerKeyBinding(captureMomentumBlockKeyBinding);
@@ -336,6 +339,10 @@ public class Forge8ParkourCalculator {
         while (rerunSimulationKeyBinding.isPressed()) {
             rerunSimulationPressed = true;
         }
+        boolean copyTeleportPressed = false;
+        while (copyTeleportKeyBinding.isPressed()) {
+            copyTeleportPressed = true;
+        }
         boolean captureMomentum = false;
         boolean captureCollision = false;
         boolean captureLand = false;
@@ -390,6 +397,9 @@ public class Forge8ParkourCalculator {
             }
             if (rerunSimulationPressed && chordFree) {
                 application.runSimulation();
+            }
+            if (copyTeleportPressed && chordFree) {
+                application.copyTeleportCommand();
             }
             if (captureMomentum && chordFree) {
                 application.captureAngleSolverBlock(BlockSelection.Kind.MOMENTUM);
@@ -462,6 +472,10 @@ public class Forge8ParkourCalculator {
         }
         if (keyCode == rerunSimulationKeyBinding.getKeyCode()) {
             application.runSimulation();
+            return true;
+        }
+        if (keyCode == copyTeleportKeyBinding.getKeyCode()) {
+            application.copyTeleportCommand();
             return true;
         }
         return false;

--- a/loader-forge-1.8.9/src/main/resources/assets/parkourcalculator/lang/en_US.lang
+++ b/loader-forge-1.8.9/src/main/resources/assets/parkourcalculator/lang/en_US.lang
@@ -9,6 +9,7 @@ key.parkourcalculator.solve=Solve and apply (Angle Solver)
 key.parkourcalculator.set_solver_start=Set solver start tick
 key.parkourcalculator.set_solver_end=Set solver goal tick
 key.parkourcalculator.rerun_simulation=Rerun simulation
+key.parkourcalculator.copy_teleport=Copy teleport command
 key.parkourcalculator.capture_momentum_block=Capture Momentum block
 key.parkourcalculator.capture_collision_block=Capture Collision block
 key.parkourcalculator.capture_land_block=Capture Land block


### PR DESCRIPTION
Closes #463.

Adds a **Copy teleport command** item to the tick right-click context menu (shown for a single selected tick). It copies

```
/tp @p <x> <y> <z> <yaw> <pitch>
```

to the clipboard, using the tick's full-precision `double` position, its yaw wrapped to `[-180, 180)`, and its pitch. A HUD message confirms the copy. Unlike *Teleport player to tick*, it works regardless of whether teleport-to-tick is available (e.g. on servers).

Format notes (easy to change if you'd prefer different):
- `@p` and this argument order (`x y z yaw pitch`) are valid on 1.8.9, 1.12.2, and modern versions.
- Coordinates use `Double.toString`, i.e. the shortest exact round-trip value (full ~e-16 precision), rather than padded 16-decimal output.

Wiring: `InputOverlay` gains the menu item; a HUD-message consumer is threaded through its constructor from `Application`.

QA: `:core:test` green. In-game QA on a loader pending.