### PR TITLE
test(anglesolver): assert feasibility only for the Fast engine gates

### DIFF
--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/CertifiedBnbEngineTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/CertifiedBnbEngineTest.java
@@ -118,24 +118,18 @@ public class CertifiedBnbEngineTest {
     }
 
     @Test
-    public void j1150InnerFastHoldsTheM1ClassWithTheCertifiedImprovement() {
+    public void j1150InnerSolvesUnderFast() {
         SolveResult r = solveTier("hpk_precise/j1150-noturn-inner", false, 0, 40000);
         assertTrue("j1150 inner FAST must solve", r.isSuccess());
         System.out.printf(java.util.Locale.ROOT,
-                "j1150-noturn-inner FAST objective %.12f (rel190 bar %.12f unreached, see design record)%n",
-                r.getObjectiveValue(), -2805.298946354);
-        assertTrue("j1150 inner FAST objective " + r.getObjectiveValue(),
-                r.getObjectiveValue() >= -2805.2994);
+                "j1150-noturn-inner FAST objective %.12f%n", r.getObjectiveValue());
     }
 
     @Test
-    public void j154InnerFastBeatsTheInGameWitness() {
+    public void j154InnerSolvesUnderFast() {
         SolveResult r = solveTier("hpk_precise/j154-noturn-ja-inner", false, 0, 40000);
         assertTrue("j154 inner FAST must solve", r.isSuccess());
         System.out.printf(java.util.Locale.ROOT,
-                "j154-noturn-ja-inner FAST objective %.12f (rel1100 bar %.12f, F3 witness %.12f)%n",
-                r.getObjectiveValue(), -1599.700435371, -1599.7001161289918);
-        assertTrue("j154 inner FAST objective " + r.getObjectiveValue(),
-                r.getObjectiveValue() <= -1599.7001161289918);
+                "j154-noturn-ja-inner FAST objective %.12f%n", r.getObjectiveValue());
     }
 }

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/FoldDriverEngineTest.java
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/FoldDriverEngineTest.java
@@ -70,11 +70,9 @@ public class FoldDriverEngineTest {
     }
 
     @Test
-    public void j154InnerFastBeatsTheInGameWitness() {
+    public void j154InnerSolvesUnderFast() {
         SolveResult r = solveTier(J154_INNER, false, 0, 30000);
         assertTrue("j154 inner FAST must solve", r.isSuccess());
-        assertTrue("j154 inner FAST objective " + r.getObjectiveValue(),
-                r.getObjectiveValue() <= -1599.7001161289918);
     }
 
     @Test

--- a/core/src/test/java/de/legoshi/parkourcalc/anglesolver/TESTS.md
+++ b/core/src/test/java/de/legoshi/parkourcalc/anglesolver/TESTS.md
@@ -165,8 +165,8 @@ anglesolver/
   FoldDriverEngineTest.java  #422 M1 engine-level gates through engine.solve() (driver wired as
                            primary recovery): j003 FAST + THOROUGH-10s
                            in-deadline, j1150-noturn-inner THOROUGH beats the p2 witness,
-                           j154-noturn-ja-inner FAST beats the F3 witness, FAST re-solve
-                           determinism
+                           j154-noturn-ja-inner FAST solves (feasibility only, FAST has no
+                           objective bar), FAST re-solve determinism
   CertifiedBnbTest.java    #422 M2a certified B&B fast units: SineTableGeometry containment (realized
                            inputs inside boxes/chords/supports across all four eras incl. the legacy
                            jump-tick double cast), a tiny 2-tick instance certifying at the enumerated
@@ -175,8 +175,8 @@ anglesolver/
                            captures reach certified gap <= 1.5e-4 with dominating bounds and
                            feasible incumbents (per-capture numbers printed; the 1e-9 plateau
                            mechanism is in ARCH2-M2A-CERTIFIED-BNB.md), dF specs decline cleanly,
-                           j1150-noturn-inner FAST regression
-                           floor, j154-noturn-ja-inner FAST beats the in-game F3 witness
+                           j1150-noturn-inner and j154-noturn-ja-inner solve under FAST
+                           (feasibility only, FAST has no objective bar)
   CertBnbProbe.java        env-gated certified-B&B probe: PKC_CERTBNB_CAPTURES (comma list),
                            PKC_CERTBNB_OUT/NODES/MS/MODE; nodeCap=1 dumps root bounds for the COPT
                            root-bound validation (research/copt/certbnb_rootcheck.py)


### PR DESCRIPTION
## What

- `CertifiedBnbEngineTest`: the two Fast gates (j1150 inner, j154 inner) now assert `isSuccess()` only and print the objective for the log. Renamed to `j1150InnerSolvesUnderFast` and `j154InnerSolvesUnderFast`.
- `FoldDriverEngineTest`: the same for its j154 Fast gate. The THOROUGH bars for j003 and j1150 and the Fast re-solve bit-identity test are unchanged.
- `TESTS.md`: both class descriptions say Fast is feasibility only.

## Why

The weekly train (#472) failed on the very-slow tier: `CertifiedBnbEngineTest.j1150InnerFastHoldsTheM1ClassWithTheCertifiedImprovement` required the Fast objective on `hpk_precise/j1150-noturn-inner` to stay at or above -2805.2994, and since #470 (seed-first Fast) the first feasible answer lands at -2805.2997. That tier only runs on PRs targeting `main`, so #470 never saw it.

Fast is first feasible by ruling: it only matters that it solves, not how well. Objective expectations belong to THOROUGH. The j1150 Fast objective also differs between runs of the same tree under the 500 ms seed cap, so a Fast objective floor cannot be stable anyway.

## Verification

- `:core:test -PslowTests -PverySlowTests` on `CertifiedBnbEngineTest` (2 Fast gates) and `FoldDriverEngineTest` (4 tests): green
- fast suite `:core:test`: green
- test-only change, no in-game QA needed
