### PR TITLE
fix(anglesolver): let a dF = 0 on Tick 1 solve the start facing

### DIFF
--- a/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/Application.java
@@ -198,6 +198,7 @@ public final class Application {
         saveController.setGraphStore(graphStore);
         AngleSolverEngine angleSolverEngine = new AngleSolverEngine(angleSolverState, boxController, inputData, this::onUserChange, forwardModel);
         angleSolverEngine.setOnStartMoved(runner::setStartPosition);
+        angleSolverEngine.setOnStartYawChanged(runner::setStartYaw);
         this.solverEngine = angleSolverEngine;
         if (saveStore != null) {
             angleSolverEngine.setRunLog(new SolveRunLog(saveStore.getSaveDir().resolve("runs"),

--- a/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/AngleSolverEngine.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/anglesolver/AngleSolverEngine.java
@@ -134,6 +134,12 @@ public final class AngleSolverEngine {
         this.onStartMoved = onStartMoved != null ? onStartMoved : pos -> { };
     }
 
+    private Consumer<Float> onStartYawChanged = yaw -> { };
+
+    public void setOnStartYawChanged(Consumer<Float> onStartYawChanged) {
+        this.onStartYawChanged = onStartYawChanged != null ? onStartYawChanged : yaw -> { };
+    }
+
     /** Byte-exact forward, configured for the loader's MC inertia rule (see ExactJumpModel.forMcVersion).
      *  Stateless/immutable, so a single instance is shared read-only across the restart threads. */
     private final ForwardModel model;
@@ -261,14 +267,10 @@ public final class AngleSolverEngine {
         final ForwardPath path;
         final Vec3dCore start;
         final boolean lockYaws;
+        final boolean freeStartYaw;
 
         Plan(int startTick, double[] yaws, boolean[] strafeMask, boolean[] force45Mask, int strafeSign,
-             ForwardPath path, Vec3dCore start) {
-            this(startTick, yaws, strafeMask, force45Mask, strafeSign, path, start, false);
-        }
-
-        Plan(int startTick, double[] yaws, boolean[] strafeMask, boolean[] force45Mask, int strafeSign,
-             ForwardPath path, Vec3dCore start, boolean lockYaws) {
+             ForwardPath path, Vec3dCore start, boolean lockYaws, boolean freeStartYaw) {
             this.startTick = startTick;
             this.yaws = yaws;
             this.strafeMask = strafeMask;
@@ -277,6 +279,7 @@ public final class AngleSolverEngine {
             this.path = path;
             this.start = start;
             this.lockYaws = lockYaws;
+            this.freeStartYaw = freeStartYaw;
         }
     }
 
@@ -310,11 +313,13 @@ public final class AngleSolverEngine {
         final boolean ilsExhaustive;
         final JumpConstraint legalGoal;
         final SolverGraph graph;
+        final boolean freeStartYaw;
 
         Job(JumpSpec spec, Objective.Sense sense, int startTick, int landingTick,
             int numTicks, boolean[] strafeMask, boolean[] force45Mask, List<ConstraintAt> uiConstraints,
             long deadlineNanos, LongRunSolver.LongRunConfig longRun, boolean useWindowSolver,
-            boolean stopOnFeasible, boolean ilsExhaustive, JumpConstraint legalGoal, SolverGraph graph
+            boolean stopOnFeasible, boolean ilsExhaustive, JumpConstraint legalGoal, SolverGraph graph,
+            boolean freeStartYaw
         ) {
             this.spec = spec;
             this.sense = sense;
@@ -331,6 +336,7 @@ public final class AngleSolverEngine {
             this.ilsExhaustive = ilsExhaustive;
             this.legalGoal = legalGoal;
             this.graph = graph;
+            this.freeStartYaw = freeStartYaw;
         }
     }
 
@@ -372,15 +378,13 @@ public final class AngleSolverEngine {
         lastStrafeMaskDebug = ph.strafeMask;
         List<ConstraintAt> uiCons = collectUiConstraints(startTick, numTicks);
 
-        Set<Constraint> footprintCons = null;
+        Set<Constraint> consumed = new HashSet<>();
         if (startTick == 0 && model instanceof ExactJumpModel) {
-            Set<Constraint> consumed = new HashSet<>();
             StartBox freeBox = deriveFreeStartBox(uiCons, ph.inputs, consumed);
-            if (freeBox != null) {
-                ph.inputs.startBox = freeBox;
-                footprintCons = consumed;
-            }
+            if (freeBox != null) ph.inputs.startBox = freeBox;
         }
+        boolean freeStartYaw = consumeFirstTickZeroTurn(uiCons, consumed);
+        if (freeStartYaw) ph.inputs.yawLockedPerTick[0] = true;
 
         List<JumpConstraint> constraints = new ArrayList<>();
         Objective objective = state.isCustomAngle()
@@ -391,7 +395,7 @@ public final class AngleSolverEngine {
                 : new Objective(axis(state.getAxis()), sense(state.getGoal()), numTicks,
                 state.getSmoothLambda());
         for (ConstraintAt ca : uiCons) {
-            if (footprintCons != null && footprintCons.contains(ca.c)) continue;
+            if (consumed.contains(ca.c)) continue;
             addMapped(constraints, ca.c, ca.absTick, ca.segTick, numTicks, ph.inputs.startYaw);
         }
 
@@ -414,7 +418,7 @@ public final class AngleSolverEngine {
                 ph.force45Mask, uiCons,
                 deadlineNanosFor(state, effort), longRunConfigFor(state, effort), useWindowSolverFor(state, effort),
                 stopOnFeasibleFor(state, effort), ilsExhaustiveFor(state, effort), legalGoal,
-                graphOverride != null ? graphOverride : GraphFactory.forState(state, effort));
+                graphOverride != null ? graphOverride : GraphFactory.forState(state, effort), freeStartYaw);
     }
 
     public String legalGoalWallLabel() {
@@ -426,7 +430,10 @@ public final class AngleSolverEngine {
         List<JumpConstraint> constraints = new ArrayList<>();
         TickState seamSeed = boxes.getState(startTick);
         float seamSeedYaw = seamSeed != null ? seamSeed.yaw : 0f;
+        Set<Constraint> consumed = new HashSet<>();
+        consumeFirstTickZeroTurn(uiCons, consumed);
         for (ConstraintAt ca : uiCons) {
+            if (consumed.contains(ca.c)) continue;
             addMapped(constraints, ca.c, ca.absTick, ca.segTick, numTicks, seamSeedYaw);
         }
         Objective objective = new Objective(axis(state.getAxis()), sense(state.getGoal()), numTicks);
@@ -653,6 +660,16 @@ public final class AngleSolverEngine {
             if (forwardIn[k] < SPRINT_SUSTAIN_F) return;
             sprint[k] = true;
         }
+    }
+
+    private static boolean consumeFirstTickZeroTurn(List<ConstraintAt> uiCons, Set<Constraint> consumed) {
+        boolean any = false;
+        for (ConstraintAt ca : uiCons) {
+            if (ca.absTick != 0 || ca.c.getField() != Constraint.Field.DF || ca.c.isUnsupportedDf()) continue;
+            consumed.add(ca.c);
+            any = true;
+        }
+        return any;
     }
 
     private List<ConstraintAt> collectUiConstraints(int startTick, int numTicks) {
@@ -946,8 +963,12 @@ public final class AngleSolverEngine {
         }
         finishRecord(rec, SolveRunRecord.STATUS_SOLVED, finalObjective, finalViolation,
                 finalViolation <= FEAS_TOL, solverName, yaws);
-        Plan plan = new Plan(job.startTick, yaws, job.strafeMask, job.force45Mask, 1, path, sc.startPos, stageLocked);
-        return new Outcome(result, plan);
+        return new Outcome(result, planOf(job, yaws, path, sc, stageLocked));
+    }
+
+    private static Plan planOf(Job job, double[] yaws, ForwardPath path, JumpPhysicsInputs sc, boolean lockYaws) {
+        return new Plan(job.startTick, yaws, job.strafeMask, job.force45Mask, 1, path, sc.startPos, lockYaws,
+                job.freeStartYaw);
     }
 
     private double[] smoothFacing(ExactJumpModel em, JumpSpec spec, JumpPhysicsInputs sc, double[] yaws,
@@ -1001,8 +1022,7 @@ public final class AngleSolverEngine {
         String name = solver == null || solver.isEmpty() ? "stopped early" : solver;
         SolveResult result = assembleResult(job, yaws, gameFacings, path, name, System.nanoTime() - startNanos, Double.NaN);
         result.addDetail("Stopped early", "kept best found");
-        Plan plan = new Plan(job.startTick, yaws, job.strafeMask, job.force45Mask, 1, path, sc.startPos);
-        return new Outcome(result, plan);
+        return new Outcome(result, planOf(job, yaws, path, sc, false));
     }
 
     private SolveResult buildResultWithObjective(Job job, double[] yaws, double[] gameFacings, ForwardPath path) {
@@ -1034,7 +1054,9 @@ public final class AngleSolverEngine {
         }
         int locked = 0;
         if (sc.yawLockedPerTick != null) {
-            for (boolean b : sc.yawLockedPerTick) if (b) locked++;
+            for (int t = job.freeStartYaw ? 1 : 0; t < sc.yawLockedPerTick.length; t++) {
+                if (sc.yawLockedPerTick[t]) locked++;
+            }
         }
         if (locked > 0) result.addDetail("Locked yaws", Integer.toString(locked));
         SolveRunRecord.Outcome smooth = new SolveRunRecord.Outcome();
@@ -1145,7 +1167,15 @@ public final class AngleSolverEngine {
                 rows.get(p.startTick + k).setYawLocked(true);
             }
         }
-        writeYawRows(rows, p.startTick, p.yaws, (float) boxes.getYaw(p.startTick));
+        if (p.freeStartYaw && p.yaws.length > 0) {
+            float startYaw = (float) p.yaws[0];
+            if (startYaw != boxes.getYaw(p.startTick)) onStartYawChanged.accept(startYaw);
+            InputRow first = rows.get(p.startTick);
+            first.setYaw(first.isYawLocked() ? startYaw : 0f);
+            writeYawRows(rows, p.startTick, p.yaws, 1, p.yaws[0]);
+        } else {
+            writeYawRows(rows, p.startTick, p.yaws, (float) boxes.getYaw(p.startTick));
+        }
         for (int k = 0; k < p.yaws.length && p.startTick + k < rows.size(); k++) {
             if (p.force45Mask[k]) {
                 // A Force-45 tick realizes its solve assumption in the rows (gh-104): W + sprint held
@@ -1159,8 +1189,11 @@ public final class AngleSolverEngine {
     }
 
     public static void writeYawRows(List<InputRow> rows, int startTick, double[] yaws, float startYaw) {
-        double prevAbs = startYaw;
-        for (int k = 0; k < yaws.length && startTick + k < rows.size(); k++) {
+        writeYawRows(rows, startTick, yaws, 0, startYaw);
+    }
+
+    private static void writeYawRows(List<InputRow> rows, int startTick, double[] yaws, int from, double prevAbs) {
+        for (int k = from; k < yaws.length && startTick + k < rows.size(); k++) {
             InputRow row = rows.get(startTick + k);
             double abs = yaws[k];
             if (row.isYawLocked()) {
@@ -1404,9 +1437,10 @@ public final class AngleSolverEngine {
         List<ConstraintAt> ordered = new ArrayList<>(job.uiConstraints);
         ordered.sort((a, b) -> Integer.compare(a.absTick, b.absTick));
         List<Integer> unmet = new ArrayList<>();
+        float seedYaw = job.freeStartYaw && gameFacings.length > 0
+                ? (float) gameFacings[0] : job.spec.asScenario().startYaw;
         for (ConstraintAt ca : ordered) {
-            Double found = findValue(ca.c, ca.segTick, job.startTick, job.numTicks, gameFacings, path,
-                    job.spec.asScenario().startYaw);
+            Double found = findValue(ca.c, ca.segTick, job.startTick, job.numTicks, gameFacings, path, seedYaw);
             if (found == null) continue; // unmappable, e.g. velocity on tick 0
             total++;
             boolean ok = satisfied(ca.c, found);

--- a/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverTable.java
+++ b/core/src/main/java/de/legoshi/parkourcalc/core/ui/anglesolver/AngleSolverTable.java
@@ -136,7 +136,8 @@ public final class AngleSolverTable {
         return c.isUnsupportedDf()
                 ? "Unsupported dF shape from an older save; solves containing it will fail."
                         + " Re-select the dF field to reset it to dF = 0, or delete it."
-                : "dF is supported as dF = 0 only (hold the facing of the previous tick)";
+                : "dF is supported as dF = 0 only (hold the facing of the previous tick;"
+                        + " on Tick 1 the start facing is solved for and Apply moves it)";
     }
 
     public AngleSolverTable(AngleSolverState state, Settings settings, SelectionManager selection,

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/FirstTickDeltaFacingTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/FirstTickDeltaFacingTest.java
@@ -1,0 +1,160 @@
+package de.legoshi.parkourcalc.anglesolver;
+
+import de.legoshi.parkourcalc.core.anglesolver.AngleSolverEngine;
+import de.legoshi.parkourcalc.core.anglesolver.AngleSolverState;
+import de.legoshi.parkourcalc.core.anglesolver.Constraint;
+import de.legoshi.parkourcalc.core.anglesolver.SolveResult;
+import de.legoshi.parkourcalc.core.anglesolver.solver.ExactJumpModel;
+import de.legoshi.parkourcalc.core.anglesolver.solver.JumpConstraint;
+import de.legoshi.parkourcalc.core.anglesolver.solver.JumpPhysicsInputs;
+import de.legoshi.parkourcalc.core.anglesolver.solver.JumpSpec;
+import de.legoshi.parkourcalc.core.sim.TickState;
+import de.legoshi.parkourcalc.core.sim.Vec3dCore;
+import de.legoshi.parkourcalc.core.ui.BoxController;
+import de.legoshi.parkourcalc.core.ui.InputData;
+import de.legoshi.parkourcalc.core.ui.InputRow;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class FirstTickDeltaFacingTest {
+
+    private static final int TICKS = 3;
+    private static final float START_YAW = 12.5f;
+    private static final double MET_TOL = 1.0e-4;
+
+    private final BoxController boxes = new BoxController();
+    private final AngleSolverState state = new AngleSolverState();
+    private InputData inputs;
+    private AngleSolverEngine engine;
+
+    @Before
+    public void setUp() {
+        inputs = new InputData();
+        for (int t = 0; t < TICKS; t++) {
+            InputRow row = new InputRow();
+            row.setKeyActive(InputRow.Key.W, true);
+            inputs.getRows().add(row);
+        }
+        for (int t = 0; t <= TICKS; t++) boxes.add(placeholder(0.5, 64.0, 0.5));
+        state.setStartTick(0);
+        state.setLandingTick(TICKS);
+        engine = new AngleSolverEngine(state, boxes, inputs, t -> { }, ExactJumpModel.forMcVersion("1.8.9"));
+    }
+
+    @Test
+    public void zeroTurnOnTickOneFreesTheStartFacing() {
+        addDf(0, Constraint.Op.EQ);
+        JumpSpec spec = engine.debugBuildSpec();
+        assertNotNull(spec);
+        assertTrue("no seam wall may remain: " + facingWalls(spec), facingWalls(spec).isEmpty());
+        assertTrue("tick 0 must realize its facing as an absolute", spec.asScenario().yawLockedPerTick[0]);
+    }
+
+    @Test
+    public void seamInsideALaterWindowStillPinsToThePreviousFacing() {
+        state.setStartTick(1);
+        addDf(1, Constraint.Op.EQ);
+        JumpSpec spec = engine.debugBuildSpec();
+        assertNotNull(spec);
+        List<JumpConstraint> walls = facingWalls(spec);
+        assertEquals(2, walls.size());
+        float seed = spec.asScenario().startYaw;
+        for (JumpConstraint w : walls) {
+            assertEquals(0, w.t1);
+            assertNull(w.t2);
+            assertEquals(JumpConstraint.Op.PLUS, w.op);
+            assertEquals(seed, w.rhs, MET_TOL + 1.0e-9);
+        }
+        assertFalse(spec.asScenario().yawLockedPerTick[0]);
+    }
+
+    @Test
+    public void unsupportedShapeOnTickOneKeepsTheSeamWall() {
+        addDf(0, Constraint.Op.LE);
+        JumpSpec spec = engine.debugBuildSpec();
+        assertNotNull(spec);
+        assertEquals(1, facingWalls(spec).size());
+        assertFalse(spec.asScenario().yawLockedPerTick[0]);
+    }
+
+    @Test
+    public void applyMovesTheStartFacingAndZeroesTickOne() {
+        addDf(0, Constraint.Op.EQ);
+        SolveResult r = solve();
+        assertTrue("the free-facing solve must succeed", r.isSuccess());
+        SolveResult.Outcome df = null;
+        for (SolveResult.Outcome o : r.getOutcomes()) if ("dF".equals(o.field)) df = o;
+        assertNotNull("dF outcome row missing", df);
+        assertTrue("the Tick 1 dF must report met against the solved start facing", df.met);
+
+        double[] yaws = new double[r.getYaws().size()];
+        for (int k = 0; k < yaws.length; k++) yaws[k] = r.getYaws().get(k).yaw;
+        float solvedStart = (float) yaws[0];
+        assertTrue("fixture must move the start facing", solvedStart != START_YAW);
+
+        AtomicReference<Float> moved = new AtomicReference<>();
+        engine.setOnStartYawChanged(moved::set);
+        engine.apply();
+        assertNotNull("Apply must publish the new start facing", moved.get());
+        assertEquals(solvedStart, moved.get(), 0f);
+
+        List<InputRow> rows = inputs.getRows();
+        InputRow first = rows.get(0);
+        assertEquals(first.isYawLocked() ? solvedStart : 0f, first.getYaw(), 0f);
+
+        JumpPhysicsInputs sc = engine.lastSpecDebug().asScenario().copy();
+        boolean[] locks = new boolean[TICKS];
+        for (int k = 0; k < TICKS; k++) locks[k] = k == 0 || rows.get(k).isYawLocked();
+        sc.yawLockedPerTick = locks;
+        double[] game = sc.toGameFacings(yaws);
+        float entity = moved.get();
+        for (int k = 0; k < TICKS; k++) {
+            InputRow row = rows.get(k);
+            entity = row.isYawLocked() ? row.getYaw() : entity + row.getYaw();
+            assertEquals("row replay must reproduce the solved facing at tick " + k, game[k], entity, 0.0);
+        }
+    }
+
+    private void addDf(int tick, Constraint.Op op) {
+        state.tickConstraints(tick).getConstraints().add(Constraint.scalar(Constraint.Field.DF, op, 0.0));
+    }
+
+    private static List<JumpConstraint> facingWalls(JumpSpec spec) {
+        List<JumpConstraint> out = new ArrayList<>();
+        for (JumpConstraint c : spec.constraints) if (c.mode == JumpConstraint.Mode.F) out.add(c);
+        return out;
+    }
+
+    private SolveResult solve() {
+        engine.solve();
+        long deadline = System.currentTimeMillis() + 30_000L;
+        while (engine.isSolving() && System.currentTimeMillis() < deadline) {
+            engine.poll();
+            try {
+                Thread.sleep(2);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        engine.poll();
+        SolveResult r = state.getResult();
+        assertNotNull("engine returned no result", r);
+        return r;
+    }
+
+    private static TickState placeholder(double x, double y, double z) {
+        return new TickState(new Vec3dCore(x, y, z), false, false, false, START_YAW,
+                Collections.<Vec3dCore>emptyList(), Vec3dCore.ZERO, false, Double.NaN);
+    }
+}


### PR DESCRIPTION
Closes #468

## Problem

A dF = 0 on Tick 1 compiled to an absolute facing pin of the first tick at the seed start yaw (`addSeamDeltaFacing`), so the whole no-turn chain was frozen at whatever the start box happened to face. To get a solvable run-up chain you had to leave Tick 1 free and put dF = 0 from Tick 2 on, and Apply then wrote the solved angle as a turn on Tick 1. That is the same thing as updating the start facing, only expressed as a camera flick on the first tick.

## Fix

The start facing is the solved variable when the window starts at the start position and Tick 1 carries a supported dF = 0.

- `AngleSolverEngine.consumeFirstTickZeroTurn` consumes the Tick 1 dF = 0 into the same `consumed` set as the free-start footprint, so no seam wall is mapped.
- Tick 0 is realized as yaw-locked in the physics inputs, so the solver scores `(float) yaws[0]` at tick 0. That is bit-identical to what Apply writes (start yaw = `(float) yaws[0]`, Tick 1 row turn = 0); a computed float delta could round to the neighbouring float and shift the sine bucket.
- Apply publishes the new start facing through a new `setOnStartYawChanged` hook (wired to `runner::setStartYaw` in `Application`, next to `setOnStartMoved`) and writes the remaining rows as turn deltas from `yaws[0]`.
- The result panel judges the Tick 1 dF against the solved start facing, so it reports met; the "Locked yaws" detail does not count the synthetic tick 0 lock.
- The dF tooltip in the constraint editor names the Tick 1 behaviour.

Unchanged on purpose: a dF = 0 on the first tick of a window that starts mid-run still pins to the previous tick's facing (that facing is fixed by the earlier rows), and unsupported dF shapes on Tick 1 keep the old seam wall so the existing "unsupported dF" notice still fires.

## Testing

- New `FirstTickDeltaFacingTest` (fast tier, synthetic 3-tick problem): no seam wall and tick 0 locked for a Tick 1 dF = 0; a later-window seam still pins to the previous facing; a dF <= 0 on Tick 1 keeps the seam wall; Apply publishes the start facing, writes Tick 1 as a zero turn, and replaying the rows reproduces the solver's game facings bit-exact.
- Existing `DeltaFacingConstraintTest` seam cases stay valid (j004's window starts at tick 18, a mid-run seam).
- `./gradlew :core:test` and `:core:tableStyleCheck` green.
- `./gradlew :core:test -PslowTests` green (151 classes, 759 tests, 0 failures).

## Scope notes

- Smooth (TAS) still anchors its turn penalty at the previous start yaw, so with a smooth lambda > 0 the freed start facing carries a small bias toward the current start facing. Left alone here.
- In-game QA on one loader pending: solve with dF = 0 on Tick 1, Apply, confirm the start box facing moves and the resim matches (no "Sim left the solved path").
